### PR TITLE
Create seperate virtual functions lookup table

### DIFF
--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -446,9 +446,9 @@ pub fn gen_abi(contract_no: usize, ns: &ast::Namespace) -> Metadata {
     }
 
     let messages = ns.contracts[contract_no]
-        .function_table
-        .values()
-        .filter_map(|(base_contract_no, function_no, _)| {
+        .all_functions
+        .keys()
+        .filter_map(|(base_contract_no, function_no)| {
             if ns.contracts[*base_contract_no].is_library() {
                 None
             } else {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6,7 +6,6 @@ mod storage;
 use self::cfg::{ControlFlowGraph, Instr, Vartable};
 use self::expression::expression;
 use sema::ast::Namespace;
-use std::collections::HashMap;
 
 /// The contracts are fully resolved but they do not have any a CFG which is needed for the llvm code emitter
 /// not all contracts need a cfg; only those for which we need the
@@ -15,33 +14,51 @@ pub fn codegen(contract_no: usize, ns: &mut Namespace) {
         // we need to iterate over the contracts function table, while generating cfg for each. We can't
         // iterate mutably over the function table because then we cannot borrow the namespace for generating
         // the cfg. So first populate a separate hash and then set in another loop
-        let mut generated = HashMap::new();
+        let mut generated = Vec::new();
 
-        for (signature, con) in &ns.contracts[contract_no].function_table {
-            let c = cfg::generate_cfg(contract_no, con.0, Some(con.1), ns);
-            generated.insert(signature.to_owned(), c);
+        let mut cfg_no = 0;
+
+        // all the functions should have a cfg_no assigned, so we can generate call instructions to the correct function
+        for (_, func_cfg) in ns.contracts[contract_no].all_functions.iter_mut() {
+            *func_cfg = cfg_no;
+            cfg_no += 1;
         }
 
-        for (signature, con) in ns.contracts[contract_no].function_table.iter_mut() {
-            con.2 = generated.remove(signature);
+        ns.contracts[contract_no]
+            .cfg
+            .resize(cfg_no, ControlFlowGraph::placeholder());
+
+        for ((base_contract_no, function_no), cfg_no) in &ns.contracts[contract_no].all_functions {
+            let c = cfg::generate_cfg(contract_no, *base_contract_no, Some(*function_no), ns);
+            generated.push((*cfg_no, c));
+        }
+
+        for (cfg_no, cfg) in generated.into_iter() {
+            ns.contracts[contract_no].cfg[cfg_no] = cfg;
         }
 
         // Generate cfg for storage initializers
-        ns.contracts[contract_no].initializer = storage_initializer(contract_no, ns);
+        let cfg = storage_initializer(contract_no, ns);
+        let pos = ns.contracts[contract_no].cfg.len();
+        ns.contracts[contract_no].cfg.push(cfg);
+        ns.contracts[contract_no].initializer = Some(pos);
 
         if !ns.contracts[contract_no].have_constructor() {
             // generate the default constructor
-            let func = ns.default_constructor(contract_no);
+            let func = ns.default_constructor();
 
-            ns.contracts[contract_no].default_constructor =
-                Some((func, cfg::generate_cfg(contract_no, contract_no, None, ns)));
+            let pos = ns.contracts[contract_no].cfg.len();
+            let cfg = cfg::generate_cfg(contract_no, contract_no, None, ns);
+            ns.contracts[contract_no].cfg.push(cfg);
+
+            ns.contracts[contract_no].default_constructor = Some((func, pos));
         }
     }
 }
 
 /// This function will set all contract storage initializers and should be called from the constructor
 fn storage_initializer(contract_no: usize, ns: &Namespace) -> ControlFlowGraph {
-    let mut cfg = ControlFlowGraph::new();
+    let mut cfg = ControlFlowGraph::new(String::from("storage_initializer"));
     let mut vartab = Vartable::new(ns.next_id);
 
     for layout in &ns.contracts[contract_no].layout {

--- a/src/codegen/storage.rs
+++ b/src/codegen/storage.rs
@@ -179,7 +179,6 @@ pub fn array_pop(
     let empty_array = cfg.new_basic_block("empty_array".to_string());
     let has_elements = cfg.new_basic_block("has_elements".to_string());
 
-    cfg.writes_contract_storage = true;
     cfg.add(
         vartab,
         Instr::BranchCond {

--- a/src/emit/ewasm.rs
+++ b/src/emit/ewasm.rs
@@ -608,11 +608,12 @@ impl EwasmTarget {
         contract.builder.build_call(initializer, &[], "");
 
         // ewasm only allows one constructor, hence find()
-        if let Some(con) = contract
+        if let Some((cfg_no, con)) = contract
             .contract
-            .functions
+            .cfg
             .iter()
-            .find(|f| f.is_constructor())
+            .enumerate()
+            .find(|(_, f)| f.ty == pt::FunctionTy::Constructor && f.public)
         {
             let mut args = Vec::new();
 
@@ -622,7 +623,7 @@ impl EwasmTarget {
 
             contract
                 .builder
-                .build_call(contract.functions[&con.vsignature], &args, "");
+                .build_call(contract.functions[&cfg_no], &args, "");
         }
 
         // the deploy code should return the runtime wasm code
@@ -661,7 +662,7 @@ impl EwasmTarget {
             function,
             None,
             self,
-            |func| !contract.function_abort_value_transfers && !func.is_payable(),
+            |func| !contract.function_abort_value_transfers && func.nonpayable,
         );
     }
 

--- a/src/emit/sabre.rs
+++ b/src/emit/sabre.rs
@@ -175,11 +175,12 @@ impl SabreTarget {
         // init our storage vars
         contract.builder.build_call(initializer, &[], "");
 
-        if let Some(con) = contract
+        if let Some((cfg_no, con)) = contract
             .contract
             .functions
             .iter()
-            .find(|f| f.is_constructor())
+            .enumerate()
+            .find(|(_, f)| f.is_constructor())
         {
             let mut args = Vec::new();
 
@@ -195,7 +196,7 @@ impl SabreTarget {
 
             contract
                 .builder
-                .build_call(contract.functions[&con.vsignature], &args, "");
+                .build_call(contract.functions[&cfg_no], &args, "");
         }
 
         // return 1 for success

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -543,7 +543,7 @@ impl SubstrateTarget {
             function,
             None,
             self,
-            |func| !contract.function_abort_value_transfers && !func.is_payable(),
+            |func| !contract.function_abort_value_transfers && func.nonpayable,
         );
     }
 

--- a/src/parser/pt.rs
+++ b/src/parser/pt.rs
@@ -430,7 +430,7 @@ pub enum FunctionAttribute {
     BaseArguments(Loc, Base),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum FunctionTy {
     Constructor,
     Function,

--- a/src/sema/functions.rs
+++ b/src/sema/functions.rs
@@ -340,10 +340,9 @@ pub fn function_decl(
 
     let mut fdecl = Function::new(
         func.loc,
-        contract_no,
         name,
         func.doc.clone(),
-        func.ty.clone(),
+        func.ty,
         mutability,
         visibility,
         params,
@@ -477,9 +476,14 @@ pub fn function_decl(
     } else {
         let id = func.name.as_ref().unwrap();
 
-        if let Some((func_contract_no, func_no, _)) = ns.contracts[contract_no]
-            .function_table
-            .get(&fdecl.vsignature)
+        if let Some((func_contract_no, func_no)) = ns.contracts[contract_no]
+            .all_functions
+            .keys()
+            .find(|(func_contract_no, func_no)| {
+                let func = &ns.contracts[*func_contract_no].functions[*func_no];
+
+                func.signature == fdecl.signature
+            })
         {
             ns.diagnostics.push(Diagnostic::error_with_note(
                 func.loc,
@@ -693,7 +697,6 @@ fn signatures() {
 
     let fdecl = Function::new(
         pt::Loc(0, 0, 0),
-        0,
         "foo".to_owned(),
         vec![],
         pt::FunctionTy::Function,

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -1110,10 +1110,9 @@ impl ast::Namespace {
     }
 
     /// Phoney default constructor
-    pub fn default_constructor(&self, contract_no: usize) -> ast::Function {
+    pub fn default_constructor(&self) -> ast::Function {
         let mut func = ast::Function::new(
             pt::Loc(0, 0, 0),
-            contract_no,
             "".to_owned(),
             vec![],
             pt::FunctionTy::Constructor,

--- a/src/sema/mutability.rs
+++ b/src/sema/mutability.rs
@@ -228,9 +228,18 @@ fn read_expression(expr: &Expression, state: &mut StateCheck) -> bool {
         Expression::Constructor { loc, .. } => {
             state.write(loc);
         }
-        Expression::InternalFunctionCall(loc, _, contract_no, signature, _) => {
-            let (base_contract_no, function_no, _) =
-                state.ns.contracts[*contract_no].function_table[signature];
+        Expression::InternalFunctionCall {
+            loc,
+            contract_no,
+            function_no,
+            signature,
+            ..
+        } => {
+            let (base_contract_no, function_no) = if let Some(signature) = signature {
+                state.ns.contracts[*contract_no].virtual_functions[signature]
+            } else {
+                (*contract_no, *function_no)
+            };
 
             match &state.ns.contracts[base_contract_no].functions[function_no].mutability {
                 None | Some(pt::StateMutability::Payable(_)) => state.write(loc),


### PR DESCRIPTION
Distinguish virtual calls from non-virtual calls. We keep one list of
all functions per contracts ("all_functions") and a virtual functions
table which is indexed by signature.

In addition, modifiers need to be specialized for the function they
are used on. So, we need one cfg per modifier used per function it is on,
rather than one cfg per modifier. So, we want to be able to have cfgs with
no associated function. So cfgs are not stored in the functions, but
in a separate vector. Functions have cfg_no to refer to their cfg.

As a result, codegen resolves virtual functions and the emitter does
not need to know anything about virtual function calls. This also means
that the emitter works purely on cfgs, not functions.

Signed-off-by: Sean Young <sean@mess.org>