### PR TITLE
Track locations of types and names separately

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -1161,8 +1161,10 @@ pub fn emit_function_call(
                         .iter()
                         .map(|ty| Parameter {
                             name: "".to_owned(),
+                            name_loc: None,
                             loc: *loc,
                             ty: ty.clone(),
+                            ty_loc: *loc,
                             indexed: false,
                         })
                         .collect(),

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -500,8 +500,10 @@ pub fn statement(
             for (i, arg) in args.iter().enumerate() {
                 let param = Parameter {
                     ty: arg.ty(),
+                    ty_loc: arg.loc(),
                     loc: arg.loc(),
                     name: "".to_owned(),
+                    name_loc: None,
                     indexed: false,
                 };
 

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -3451,7 +3451,9 @@ impl<'a> Contract<'a> {
                             &[ast::Parameter {
                                 loc: pt::Loc(0, 0, 0),
                                 name: "error".to_owned(),
+                                name_loc: None,
                                 ty: ast::Type::String,
+                                ty_loc: pt::Loc(0, 0, 0),
                                 indexed: false,
                             }],
                         );

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -2422,7 +2422,9 @@ impl TargetRuntime for SubstrateTarget {
         params.push(ast::Parameter {
             loc: pt::Loc(0, 0, 0),
             ty: salt_ty,
+            ty_loc: pt::Loc(0, 0, 0),
             name: "salt".to_string(),
+            name_loc: None,
             indexed: false,
         });
 

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -91,7 +91,10 @@ impl fmt::Display for EnumDecl {
 pub struct Parameter {
     pub loc: pt::Loc,
     pub name: String,
+    // The name can empty (e.g. in an event field or unnamed parameter/return)
+    pub name_loc: Option<pt::Loc>,
     pub ty: Type,
+    pub ty_loc: pt::Loc,
     pub indexed: bool,
 }
 
@@ -804,6 +807,7 @@ pub enum Statement {
     Emit {
         loc: pt::Loc,
         event_no: usize,
+        event_loc: pt::Loc,
         args: Vec<Expression>,
     },
     TryCatch {

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -337,9 +337,11 @@ pub fn struct_decl(
         }
 
         fields.push(Parameter {
-            loc: field.name.loc,
+            loc: field.loc,
+            name_loc: Some(field.name.loc),
             name: field.name.name.to_string(),
             ty,
+            ty_loc: field.ty.loc(),
             indexed: false,
         });
     }
@@ -403,7 +405,7 @@ pub fn event_decl(
             valid = false;
         }
 
-        let name = if let Some(name) = &field.name {
+        let (name, name_loc) = if let Some(name) = &field.name {
             if let Some(other) = fields.iter().find(|f| f.name == name.name) {
                 ns.diagnostics.push(Diagnostic::error_with_note(
                     name.loc,
@@ -417,9 +419,9 @@ pub fn event_decl(
                 valid = false;
                 continue;
             }
-            name.name.to_owned()
+            (name.name.to_owned(), Some(name.loc))
         } else {
-            String::new()
+            (String::new(), None)
         };
 
         if field.indexed {
@@ -429,7 +431,9 @@ pub fn event_decl(
         fields.push(Parameter {
             loc: field.loc,
             name,
+            name_loc,
             ty,
+            ty_loc: field.ty.loc(),
             indexed: field.indexed,
         });
     }


### PR DESCRIPTION
For the solang language server, we need to track the location of the
types of parameters and returns, so we can provided a hover-over,
which shows e.g the fields of a structure or event.

This also tracks the location of types for emit and try-catch.

Signed-off-by: Sean Young <sean@mess.org>