### PR TITLE
Use ext_hash_keccak_256 on Substrate

### DIFF
--- a/src/emit/sabre.rs
+++ b/src/emit/sabre.rs
@@ -512,6 +512,40 @@ impl TargetRuntime for SabreTarget {
         res.as_basic_value().into_int_value()
     }
 
+    /// sabre has no keccak256 host function, so call our implementation
+    fn keccak256_hash(
+        &self,
+        contract: &Contract,
+        src: PointerValue,
+        length: IntValue,
+        dest: PointerValue,
+    ) {
+        contract.builder.build_call(
+            contract.module.get_function("sha3").unwrap(),
+            &[
+                contract
+                    .builder
+                    .build_pointer_cast(
+                        src,
+                        contract.context.i8_type().ptr_type(AddressSpace::Generic),
+                        "src",
+                    )
+                    .into(),
+                length.into(),
+                contract
+                    .builder
+                    .build_pointer_cast(
+                        dest,
+                        contract.context.i8_type().ptr_type(AddressSpace::Generic),
+                        "dest",
+                    )
+                    .into(),
+                contract.context.i32_type().const_int(32, false).into(),
+            ],
+            "",
+        );
+    }
+
     fn return_empty_abi(&self, contract: &Contract) {
         // return 1 for success
         contract


### PR DESCRIPTION
Sabre and ewasm do not provide such a host function, so link our own in.

Signed-off-by: Sean Young <sean@mess.org>