### PR TITLE
Implement destructuring function call

### DIFF
--- a/src/resolver/storage.rs
+++ b/src/resolver/storage.rs
@@ -116,7 +116,7 @@ pub fn array_push(
     ns: &resolver::Namespace,
     vartab: &mut Option<&mut Vartable>,
     errors: &mut Vec<Output>,
-) -> Result<(Expression, resolver::Type), ()> {
+) -> Result<Vec<(Expression, resolver::Type)>, ()> {
     let tab = match vartab {
         &mut Some(ref mut tab) => tab,
         None => {
@@ -224,9 +224,9 @@ pub fn array_push(
     );
 
     if args.is_empty() {
-        Ok((Expression::Variable(*loc, entry_pos), elem_ty))
+        Ok(vec![(Expression::Variable(*loc, entry_pos), elem_ty)])
     } else {
-        Ok((Expression::Poison, resolver::Type::Undef))
+        Ok(vec![(Expression::Poison, resolver::Type::Undef)])
     }
 }
 
@@ -241,7 +241,7 @@ pub fn array_pop(
     ns: &resolver::Namespace,
     vartab: &mut Option<&mut Vartable>,
     errors: &mut Vec<Output>,
-) -> Result<(Expression, resolver::Type), ()> {
+) -> Result<Vec<(Expression, resolver::Type)>, ()> {
     let tab = match vartab {
         &mut Some(ref mut tab) => tab,
         None => {
@@ -359,7 +359,7 @@ pub fn array_pop(
         },
     );
 
-    Ok((Expression::Variable(*loc, res_pos), elem_ty))
+    Ok(vec![(Expression::Variable(*loc, res_pos), elem_ty)])
 }
 
 /// Push() method on dynamic bytes in storage
@@ -373,7 +373,7 @@ pub fn bytes_push(
     ns: &resolver::Namespace,
     vartab: &mut Option<&mut Vartable>,
     errors: &mut Vec<Output>,
-) -> Result<(Expression, resolver::Type), ()> {
+) -> Result<Vec<(Expression, resolver::Type)>, ()> {
     let tab = match vartab {
         &mut Some(ref mut tab) => tab,
         None => {
@@ -413,15 +413,15 @@ pub fn bytes_push(
     };
 
     if args.is_empty() {
-        Ok((
+        Ok(vec![(
             Expression::StorageBytesPush(*loc, Box::new(var_expr), Box::new(val)),
             resolver::Type::Bytes(1),
-        ))
+        )])
     } else {
-        Ok((
+        Ok(vec![(
             Expression::StorageBytesPush(*loc, Box::new(var_expr), Box::new(val)),
             resolver::Type::Undef,
-        ))
+        )])
     }
 }
 
@@ -433,7 +433,7 @@ pub fn bytes_pop(
     args: &[ast::Expression],
     cfg: &mut ControlFlowGraph,
     errors: &mut Vec<Output>,
-) -> Result<(Expression, resolver::Type), ()> {
+) -> Result<Vec<(Expression, resolver::Type)>, ()> {
     cfg.writes_contract_storage = true;
 
     if !args.is_empty() {
@@ -444,10 +444,10 @@ pub fn bytes_pop(
         return Err(());
     }
 
-    Ok((
+    Ok(vec![(
         Expression::StorageBytesPop(*loc, Box::new(var_expr)),
         resolver::Type::Bytes(1),
-    ))
+    )])
 }
 
 /// Calculate storage subscript

--- a/tests/substrate_functions/mod.rs
+++ b/tests/substrate_functions/mod.rs
@@ -668,3 +668,64 @@ fn print() {
 
     runtime.function("test", Vec::new());
 }
+
+#[test]
+fn destructuring_call() {
+    let mut runtime = build_solidity(
+        r#"
+        contract c {
+            function func1() public returns (int32, bool) {
+                return (102, true);
+            }
+        
+            function test() public {
+                (int32 a, bool b) = func1();
+        
+                assert(a == 102 && b == true);
+            }
+        }"#,
+    );
+
+    runtime.function("test", Vec::new());
+
+    let mut runtime = build_solidity(
+        r#"
+        contract c {
+            function func1(int32 x) public returns (int32, bool) {
+                return (102 + x, true);
+            }
+        
+            function test() public {
+                (int32 a, bool b) = func1({x: 5});
+        
+                assert(a == 107 && b == true);
+            }
+        }"#,
+    );
+
+    runtime.function("test", Vec::new());
+
+    let mut runtime = build_solidity(
+        r#"
+        contract c {
+            function test() public {
+                b x = new b();
+                (int32 a, bool b) = x.func1({x: 5});
+        
+                assert(a == 107 && b == true);
+
+                (a, b) = x.func1(-1);
+        
+                assert(a == 101 && b == true);
+            }
+        }
+        
+        contract b {
+            function func1(int32 x) public returns (int32, bool) {
+                return (102 + x, true);
+            }
+        }"#,
+    );
+
+    runtime.function("test", Vec::new());
+}


### PR DESCRIPTION
Now it is possible to call functions with multiple return values.
These can be put into a structuring expression like so:

	(a, b) = f();

Signed-off-by: Sean Young <sean@mess.org>