### PR TITLE
Make the lexer deal with unicode identifiers correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_derive = { version = "1.0" }
 inkwell = { version = "0.1.0-llvm8sample", features = ["target-webassembly", "llvm8-0"] }
 blake2-rfc = "0.2.18"
 phf = { version = "0.8", features = ["macros"] }
+unicode-xid = "0.2.0"
 
 [dev-dependencies]
 parity-scale-codec-derive = "1.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate tiny_keccak;
 extern crate unescape;
+extern crate unicode_xid;
 
 pub mod abi;
 pub mod link;


### PR DESCRIPTION
Now we can have unicode identifiers, like rust and clang.

Signed-off-by: Sean Young <sean@mess.org>