### PR TITLE
Substrate 2.0 and Solidity Function Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to [Solang](https://github.com/hyperledger-labs/solang/)
 will be documented here.
 
-## [Unreleased]
+## [0.1.5]
 
 ### Added
 - Function types are implemented

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, 2020 Sean Young <sean@mess.org>'
 author = 'Sean Young <sean@mess.org>'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.4'
+release = '0.1.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,18 +8,22 @@ Download release binaries
 
 For Linux x86-64, there is a binary available in the github releases:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.4/solang_linux>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.5/solang_linux>`_
 
-For Windows x64, there is also a binary available:
+For Windows x64, there is a binary available:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.4/solang.exe>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.5/solang.exe>`_
+
+For MacOS, there is a binary available:
+
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.5/solang_mac>`_
 
 Using hyperledgerlabs/solang docker hub images
 ----------------------------------------------
 
 New images are automatically made available on
 `docker hub <https://hub.docker.com/repository/docker/hyperledgerlabs/solang/>`_.
-There is a release `v0.1.4` tag and a `latest` tag:
+There is a release `v0.1.5` tag and a `latest` tag:
 
 .. code-block:: bash
 


### PR DESCRIPTION
- Function types are implemented
- An experimental [Solana](https://solana.com/) target has been added
- Binaries are generated for Mac

- The Substrate target requires Substrate 2.0
- Various bug fixes (see git log)

Signed-off-by: Sean Young <sean@mess.org>