### PR TITLE
LLVM only needs the WebAssembly target

### DIFF
--- a/scripts/build-llvm-linux.dockerfile
+++ b/scripts/build-llvm-linux.dockerfile
@@ -13,8 +13,8 @@ RUN git checkout -b release_8.x origin/release/8.x
 RUN sed -i '7 a #include <string>' llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
 
 RUN cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_PROJECTS=clang  \
-    -DLLVM_ENABLE_TERMINFO=Off -DCMAKE_BUILD_TYPE=MinSizeRel \
-    -DCMAKE_INSTALL_PREFIX=/llvm80 -B build llvm
+    -DLLVM_ENABLE_TERMINFO=Off -DLLVM_TARGETS_TO_BUILD=WebAssembly \
+    -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/llvm80 -B build llvm
 
 RUN cmake --build build --target install
 

--- a/scripts/ci.dockerfile
+++ b/scripts/ci.dockerfile
@@ -13,8 +13,8 @@ RUN git checkout -b release_8.x origin/release/8.x
 RUN sed -i '7 a #include <string>' llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
 
 RUN cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_PROJECTS=clang  \
-    -DLLVM_ENABLE_TERMINFO=Off -DCMAKE_BUILD_TYPE=MinSizeRel \
-    -DCMAKE_INSTALL_PREFIX=/llvm80 -B build llvm
+    -DLLVM_ENABLE_TERMINFO=Off -DLLVM_TARGETS_TO_BUILD=WebAssembly \
+    -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/llvm80 -B build llvm
 
 RUN cmake --build build --target install
 


### PR DESCRIPTION
This reduces the solang binary by about 4 MiB.

Signed-off-by: Sean Young <sean@mess.org>