### PR TITLE
Use ld.lld as a library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Download LLVM
-      run: curl -sS -o c:\llvm.zip https://solang.io/download/llvm10.0.zip
+      run: curl -sS -o c:\llvm.zip https://solang.io/download/llvm10.0-win.zip
     - name: Extract LLVM
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Download LLVM
-      run: curl -sS -o c:\llvm.zip https://solang.io/download/llvm10.0.zip
+      run: curl -sS -o c:\llvm.zip https://solang.io/download/llvm10.0-win.zip
     - name: Extract LLVM
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = [ "solidity", "compiler", "ewasm", "llvm", "substrate" ]
 
 [build-dependencies]
 lalrpop = "0.19"
+cc = "1.0"
 
 [dependencies]
 lalrpop-util = "0.19"
@@ -34,6 +35,7 @@ handlebars = "3.4"
 contract-metadata = "0.1.0"
 semver = { version = "0.10.0", features = ["serde"] }
 tempfile = "3.1"
+libc = "0.2"
 
 [dev-dependencies]
 parity-scale-codec-derive = "1.2"
@@ -45,7 +47,6 @@ rand = "0.7"
 sha2 = "0.9"
 solana_rbpf = "=0.1.32"
 byteorder = "1.3"
-libc = "0.2"
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN cargo build --release
 
 FROM ubuntu:18.04
 COPY --from=builder /src/target/release/solang /usr/bin/solang
-COPY --from=builder /llvm10.0/bin/wasm-ld /usr/bin/
-COPY --from=builder /llvm10.0/bin/ld.lld /usr/bin/
 
 ENV PATH="/llvm10.0/bin:${PATH}"
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
+extern crate cc;
 extern crate lalrpop;
+
 use std::process::Command;
 
 fn main() {
@@ -7,6 +9,45 @@ fn main() {
         .emit_rerun_directives(true)
         .process()
         .unwrap();
+
+    // compile our linker
+    let cxxflags = Command::new("llvm-config")
+        .args(&["--cxxflags"])
+        .output()
+        .unwrap();
+
+    let cxxflags = String::from_utf8(cxxflags.stdout).unwrap();
+
+    let mut build = cc::Build::new();
+
+    build.file("src/linker/linker.cpp").cpp(true);
+
+    if !cfg!(target_os = "windows") {
+        build.flag("-Wno-unused-parameter");
+    }
+
+    for flag in cxxflags.split_whitespace() {
+        build.flag(flag);
+    }
+
+    build.compile("liblinker.a");
+
+    // add the llvm linker
+    let libdir = Command::new("llvm-config")
+        .args(&["--libdir"])
+        .output()
+        .unwrap();
+    let libdir = String::from_utf8(libdir.stdout).unwrap();
+
+    println!("cargo:libdir={}", libdir);
+    for lib in &["lldELF", "lldDriver", "lldCore", "lldCommon", "lldWasm"] {
+        println!("cargo:rustc-link-lib=static={}", lib);
+    }
+
+    // And all the symbols were not using, needed by Windows and debug builds
+    for lib in &["lldReaderWriter", "lldMachO", "lldYAML"] {
+        println!("cargo:rustc-link-lib=static={}", lib);
+    }
 
     // note: add error checking yourself.
     let output = Command::new("git")

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -102,13 +102,13 @@ Installing LLVM on Windows
 __________________________
 
 A pre-built version of llvm, specifically configured for Solang, is available at
-`<https://solang.io/download/llvm10.0.zip>`_. This version is built using the
+`<https://solang.io/download/llvm10.0-win.zip>`_. This version is built using the
 `dockerfile for building llvm on Windows <https://github.com/hyperledger-labs/solang/blob/master/scripts/build-llvm-windows.dockerfile>`_.
 
 If you want to use the dockerfile yourself rather than download the binaries above, then this
 requires `Docker Desktop <https://www.docker.com/products/docker-desktop>`_ and switch to
 `windows containers <https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers>`_.
-Docker on Windows needs Hyper-V. The result will be an image with llvm compressed in ``c:\llvm10.0.zip``.
+Docker on Windows needs Hyper-V. The result will be an image with llvm compressed in ``c:\llvm10.0-win.zip``.
 If you are running Windows 10 in a virtual machine, be sure to check
 `this blog post <https://www.mess.org/2020/06/22/Hyper-V-in-KVM/>`_.
 

--- a/scripts/build-llvm-linux.dockerfile
+++ b/scripts/build-llvm-linux.dockerfile
@@ -16,4 +16,4 @@ RUN cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off \
 
 RUN cmake --build . --target install
 
-RUN tar jcf /llvm10.0.tar.bz2 /llvm10.0/
+RUN tar jcf /llvm10.0-linux.tar.bz2 /llvm10.0/

--- a/scripts/build-llvm-windows.dockerfile
+++ b/scripts/build-llvm-windows.dockerfile
@@ -67,6 +67,6 @@ RUN cmake --build build --target install
 
 WORKDIR \
 
-RUN Compress-Archive -Path C:\llvm10.0 -DestinationPath C:\llvm10.0.zip
+RUN Compress-Archive -Path C:\llvm10.0 -DestinationPath C:\llvm10.0-win.zip
 
 RUN Remove-Item -Path \llvm-project,C:\TEMP -Recurse -Force

--- a/scripts/ci.dockerfile
+++ b/scripts/ci.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04 as builder
 
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python
 
 RUN git clone --branch bpf --single-branch \

--- a/src/linker/linker.cpp
+++ b/src/linker/linker.cpp
@@ -1,0 +1,16 @@
+// Call the LLD linker
+#include "lld/Common/Driver.h"
+
+extern "C" bool LLDWasmLink(const char *argv[], size_t length)
+{
+	llvm::ArrayRef<const char *> args(argv, length);
+
+	return lld::wasm::link(args, false, llvm::outs(), llvm::errs());
+}
+
+extern "C" bool LLDELFLink(const char *argv[], size_t length)
+{
+	llvm::ArrayRef<const char *> args(argv, length);
+
+	return lld::elf::link(args, false, llvm::outs(), llvm::errs());
+}

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -2,12 +2,58 @@ mod bpf;
 mod wasm;
 
 use crate::Target;
+use std::ffi::CString;
+use std::sync::Mutex;
+
+lazy_static::lazy_static! {
+    static ref LINKER_MUTEX: Mutex<i32> = Mutex::new(0i32);
+}
 
 /// Take an object file and turn it into a final linked binary ready for deployment
 pub fn link(input: &[u8], name: &str, target: Target) -> Vec<u8> {
+    // The lld linker is totally not thread-safe; it uses many globals
+    // We should fix this one day
+    let _lock = LINKER_MUTEX.lock().unwrap();
+
     if target == Target::Solana {
         bpf::link(input, name)
     } else {
         wasm::link(input, name, target)
     }
+}
+
+extern "C" {
+    fn LLDELFLink(args: *const *const libc::c_char, size: libc::size_t) -> libc::c_int;
+}
+
+pub fn elf_linker(args: &[CString]) -> bool {
+    let mut command_line: Vec<*const libc::c_char> = Vec::with_capacity(args.len() + 1);
+
+    let executable_name = CString::new("ld.lld").unwrap();
+
+    command_line.push(executable_name.as_ptr());
+
+    for arg in args {
+        command_line.push(arg.as_ptr());
+    }
+
+    unsafe { LLDELFLink(command_line.as_ptr(), command_line.len()) == 0 }
+}
+
+extern "C" {
+    fn LLDWasmLink(args: *const *const libc::c_char, size: libc::size_t) -> libc::c_int;
+}
+
+pub fn wasm_linker(args: &[CString]) -> bool {
+    let mut command_line: Vec<*const libc::c_char> = Vec::with_capacity(args.len() + 1);
+
+    let executable_name = CString::new("wasm-ld").unwrap();
+
+    command_line.push(executable_name.as_ptr());
+
+    for arg in args {
+        command_line.push(arg.as_ptr());
+    }
+
+    unsafe { LLDWasmLink(command_line.as_ptr(), command_line.len()) == 0 }
 }


### PR DESCRIPTION
This has the advantage that solang does not depend on the ld.lld
executable.

Signed-off-by: Sean Young <sean@mess.org>