### PR TITLE
Implement noreturn and mark revert() as noreturn

### DIFF
--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -1629,6 +1629,7 @@ impl<'a> Contract<'a> {
                     .into()
             }
             Expression::Poison => unreachable!(),
+            Expression::Unreachable => unreachable!(),
         }
     }
 

--- a/src/resolver/builtin.rs
+++ b/src/resolver/builtin.rs
@@ -328,6 +328,8 @@ fn add_revert(ns: &mut Namespace, contract_no: usize) {
         ns,
     );
 
+    revert.noreturn = true;
+
     let mut errors = Vec::new();
     let mut vartab = Vartable::new();
     let mut cfg = ControlFlowGraph::new();
@@ -373,6 +375,8 @@ fn add_revert(ns: &mut Namespace, contract_no: usize) {
         vec![],
         ns,
     );
+
+    revert.noreturn = true;
 
     let mut errors = Vec::new();
     let mut vartab = Vartable::new();

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -429,6 +429,7 @@ pub struct FunctionDecl {
     pub visibility: ast::Visibility,
     pub params: Vec<Parameter>,
     pub returns: Vec<Parameter>,
+    pub noreturn: bool,
     pub cfg: Option<Box<cfg::ControlFlowGraph>>,
 }
 
@@ -466,6 +467,7 @@ impl FunctionDecl {
             visibility,
             params,
             returns,
+            noreturn: false,
             cfg: None,
         }
     }

--- a/tests/substrate_contracts/mod.rs
+++ b/tests/substrate_contracts/mod.rs
@@ -314,7 +314,6 @@ fn revert_external_call() {
             }
             function get_x(int32 t) public returns (int32) {
                 revert("The reason why");
-                return 0;
             }
         }"##,
     );


### PR DESCRIPTION
By definition revert() will never return, and any code following
it will not be executed.

Signed-off-by: Sean Young <sean@mess.org>