### PR TITLE
Produce warning if tx.gasprice is used on Substrate

### DIFF
--- a/docs/language.rst
+++ b/docs/language.rst
@@ -2560,7 +2560,21 @@ uint128 ``tx.gasprice(uint64 gas)``
     if the gas price is less than 1 it may round down to 0, giving the incorrect appearance gas is free.
     Therefore, avoid the ``tx.gasprice`` member in favour of the function ``tx.gasprice(uint64 gas)``.
 
-    This function is not available on the Ethereum Foundation Solidity compiler.
+    To avoid rounding errors, pass the total amount of gas into ``tx.gasprice(uint64 gas)`` rather than
+    doing arithmetic on the result. As an example, **replace** this bad example:
+
+    .. code-block::
+
+        // BAD example
+        uint128 cost = num_items * tx.gasprice(gas_per_item);
+
+    with:
+
+    .. code-block::
+
+        uint128 cost = tx.gasprice(num_items * gas_per_item);
+
+    Note this function is not available on the Ethereum Foundation Solidity compiler.
 
 adddress ``tx.origin``
     The address that started this transaction. Not available on Parity Substrate

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -2546,17 +2546,21 @@ address ``msg.sender``
 ``tx`` properties
 +++++++++++++++++
 
+.. _gasprice:
+
 uint128 ``tx.gasprice``
-    The cost of one unit of gas.
+    The price of one unit of gas. This field cannot be used on Parity Substrate, the explanation
+    is in the warning box below.
 
 uint128 ``tx.gasprice(uint64 gas)``
-    The cost of `gas` units of gas.
+    The total price of `gas` units of gas.
 
-.. note::
-    On Parity Substrate, the cost of one gas unit may not be an exact whole round value. So, to
-    avoid rounding errors, use the ``tx.gasprice()`` function to get the correct pricing
-    for a total units of gas. This function is not available on the Ethereum Foundation Solidity
-    compiler.
+.. warning::
+    On Parity Substrate, the cost of one gas unit may not be an exact whole round value. In fact,
+    if the gas price is less than 1 it may round down to 0, giving the incorrect appearance gas is free.
+    Therefore, avoid the ``tx.gasprice`` member in favour of the function ``tx.gasprice(uint64 gas)``.
+
+    This function is not available on the Ethereum Foundation Solidity compiler.
 
 adddress ``tx.origin``
     The address that started this transaction. Not available on Parity Substrate

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -1127,7 +1127,7 @@ pub fn expression(
                 };
             }
 
-            if let Some((builtin, ty)) = builtin::builtin_var(None, &id.name, ns) {
+            if let Some((builtin, ty)) = builtin::builtin_var(&id.loc, None, &id.name, ns) {
                 return Ok(Expression::Builtin(id.loc, vec![ty], builtin, vec![]));
             }
 
@@ -2914,7 +2914,8 @@ fn member_access(
 ) -> Result<Expression, ()> {
     // is it a builtin special variable like "block.timestamp"
     if let pt::Expression::Variable(namespace) = e {
-        if let Some((builtin, ty)) = builtin::builtin_var(Some(&namespace.name), &id.name, ns) {
+        if let Some((builtin, ty)) = builtin::builtin_var(loc, Some(&namespace.name), &id.name, ns)
+        {
             return Ok(Expression::Builtin(*loc, vec![ty], builtin, vec![]));
         }
     }


### PR DESCRIPTION
tx.gasprice may round to zero giving the impression gas is free.

Signed-off-by: Sean Young <sean@mess.org>