### PR TITLE
Ensure that libraries can be used by base contracts

### DIFF
--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -100,6 +100,7 @@ pub fn resolve(
         for (contract_no, _) in contracts {
             check_base_args(*contract_no, ns);
             missing_overrides(*contract_no, ns);
+            inherited_libraries(*contract_no, ns);
         }
     }
 }
@@ -628,6 +629,15 @@ fn missing_overrides(contract_no: usize, ns: &mut ast::Namespace) {
                 format!("contract ‘{}’ is missing function overrides", contract.name),
                 notes,
             ));
+        }
+    }
+}
+
+// Add libraries used by base contracts
+fn inherited_libraries(contract_no: usize, ns: &mut ast::Namespace) {
+    for base_no in visit_bases(contract_no, ns) {
+        for library_no in ns.contracts[base_no].libraries.to_owned() {
+            import_library(contract_no, library_no, ns);
         }
     }
 }

--- a/tests/substrate_libraries/mod.rs
+++ b/tests/substrate_libraries/mod.rs
@@ -348,3 +348,38 @@ fn using() {
         "cannot find overloaded library function which matches signature"
     );
 }
+
+#[test]
+fn using_in_base() {
+    let mut runtime = build_solidity(
+        r#"
+        contract r is base {
+            function baz(uint64 arg) public returns (bool) {
+                    bar(arg);
+
+                    return x;
+            }
+        }
+
+        library Lib {
+                function foo(uint64 a, uint64 b) internal returns (bool) {
+                        return a == b;
+                }
+        }
+
+        contract base {
+                using Lib for *;
+                bool x;
+
+                function bar(uint64 arg) internal {
+                        x = arg.foo(102);
+                }
+        }
+        "#,
+    );
+
+    runtime.constructor(0, Vec::new());
+    runtime.function("baz", 102u64.encode());
+
+    assert_eq!(runtime.vm.output, true.encode());
+}


### PR DESCRIPTION
If a base contract uses a library which was not references by the concrete
library, then this cause a panic.

thread 'main' panicked at 'no entry found for key', src/codegen/expression.rs:1076:30

Fixes #312 

Signed-off-by: Sean Young <sean@mess.org>