### PR TITLE
Fix imported base contracts

### DIFF
--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -277,9 +277,12 @@ fn layout_contract(contract_no: usize, ns: &mut ast::Namespace) {
     let mut slot = BigInt::zero();
 
     for base_contract_no in visit_bases(contract_no, ns) {
+        // find file number where contract is defined
+        let contract_file_no = ns.contracts[base_contract_no].loc.0;
+
         // find all syms for this contract
-        for ((_, iter_contract_no, name), sym) in &ns.symbols {
-            if *iter_contract_no != Some(base_contract_no) {
+        for ((file_no, iter_contract_no, name), sym) in &ns.symbols {
+            if *iter_contract_no != Some(base_contract_no) || *file_no != contract_file_no {
                 continue;
             }
 

--- a/tests/substrate_tests/inheritance.rs
+++ b/tests/substrate_tests/inheritance.rs
@@ -126,6 +126,43 @@ fn test_abstract() {
     no_errors(ns.diagnostics);
 
     assert_eq!(contracts.len(), 1);
+
+    let mut cache = FileCache::new();
+
+    cache.set_file_contents(
+        "a.sol",
+        r#"
+        contract foo {
+            function f1() public {
+            }
+        }"#
+        .to_string(),
+    );
+
+    cache.set_file_contents(
+        "b.sol",
+        r#"
+        import "a.sol";
+
+        contract bar is foo {
+            function test() public returns (uint32) {
+                return 102;
+            }
+        }
+        "#
+        .to_string(),
+    );
+
+    let (contracts, ns) = solang::compile(
+        "a.sol",
+        &mut cache,
+        inkwell::OptimizationLevel::Default,
+        Target::Substrate,
+    );
+
+    no_errors(ns.diagnostics);
+
+    assert_eq!(contracts.len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
This is giving "already defined" for each symbol in the contract.

Signed-off-by: Sean Young <sean@mess.org>