### PR TITLE
Expand constant folding unit tests

### DIFF
--- a/tests/codegen_testcases/const.sol
+++ b/tests/codegen_testcases/const.sol
@@ -1,8 +1,25 @@
 // RUN: --emit cfg
 contract c {
+// BEGIN-CHECK: c::test
 	function test() public pure returns (int32) {
 		int32 x = 102;
 // CHECK: return int32 102
+		return x;
+	}
+
+// BEGIN-CHECK: c::add
+	function add() public pure returns (int32) {
+		int32 x = 5;
+		x += 3;
+// CHECK: return int32 8
+		return x;
+	}
+
+// BEGIN-CHECK: c::power
+	function power() public pure returns (uint32) {
+		uint32 x = 2;
+		x = x**4;
+// CHECK: return uint32 16
 		return x;
 	}
 }

--- a/tests/codegen_testcases/const_fail.sol
+++ b/tests/codegen_testcases/const_fail.sol
@@ -1,0 +1,10 @@
+// RUN: --emit cfg
+contract c {
+	function divide_zero() public pure returns (uint32) {
+		uint32 x = 2;
+		x = x / 0;
+// FAIL: divide by zero
+		return x;
+	}
+
+}


### PR DESCRIPTION
Note: fail tests & pass tests must be in separate `.sol` files, else the code won't compile at all and so you won't be able to test the passing tests.