### PR TITLE
unzip is faster than rather than Extract-Archive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,11 @@ jobs:
     - name: Add LLVM to Path
       run: echo "::add-path::c:\llvm80\bin"
     - name: Download LLVM
-      run: curl -sS -o c:\llvm.zip https://solang.io/download/llvm80.zip
+      run: curl -sS -o c:\llvm.zip https://solang.io/download/llvm2.zip
     - name: Extract LLVM
       # unzip exists but always exits with code 1
-      run: powershell Expand-Archive c:\llvm.zip -DestinationPath c:\
+      # run: powershell Expand-Archive c:\llvm.zip -DestinationPath c:\
+      run: unzip c:/llvm.zip -d c:/
     - name: Compile stdlib
       run: clang --target=wasm32 -c -emit-llvm -O3 -ffreestanding -fno-builtin -Wall stdlib.c sha3.c substrate.c ripemd160.c
       working-directory: ./stdlib


### PR DESCRIPTION
unzip takes 20 on github actions rather than 95 seconds for Extract-Archive

Signed-off-by: Sean Young <sean@mess.org>