### PR TITLE
Solana struct support and eth abi codec struct fixes

### DIFF
--- a/integration/solana/index.ts
+++ b/integration/solana/index.ts
@@ -114,7 +114,7 @@ class TestConnection {
 
         console.log('Program loaded to account', programId.toBase58());
 
-        const returnDataAccount = await this.createStorageAccount(programId, 1024);
+        const returnDataAccount = await this.createStorageAccount(programId, 2048);
         const contractStorageAccount = await this.createStorageAccount(programId, 512);
 
         return new Program(programId, returnDataAccount, contractStorageAccount, abi);
@@ -153,7 +153,7 @@ class Program {
         );
     }
 
-    async call_function(test: TestConnection, name: string, params: string[]): Promise<{ [key: string]: any }> {
+    async call_function(test: TestConnection, name: string, params: any[]): Promise<{ [key: string]: any }> {
         let abi: AbiItem = JSON.parse(this.abi).find((e: AbiItem) => e.name == name);
 
         const input: string = Web3EthAbi.encodeFunctionCall(abi, params);

--- a/integration/solana/storage.sol
+++ b/integration/solana/storage.sol
@@ -1,5 +1,21 @@
+ // ethereum solc wants his pragma
+pragma abicoder v2;
+
 contract store {
     enum enum_bar { bar1, bar2, bar3, bar4 }
+    struct struct_foo {
+        enum_bar f1;
+        bytes f2;
+        int64 f3;
+        bytes3 f4;
+        string f5;
+        inner_foo f6;
+    }
+
+    struct inner_foo {
+        bool in1;
+        string in2;
+    }
 
     uint64 u64;
     uint32 u32;
@@ -10,6 +26,8 @@ contract store {
     bytes bs = hex"b00b1e";
     bytes4 fixedbytes;
     enum_bar bar;
+    struct_foo foo1;
+    struct_foo foo2;
 
     function set_values() public {
         u64 = type(uint64).max;
@@ -26,7 +44,7 @@ contract store {
         return (u64, u32, i16, i256);
     }
 
-    function get_values2() public view returns (uint256, string, bytes, bytes4, enum_bar) {
+    function get_values2() public view returns (uint256, string memory, bytes memory, bytes4, enum_bar) {
         return (u256, str, bs, fixedbytes, bar);
     }
 
@@ -49,15 +67,89 @@ contract store {
         bs.push();
     }
 
-    function push(byte b) public {
+    function push(bytes1 b) public {
         bs.push(b);
     }
 
     function pop() public returns (byte) {
+        // note: ethereum solidity bytes.pop() does not return a value
         return bs.pop();
     }
 
-    function get_bs() public view returns (bytes) {
+    function get_bs() public view returns (bytes memory) {
         return bs;
+    }
+
+    // function for setting the in2 field in either contract storage or memory
+    function set_storage_in2(struct_foo storage f, string memory v) internal {
+        f.f6.in2 = v;
+    }
+
+    // A memory struct is passed by memory reference (pointer)
+    function set_in2(struct_foo memory f, string memory v) pure internal {
+        f.f6.in2 = v;
+    }
+
+    function get_both_foos() public view returns (struct_foo memory, struct_foo memory) {
+        return (foo1, foo2);
+    }
+
+    function get_foo(bool first) public view returns (struct_foo memory) {
+        struct_foo storage f;
+
+        if (first) {
+            f = foo1;
+        } else {
+            f = foo2;
+        }
+
+        return f;
+    }
+
+    function set_foo2(struct_foo f, string v) public {
+        set_in2(f, v);
+        foo2 = f;
+    }
+
+    function set_foo1() public {
+        foo1.f1 = enum_bar.bar2;
+        foo1.f2 = "Don't count your chickens before they hatch";
+        foo1.f3 = -102;
+        foo1.f4 = hex"edaeda";
+        foo1.f5 = "You can't have your cake and eat it too";
+        foo1.f6.in1 = true;
+
+        set_storage_in2(foo1, 'There are other fish in the sea');
+    }
+
+    function delete_foo(bool first) public {
+        struct_foo storage f;
+
+        if (first) {
+            f = foo1;
+        } else {
+            f = foo2;
+        }
+
+        delete f;
+    }
+
+    function struct_literal() public {
+        // declare a struct literal with fields. There is an
+        // inner struct literal which uses positions
+        struct_foo literal = struct_foo({
+            f1: enum_bar.bar4,
+            f2: "Supercalifragilisticexpialidocious",
+            f3: 0xeffedead1234,
+            f4: unicode'€',
+            f5: "Antidisestablishmentarianism",
+            f6: inner_foo(true, "Pseudopseudohypoparathyroidism")
+        });
+
+        // a literal is just a regular memory struct which can be modified
+        literal.f3 = 0xfd9f;
+
+        // now assign it to a storage variable; it will be copied to contract storage
+        foo1 = literal;
     }
 }

--- a/src/abi/ethereum.rs
+++ b/src/abi/ethereum.rs
@@ -59,9 +59,15 @@ pub fn gen_abi(contract_no: usize, ns: &Namespace) -> Vec<ABI> {
             Vec::new()
         };
 
+        let ty = if let Type::Struct(_) = param.ty {
+            String::from("tuple")
+        } else {
+            param.ty.to_signature_string(ns)
+        };
+
         ABIParam {
             name: param.name.to_string(),
-            ty: param.ty.to_signature_string(ns),
+            ty,
             internal_ty: param.ty.to_string(ns),
             components,
             indexed: param.indexed,

--- a/src/emit/ethabiencoder.rs
+++ b/src/emit/ethabiencoder.rs
@@ -51,6 +51,14 @@ impl EthAbiEncoder {
                     *fixed,
                     arg,
                 );
+
+                *fixed = unsafe {
+                    contract.builder.build_gep(
+                        *fixed,
+                        &[contract.context.i32_type().const_int(32, false)],
+                        "",
+                    )
+                };
             }
             ast::Type::Array(_, dim) => {
                 let arg = if load {

--- a/src/emit/ewasm.rs
+++ b/src/emit/ewasm.rs
@@ -805,7 +805,12 @@ impl EwasmTarget {
 }
 
 impl<'a> TargetRuntime<'a> for EwasmTarget {
-    fn clear_storage(&self, contract: &Contract, _function: FunctionValue, slot: PointerValue) {
+    fn storage_delete_single_slot(
+        &self,
+        contract: &Contract,
+        _function: FunctionValue,
+        slot: PointerValue,
+    ) {
         let value = contract
             .builder
             .build_alloca(contract.context.custom_width_int_type(256), "value");

--- a/src/emit/generic.rs
+++ b/src/emit/generic.rs
@@ -192,7 +192,12 @@ impl GenericTarget {
 }
 
 impl<'a> TargetRuntime<'a> for GenericTarget {
-    fn clear_storage(&self, contract: &Contract, _function: FunctionValue, slot: PointerValue) {
+    fn storage_delete_single_slot(
+        &self,
+        contract: &Contract,
+        _function: FunctionValue,
+        slot: PointerValue,
+    ) {
         contract.builder.build_call(
             contract
                 .module

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -6019,9 +6019,7 @@ impl<'a> Contract<'a> {
                 .llvm_type(r)
                 .ptr_type(AddressSpace::Generic)
                 .as_basic_type_enum(),
-            ast::Type::StorageRef(_) => {
-                BasicTypeEnum::IntType(self.context.custom_width_int_type(256))
-            }
+            ast::Type::StorageRef(_) => self.llvm_type(&self.ns.storage_type()),
             ast::Type::InternalFunction {
                 params, returns, ..
             } => {

--- a/src/emit/sabre.rs
+++ b/src/emit/sabre.rs
@@ -229,7 +229,12 @@ impl SabreTarget {
 }
 
 impl<'a> TargetRuntime<'a> for SabreTarget {
-    fn clear_storage(&self, contract: &Contract, _function: FunctionValue, slot: PointerValue) {
+    fn storage_delete_single_slot(
+        &self,
+        contract: &Contract,
+        _function: FunctionValue,
+        slot: PointerValue,
+    ) {
         let address = contract
             .builder
             .build_call(

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -1666,7 +1666,12 @@ impl SubstrateTarget {
 }
 
 impl<'a> TargetRuntime<'a> for SubstrateTarget {
-    fn clear_storage(&self, contract: &Contract, _function: FunctionValue, slot: PointerValue) {
+    fn storage_delete_single_slot(
+        &self,
+        contract: &Contract,
+        _function: FunctionValue,
+        slot: PointerValue,
+    ) {
         contract.builder.build_call(
             contract.module.get_function("seal_clear_storage").unwrap(),
             &[contract

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -49,6 +49,8 @@ pub struct StructDecl {
     pub loc: pt::Loc,
     pub contract: Option<String>,
     pub fields: Vec<Parameter>,
+    // List of offsets of the fields, last entry is the offset for the struct overall size
+    pub offsets: Vec<BigInt>,
 }
 
 #[derive(PartialEq, Clone, Debug)]

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -3367,8 +3367,14 @@ fn member_access(
             Type::Struct(n) => {
                 let mut slot = BigInt::zero();
 
-                for field in &ns.structs[n].fields {
+                for (i, field) in ns.structs[n].fields.iter().enumerate() {
                     if id.name == field.name {
+                        let slot = if ns.target == Target::Solana {
+                            ns.structs[n].offsets[i].clone()
+                        } else {
+                            slot
+                        };
+
                         return Ok(Expression::Add(
                             *loc,
                             Type::StorageRef(Box::new(field.ty.clone())),

--- a/src/sema/format.rs
+++ b/src/sema/format.rs
@@ -1,5 +1,5 @@
 use super::ast::{Diagnostic, Expression, FormatArg, Namespace, Type};
-use super::expression::expression;
+use super::expression::{expression, try_cast};
 use super::symtable::Symtable;
 use crate::parser::pt;
 
@@ -25,7 +25,9 @@ pub fn string_format(
 
     for arg in args {
         let expr = expression(arg, file_no, contract_no, ns, symtable, false)?;
-        resolved_args.push(expr);
+        let ty = expr.ty();
+
+        resolved_args.push(try_cast(&arg.loc(), expr, ty.deref_any(), true, ns).unwrap());
     }
 
     let mut format_iterator = FormatIterator::new(literals).peekable();

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -268,6 +268,11 @@ fn resolve_pragma(name: &pt::Identifier, value: &pt::StringLiteral, ns: &mut ast
             pt::Loc(name.loc.0, name.loc.1, value.loc.2),
             "pragma ‘experimental’ with value ‘ABIEncoderV2’ is ignored".to_string(),
         ));
+    } else if name.name == "abicoder" && value.string == "v2" {
+        ns.diagnostics.push(ast::Diagnostic::debug(
+            pt::Loc(name.loc.0, name.loc.1, value.loc.2),
+            "pragma ‘abicoder’ with value ‘v2’ is ignored".to_string(),
+        ));
     } else {
         ns.diagnostics.push(ast::Diagnostic::warning(
             pt::Loc(name.loc.0, name.loc.1, value.loc.2),

--- a/src/sema/printer.rs
+++ b/src/sema/printer.rs
@@ -239,7 +239,7 @@ fn print_expr(e: &Expression, func: Option<&Function>, ns: &Namespace) -> Tree {
             ],
         ),
         Expression::StructMember(_, ty, struct_expr, member) => {
-            if let Type::Struct(struct_no) = struct_expr.ty() {
+            if let Type::Struct(struct_no) = struct_expr.ty().deref_any() {
                 Tree::Branch(
                     format!("struct member {}", ty.to_string(ns)),
                     vec![
@@ -248,9 +248,9 @@ fn print_expr(e: &Expression, func: Option<&Function>, ns: &Namespace) -> Tree {
                             vec![print_expr(struct_expr, func, ns)],
                         ),
                         Tree::Branch(
-                            String::from("member"),
+                            String::from("field"),
                             vec![Tree::Leaf(
-                                ns.structs[struct_no].fields[*member].name.to_owned(),
+                                ns.structs[*struct_no].fields[*member].name.to_owned(),
                             )],
                         ),
                     ],

--- a/src/sema/printer.rs
+++ b/src/sema/printer.rs
@@ -241,7 +241,7 @@ fn print_expr(e: &Expression, func: Option<&Function>, ns: &Namespace) -> Tree {
         Expression::StructMember(_, ty, struct_expr, member) => {
             if let Type::Struct(struct_no) = struct_expr.ty() {
                 Tree::Branch(
-                    format!("array subscript {}", ty.to_string(ns)),
+                    format!("struct member {}", ty.to_string(ns)),
                     vec![
                         Tree::Branch(
                             String::from("struct"),

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -781,7 +781,17 @@ impl Type {
             ),
             Type::Ref(r) => r.to_string(ns),
             Type::StorageRef(r) => r.to_string(ns),
-            Type::Struct(_) => "tuple".to_owned(),
+            Type::Struct(struct_no) => {
+                format!(
+                    "({})",
+                    ns.structs[*struct_no]
+                        .fields
+                        .iter()
+                        .map(|f| f.ty.to_signature_string(ns))
+                        .collect::<Vec<String>>()
+                        .join(",")
+                )
+            }
             Type::InternalFunction { .. } | Type::ExternalFunction { .. } => "function".to_owned(),
             _ => unreachable!(),
         }

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -258,12 +258,6 @@ impl VM {
         let output = accounts.remove(0);
         let data = accounts.remove(0);
 
-        println!(
-            "output: {} \ndata: {}",
-            hex::encode(&output),
-            hex::encode(&data)
-        );
-
         let len = LittleEndian::read_u64(&output);
         self.output = output[8..len as usize + 8].to_vec();
         self.data = data;
@@ -291,9 +285,13 @@ impl VM {
             Err(x) => panic!(format!("{}", x)),
         };
 
+        println!("input: {}", hex::encode(&calldata));
+
         let mut buf = String::new();
         self.execute(&mut buf, &calldata);
         self.printbuf = buf;
+
+        println!("output: {}", hex::encode(&self.output));
 
         self.abi.functions[name][0]
             .decode_output(&self.output)

--- a/tests/solana_tests/storage.rs
+++ b/tests/solana_tests/storage.rs
@@ -1,4 +1,5 @@
 use crate::build_solidity;
+use ethabi::Token;
 
 #[test]
 fn string() {
@@ -26,12 +27,9 @@ fn string() {
 
     let returns = vm.function("get", &[]);
 
-    assert_eq!(returns, vec![ethabi::Token::String(String::from(""))]);
+    assert_eq!(returns, vec![Token::String(String::from(""))]);
 
-    vm.function(
-        "set",
-        &[ethabi::Token::String(String::from("Hello, World!"))],
-    );
+    vm.function("set", &[Token::String(String::from("Hello, World!"))]);
 
     assert_eq!(
         vm.data[0..12].to_vec(),
@@ -42,24 +40,15 @@ fn string() {
 
     let returns = vm.function("get", &[]);
 
-    assert_eq!(
-        returns,
-        vec![ethabi::Token::String(String::from("Hello, World!"))]
-    );
+    assert_eq!(returns, vec![Token::String(String::from("Hello, World!"))]);
 
     // try replacing it with a string of the same length. This is a special
     // fast-path handling
-    vm.function(
-        "set",
-        &[ethabi::Token::String(String::from("Hallo, Werld!"))],
-    );
+    vm.function("set", &[Token::String(String::from("Hallo, Werld!"))]);
 
     let returns = vm.function("get", &[]);
 
-    assert_eq!(
-        returns,
-        vec![ethabi::Token::String(String::from("Hallo, Werld!"))]
-    );
+    assert_eq!(returns, vec![Token::String(String::from("Hallo, Werld!"))]);
 
     assert_eq!(
         vm.data[0..12].to_vec(),
@@ -68,11 +57,11 @@ fn string() {
 
     // Try setting this to an empty string. This is also a special case where
     // the result should be offset 0
-    vm.function("set", &[ethabi::Token::String(String::from(""))]);
+    vm.function("set", &[Token::String(String::from(""))]);
 
     let returns = vm.function("get", &[]);
 
-    assert_eq!(returns, vec![ethabi::Token::String(String::from(""))]);
+    assert_eq!(returns, vec![Token::String(String::from(""))]);
 
     assert_eq!(
         vm.data[0..12].to_vec(),
@@ -114,14 +103,11 @@ fn bytes() {
 
     let returns = vm.function("foo_length", &[]);
 
-    assert_eq!(
-        returns,
-        vec![ethabi::Token::Uint(ethereum_types::U256::from(0))]
-    );
+    assert_eq!(returns, vec![Token::Uint(ethereum_types::U256::from(0))]);
 
     vm.function(
         "set_foo",
-        &[ethabi::Token::Bytes(
+        &[Token::Bytes(
             b"The shoemaker always wears the worst shoes".to_vec(),
         )],
     );
@@ -138,25 +124,25 @@ fn bytes() {
     {
         let returns = vm.function(
             "get_foo_offset",
-            &[ethabi::Token::Uint(ethereum_types::U256::from(i))],
+            &[Token::Uint(ethereum_types::U256::from(i))],
         );
 
-        assert_eq!(returns, vec![ethabi::Token::FixedBytes(vec![b])]);
+        assert_eq!(returns, vec![Token::FixedBytes(vec![b])]);
     }
 
     vm.function(
         "set_foo_offset",
         &[
-            ethabi::Token::Uint(ethereum_types::U256::from(2)),
-            ethabi::Token::FixedBytes(b"E".to_vec()),
+            Token::Uint(ethereum_types::U256::from(2)),
+            Token::FixedBytes(b"E".to_vec()),
         ],
     );
 
     vm.function(
         "set_foo_offset",
         &[
-            ethabi::Token::Uint(ethereum_types::U256::from(7)),
-            ethabi::Token::FixedBytes(b"E".to_vec()),
+            Token::Uint(ethereum_types::U256::from(7)),
+            Token::FixedBytes(b"E".to_vec()),
         ],
     );
 
@@ -167,10 +153,10 @@ fn bytes() {
     {
         let returns = vm.function(
             "get_foo_offset",
-            &[ethabi::Token::Uint(ethereum_types::U256::from(i))],
+            &[Token::Uint(ethereum_types::U256::from(i))],
         );
 
-        assert_eq!(returns, vec![ethabi::Token::FixedBytes(vec![b])]);
+        assert_eq!(returns, vec![Token::FixedBytes(vec![b])]);
     }
 }
 
@@ -205,8 +191,8 @@ fn bytes_set_subscript_range() {
     vm.function(
         "set_foo_offset",
         &[
-            ethabi::Token::Uint(ethereum_types::U256::from(0)),
-            ethabi::Token::FixedBytes(b"E".to_vec()),
+            Token::Uint(ethereum_types::U256::from(0)),
+            Token::FixedBytes(b"E".to_vec()),
         ],
     );
 }
@@ -241,16 +227,14 @@ fn bytes_get_subscript_range() {
 
     vm.function(
         "set_foo",
-        &[ethabi::Token::Bytes(
+        &[Token::Bytes(
             b"The shoemaker always wears the worst shoes".to_vec(),
         )],
     );
 
     vm.function(
         "get_foo_offset",
-        &[ethabi::Token::Uint(ethereum_types::U256::from(
-            0x80000000u64,
-        ))],
+        &[Token::Uint(ethereum_types::U256::from(0x80000000u64))],
     );
 }
 
@@ -303,29 +287,29 @@ fn bytes_push_pop() {
 
     let returns = vm.function("get_bs", &[]);
 
-    assert_eq!(returns, vec![ethabi::Token::Bytes(vec!(0x0e, 0xda))]);
+    assert_eq!(returns, vec![Token::Bytes(vec!(0x0e, 0xda))]);
 
     let returns = vm.function("pop", &[]);
 
-    assert_eq!(returns, vec![ethabi::Token::FixedBytes(vec!(0xda))]);
+    assert_eq!(returns, vec![Token::FixedBytes(vec!(0xda))]);
 
     let returns = vm.function("get_bs", &[]);
 
-    assert_eq!(returns, vec![ethabi::Token::Bytes(vec!(0x0e))]);
+    assert_eq!(returns, vec![Token::Bytes(vec!(0x0e))]);
 
-    vm.function("push", &[ethabi::Token::FixedBytes(vec![0x41])]);
+    vm.function("push", &[Token::FixedBytes(vec![0x41])]);
 
     println!("data:{}", hex::encode(&vm.data));
 
     let returns = vm.function("get_bs", &[]);
 
-    assert_eq!(returns, vec![ethabi::Token::Bytes(vec!(0x0e, 0x41))]);
+    assert_eq!(returns, vec![Token::Bytes(vec!(0x0e, 0x41))]);
 
-    vm.function("push", &[ethabi::Token::FixedBytes(vec![0x01])]);
+    vm.function("push", &[Token::FixedBytes(vec![0x01])]);
 
     let returns = vm.function("get_bs", &[]);
 
-    assert_eq!(returns, vec![ethabi::Token::Bytes(vec!(0x0e, 0x41, 0x01))]);
+    assert_eq!(returns, vec![Token::Bytes(vec!(0x0e, 0x41, 0x01))]);
 }
 
 #[test]
@@ -346,3 +330,159 @@ fn bytes_empty_pop() {
 
     vm.function("pop", &[]);
 }
+
+#[test]
+fn simple_struct() {
+    let mut vm = build_solidity(
+        r#"
+        contract c {
+            struct s {
+                uint8 f1;
+                uint32 f2;
+            }
+
+            uint16 s2 = 0xdead;
+            s s1;
+
+            function get_s1() public returns (s) {
+                return s1;
+            }
+
+            function set_s1(s v) public {
+                s1 = v;
+            }
+
+            function set_s2() public {
+                s1 = s({f1: 254, f2: 0xdead});
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    vm.function("set_s2", &[]);
+
+    assert_eq!(
+        vm.data[0..24].to_vec(),
+        vec![
+            11, 66, 182, 57, 24, 0, 0, 0, 173, 222, 0, 0, 254, 0, 0, 0, 173, 222, 0, 0, 0, 0, 0, 0
+        ]
+    );
+
+    let returns = vm.function("get_s1", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::Tuple(vec![
+            Token::Uint(ethereum_types::U256::from(254)),
+            Token::Uint(ethereum_types::U256::from(0xdead)),
+        ])]
+    );
+
+    vm.function(
+        "set_s1",
+        &[Token::Tuple(vec![
+            Token::Uint(ethereum_types::U256::from(102)),
+            Token::Uint(ethereum_types::U256::from(3240121)),
+        ])],
+    );
+
+    let returns = vm.function("get_s1", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::Tuple(vec![
+            Token::Uint(ethereum_types::U256::from(102)),
+            Token::Uint(ethereum_types::U256::from(3240121)),
+        ])]
+    );
+}
+
+#[test]
+fn struct_in_struct() {
+    let mut vm = build_solidity(
+        r#"
+        contract c {
+            struct s {
+                uint8 f1;
+                X f3;
+                uint64 f4;
+            }
+
+            struct X {
+                int32 f1;
+                bytes6 f2;
+            }
+
+            uint32 s2 = 0xdead;
+            s s1;
+
+            function get_s1() public returns (s) {
+                return s1;
+            }
+
+            function set_s1(s v) public {
+                s1 = v;
+            }
+
+            function set_s2() public {
+                s1 = s({f1: 254, f3: X({f1: 102, f2: "foobar"}), f4: 1234567890});
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    vm.function("set_s2", &[]);
+
+    assert_eq!(
+        vm.data[0..44].to_vec(),
+        vec![
+            11, 66, 182, 57, 40, 0, 0, 0, 173, 222, 0, 0, 0, 0, 0, 0, 254, 0, 0, 0, 102, 0, 0, 0,
+            114, 97, 98, 111, 111, 102, 0, 0, 210, 2, 150, 73, 0, 0, 0, 0, 0, 0, 0, 0
+        ]
+    );
+
+    let returns = vm.function("get_s1", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::Tuple(vec![
+            Token::Uint(ethereum_types::U256::from(254)),
+            Token::Tuple(vec![
+                Token::Int(ethereum_types::U256::from(102)),
+                Token::FixedBytes(vec![102, 111, 111, 98, 97, 114])
+            ]),
+            Token::Uint(ethereum_types::U256::from(1234567890))
+        ])]
+    );
+
+    vm.function(
+        "set_s1",
+        &[Token::Tuple(vec![
+            Token::Uint(ethereum_types::U256::from(127)),
+            Token::Tuple(vec![
+                Token::Int(ethereum_types::U256::from(8192)),
+                Token::FixedBytes(vec![1, 2, 3, 4, 5, 6]),
+            ]),
+            Token::Uint(ethereum_types::U256::from(12345678901234567890u64)),
+        ])],
+    );
+
+    let returns = vm.function("get_s1", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::Tuple(vec![
+            Token::Uint(ethereum_types::U256::from(127)),
+            Token::Tuple(vec![
+                Token::Int(ethereum_types::U256::from(8192)),
+                Token::FixedBytes(vec![1, 2, 3, 4, 5, 6]),
+            ]),
+            Token::Uint(ethereum_types::U256::from(12345678901234567890u64)),
+        ])]
+    );
+}
+
+// string in struct
+// dereference struct storage member (read/write)

--- a/tests/solana_tests/storage.rs
+++ b/tests/solana_tests/storage.rs
@@ -602,6 +602,10 @@ fn complex_struct() {
                 s1.f5.sss2 = "jasldajldjaldjlads";
                 s1.f6 = "as nervous as a long-tailed cat in a room full of rocking chairs";
             }
+
+            function rm() public {
+                delete s1;
+            }
         }"#,
     );
 
@@ -677,6 +681,28 @@ fn complex_struct() {
                     Token::Bytes(b"jasldajldjaldjlads".to_vec()),
                 ]),
                 Token::String(String::from("be as honest as the day is long")),
+            ]),
+            Token::String(String::from("yadayada")),
+        ]
+    );
+
+    vm.function("rm", &[]);
+
+    let returns = vm.function("get_s1", &[]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Tuple(vec![
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::String(String::from("")),
+                Token::Tuple(vec![Token::Bool(false), Token::FixedBytes(vec![0, 0, 0]),]),
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::Tuple(vec![
+                    Token::Uint(ethereum_types::U256::from(0)),
+                    Token::Bytes(Vec::new()),
+                ]),
+                Token::String(String::from("")),
             ]),
             Token::String(String::from("yadayada")),
         ]

--- a/tests/solana_tests/storage.rs
+++ b/tests/solana_tests/storage.rs
@@ -260,8 +260,8 @@ fn storage_alignment() {
         r#"
         contract c {
             bool f1 = true;
-            uint8 f2 = 2;
-            uint16 f3 = 0x304;
+            uint16 f3 = 0x203;
+            uint8 f2 = 4;
             uint32 f4 = 0x5060708;
             uint64 f5 = 0x90a0b0c0d0e0f10;
         }"#,
@@ -270,8 +270,11 @@ fn storage_alignment() {
     vm.constructor(&[]);
 
     assert_eq!(
-        vm.data[0..24].to_vec(),
-        vec![11, 66, 182, 57, 24, 0, 0, 0, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 1, 2,]
+        vm.data[0..32].to_vec(),
+        vec![
+            11, 66, 182, 57, 32, 0, 0, 0, 1, 0, 3, 2, 4, 0, 0, 0, 8, 7, 6, 5, 0, 0, 0, 0, 16, 15,
+            14, 13, 12, 11, 10, 9
+        ]
     );
 }
 


### PR DESCRIPTION
- Implements `delete` keyword for Solana
- Implements `struct` for Solana
- Various fixes to eth abi encoder and decoder wrt struct
- There was codegen in sema which did not belong there.