### PR TITLE
Make it possible to instantiate the same contract multiple times

### DIFF
--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -169,7 +169,7 @@ pub trait TargetRuntime {
 
     /// Calls constructor
     fn create_contract<'b>(
-        &self,
+        &mut self,
         contract: &Contract<'b>,
         function: FunctionValue,
         success: Option<&mut BasicValueEnum<'b>>,
@@ -653,7 +653,7 @@ impl<'a> Contract<'a> {
     }
 
     /// Emit all functions, constructors, fallback and receiver
-    fn emit_functions(&mut self, runtime: &dyn TargetRuntime) {
+    fn emit_functions(&mut self, runtime: &mut dyn TargetRuntime) {
         let mut defines = Vec::new();
 
         for resolver_func in &self.contract.functions {
@@ -2394,7 +2394,7 @@ impl<'a> Contract<'a> {
     }
 
     /// Emit the contract storage initializers
-    fn emit_initializer(&self, runtime: &dyn TargetRuntime) -> FunctionValue<'a> {
+    fn emit_initializer(&self, runtime: &mut dyn TargetRuntime) -> FunctionValue<'a> {
         let function = self.module.add_function(
             "storage_initializers",
             self.context.i32_type().fn_type(&[], false),
@@ -2442,7 +2442,7 @@ impl<'a> Contract<'a> {
         &self,
         resolver_func: &resolver::FunctionDecl,
         function: FunctionValue<'a>,
-        runtime: &dyn TargetRuntime,
+        runtime: &mut dyn TargetRuntime,
     ) {
         let cfg = match resolver_func.cfg {
             Some(ref cfg) => cfg,
@@ -2458,7 +2458,7 @@ impl<'a> Contract<'a> {
         cfg: &cfg::ControlFlowGraph,
         resolver_function: Option<&resolver::FunctionDecl>,
         function: FunctionValue<'a>,
-        runtime: &dyn TargetRuntime,
+        runtime: &mut dyn TargetRuntime,
     ) {
         // recurse through basic blocks
         struct BasicBlock<'a> {

--- a/src/emit/sabre.rs
+++ b/src/emit/sabre.rs
@@ -26,14 +26,14 @@ impl SabreTarget {
         opt: OptimizationLevel,
     ) -> Contract<'a> {
         let mut c = Contract::new(context, contract, ns, filename, opt, None);
-        let b = SabreTarget {
+        let mut b = SabreTarget {
             abi: ethabiencoder::EthAbiEncoder {},
         };
 
         // externals
         b.declare_externals(&mut c);
 
-        c.emit_functions(&b);
+        c.emit_functions(&mut b);
 
         b.emit_entrypoint(&mut c);
 
@@ -103,7 +103,7 @@ impl SabreTarget {
         );
     }
 
-    fn emit_entrypoint(&self, contract: &mut Contract) {
+    fn emit_entrypoint(&mut self, contract: &mut Contract) {
         let initializer = contract.emit_initializer(self);
 
         let bytes_ptr = contract.context.i32_type().ptr_type(AddressSpace::Generic);
@@ -717,7 +717,7 @@ impl TargetRuntime for SabreTarget {
 
     /// Create new contract
     fn create_contract<'b>(
-        &self,
+        &mut self,
         _contract: &Contract<'b>,
         _function: FunctionValue,
         _success: Option<&mut BasicValueEnum<'b>>,

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -70,6 +70,7 @@ enum SubstrateExternal {
     ext_instantiate,
     ext_value_transferred,
     ext_minimum_balance,
+    ext_random,
 }
 
 pub struct VM {
@@ -258,6 +259,23 @@ impl Externals for TestRuntime {
                 println!("ext_println: {}", s);
 
                 self.printbuf.push_str(&s);
+
+                Ok(None)
+            }
+            Some(SubstrateExternal::ext_random) => {
+                let data_ptr: u32 = args.nth_checked(0)?;
+                let len: u32 = args.nth_checked(1)?;
+
+                let mut buf = Vec::new();
+                buf.resize(len as usize, 0u8);
+
+                if let Err(e) = self.vm.memory.get_into(data_ptr, &mut buf) {
+                    panic!("ext_random: {}", e);
+                }
+
+                println!("ext_random: {}", hex::encode(&buf));
+
+                self.vm.scratch = buf;
 
                 Ok(None)
             }
@@ -461,6 +479,7 @@ impl ModuleImportResolver for TestRuntime {
             "ext_instantiate" => SubstrateExternal::ext_instantiate,
             "ext_value_transferred" => SubstrateExternal::ext_value_transferred,
             "ext_minimum_balance" => SubstrateExternal::ext_minimum_balance,
+            "ext_random" => SubstrateExternal::ext_random,
             _ => {
                 panic!("{} not implemented", field_name);
             }

--- a/tests/substrate_calls/mod.rs
+++ b/tests/substrate_calls/mod.rs
@@ -214,7 +214,8 @@ fn input_wrong_size() {
 
     runtime.function_expect_return("test", b"A".to_vec(), 3);
 
-    runtime.function_expect_return("test", b"ABCDE".to_vec(), 3);
+    // the decoder does not check if there is too much data
+    runtime.function_expect_return("test", b"ABCDE".to_vec(), 0);
 }
 
 #[test]

--- a/tests/substrate_calls/mod.rs
+++ b/tests/substrate_calls/mod.rs
@@ -246,6 +246,25 @@ fn contract_already_exists() {
         r##"
         contract c {
             function test() public {
+                other o = new other{salt: 0}();
+
+                other t = new other{salt: 0}();
+            }
+        }
+        
+        contract other {
+            function test() public {
+
+            }
+        }"##,
+    );
+
+    runtime.function_expect_return("test", Vec::new(), 4);
+
+    let mut runtime = build_solidity(
+        r##"
+        contract c {
+            function test() public {
                 other o = new other();
 
                 other t = new other();
@@ -259,7 +278,7 @@ fn contract_already_exists() {
         }"##,
     );
 
-    runtime.function_expect_return("test", Vec::new(), 4);
+    runtime.function("test", Vec::new());
 }
 
 #[test]

--- a/tests/substrate_value/mod.rs
+++ b/tests/substrate_value/mod.rs
@@ -440,3 +440,60 @@ fn constructor_value() {
         assert_eq!(account.1, 511);
     }
 }
+
+#[test]
+fn constructor_salt() {
+    let mut runtime = build_solidity(
+        r##"
+        contract b {
+            function step1() public {
+                a f = new a{salt: 0}();
+            }
+        }
+
+        contract a {
+            function test(int32 l) public payable {
+            }
+        }"##,
+    );
+
+    runtime.constructor(0, Vec::new());
+
+    runtime.function("step1", Vec::new());
+
+    let mut runtime = build_solidity(
+        r##"
+        contract b {
+            function step1() public {
+                a f = new a{salt: 1}();
+            }
+        }
+
+        contract a {
+            function test(int32 l) public payable {
+            }
+        }"##,
+    );
+    runtime.constructor(0, Vec::new());
+
+    runtime.function("step1", Vec::new());
+
+    // we can instantiate the same contract if we provide a different contract
+    let mut runtime = build_solidity(
+        r##"
+        contract b {
+            function step1() public {
+                a f = new a{salt: 1}();
+                f = new a{salt: 2}();
+            }
+        }
+
+        contract a {
+            function test(int32 l) public payable {
+            }
+        }"##,
+    );
+    runtime.constructor(0, Vec::new());
+
+    runtime.function("step1", Vec::new());
+}

--- a/tests/substrate_value/mod.rs
+++ b/tests/substrate_value/mod.rs
@@ -349,7 +349,7 @@ fn constructor_value() {
             continue;
         }
 
-        assert_eq!(account.1, 500);
+        assert_eq!(account.1, 0);
     }
 
     let mut runtime = build_solidity(


### PR DESCRIPTION
In order to create multiple instances of the same contract, the input must be different. So, the salt is appended to the input. If no salt is provided, generate random salt using ext_random().
