### PR TITLE
Implement interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ will be documented here.
 ## Unreleased
 
 ### Added
- - `import` directives are supported
- - New `--importpath` command line argument to specify directories to search
-   for imports.
- - Contracts can have base contracts
+- `import` directives are supported
+- New `--importpath` command line argument to specify directories to search for imports
+- Contracts can have base contracts
+- Contracts can be abstract
+- Interfaces are supported
 
 ### Changed
- - Solang now uses llvm 10.0 rather than 8.0. This will produce slightly smaller 
- - Inline with Solidity 0.7.0, constructors no longer need a visibility argument
+- Solang now uses llvm 10.0 rather than llvm 8.0
+- In line with Solidity 0.7.0, constructors no longer need a visibility argument

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -371,6 +371,15 @@ impl Contract {
         }
     }
 
+    // Is this an interface
+    pub fn is_interface(&self) -> bool {
+        if let pt::ContractTy::Interface(_) = self.ty {
+            true
+        } else {
+            false
+        }
+    }
+
     /// Get the storage slot for a variable, possibly from base contract
     pub fn get_storage_slot(&self, var_contract_no: usize, var_no: usize) -> Expression {
         if let Some(layout) = self

--- a/tests/substrate_functions/mod.rs
+++ b/tests/substrate_functions/mod.rs
@@ -19,6 +19,19 @@ fn constructors() {
         "‘internal’: visibility for constructors is ignored"
     );
 
+    let ns = parse_and_resolve(
+        r##"
+        contract test {
+            constructor() virtual {}
+        }"##,
+        Target::Substrate,
+    );
+
+    assert_eq!(
+        first_error(ns.diagnostics),
+        "constructors cannot be declared ‘virtual’"
+    );
+
     #[derive(Debug, PartialEq, Encode, Decode)]
     struct Val(u64);
 


### PR DESCRIPTION
Interfaces are syntax sugar that need to follow these rules:

- They cannot inherit from other contracts, but they can inherit from other interfaces.
- All declared functions must be external.
- They cannot declare a constructor.
- They cannot declare state variables.
- They cannot have function implementations

Signed-off-by: Sean Young <sean@mess.org>