### PR TITLE
The matches! macro requires rust 1.42.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: Build Release Binaries
 jobs:
   linux:
     name: Build Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   lints:
     name: Lints
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -48,3 +48,12 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  dockerfile:
+    name: docker
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Build dockerfile
+      run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Ubuntu 18.04 produces a builder image 1.53 GiB and solang image of 84 MiB
 # Debian Buster produces a builder image 2.04 GiB
 
-FROM rust:1.40-slim-buster as builder
+FROM rust:1.42-slim-buster as builder
 MAINTAINER Sean Young <sean@mess.org>
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
 RUN apt-get update

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -55,7 +55,7 @@ this has not been updated in a long time. This is due to
 
 Building Solang from source
 ---------------------------
-In order to build solang from source, you will need rust 1.40.0 or higher,
+In order to build solang from source, you will need rust 1.42.0 or higher,
 and llvm version 8 or higher with the WebAssembly target enabled.
 
 So see if you have the correct version of rust, simply execute:
@@ -200,4 +200,4 @@ is in Solang github repo. Simply run the dockerfile:
 
 	docker build -f build-llvm-windows.dockerfile .
 
-This will take a few hours. The result will be dockerfile with llvm compressed in ``llvm80.zip`` in the image.
+This will take a few hours. The result will be an image with llvm compressed in ``c:\llvm80.zip``.


### PR DESCRIPTION
This was caught by docker hub builder. So, add test for this in CI
before merging.

Update images as well.

Signed-off-by: Sean Young <sean@mess.org>