### PR TITLE
cargo publish is not happy with our keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://solang.readthedocs.io/"
 license = "Apache-2.0 OR MIT"
 build = "build.rs"
 description = "Solang Solidity Compiler"
-keywords = [ "solidity", "compiler", "ewasm",  "llvm", "smart-contract", "substrate" ]
+keywords = [ "solidity", "compiler", "ewasm", "llvm", "substrate" ]
 
 [build-dependencies]
 lalrpop = "0.18"


### PR DESCRIPTION
$ cargo publish
...
error: api errors (status 200 OK): invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 3201

Signed-off-by: Sean Young <sean@mess.org>