### PR TITLE
Use seal_transfer() rather than seal_call() for .transfer() and .send()

### DIFF
--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -24,8 +24,8 @@ Using the extension
 
 The extension can be found on the `Visual Studio Marketplace <https://marketplace.visualstudio.com/items?itemName=solang.solang>`_.
 
-First, install the extension and the solang compiler binary. The extension needs
-to know where to find the solang binary to start the language server, and also
+First, install the extension and the Solang compiler binary. The extension needs
+to know where to find the Solang binary to start the language server, and also
 it needs to know what target you wish to compile your solidity code for.
 
 .. image:: extension-config.png
@@ -35,7 +35,7 @@ Development
 
 The code is spread over two parts. The first part the vscode extension client code,
 `written in TypeScript <https://github.com/hyperledger-labs/solang/tree/main/vscode>`_.
-This part deals with syntax highlighting, and calling out to the solang language server when
+This part deals with syntax highlighting, and calling out to the Solang language server when
 needed. The client needs `npm and node installed <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_.
 The client implementation is present in
 `src/client <https://github.com/hyperledger-labs/solang/tree/main/vscode/src/client>`_.
@@ -43,7 +43,7 @@ The extension client code is in
 `src/client/extension.ts <https://github.com/hyperledger-labs/solang/tree/main/vscode/src/client/extension.ts>`_.
 
 Secondly, there is the language server which is written in Rust.
-The solang binary has an option ``--language-server``, which start the
+The Solang binary has an option ``--language-server``, which start the
 `built-in language server <https://github.com/hyperledger-labs/solang/blob/main/src/bin/languageserver/mod.rs>`_.
 
 Once you have node and npm installed, you can build the extension like so:

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -30,8 +30,7 @@ There is a release `v0.1.6` tag and a `latest` tag:
 	docker pull hyperledgerlabs/solang
 
 The Solang binary is stored at ``/usr/bin/solang`` in this image. The `latest` tag
-gets updated each time there is a commit to the main branch of the solang
-git repository.
+gets updated each time there is a commit to the main branch of the Solang git repository.
 
 Build Solang using Dockerfile
 -----------------------------
@@ -51,7 +50,7 @@ Then you can build the image using:
 Building Solang from source
 ---------------------------
 
-In order to build solang from source, you will need rust 1.43.0 or higher,
+In order to build Solang from source, you will need rust 1.43.0 or higher,
 and a build of llvm based on our tree. There are a few patches which are not upstream yet
 First, follow the steps below for installing llvm and then proceed from there.
 
@@ -157,7 +156,7 @@ And on Windows, assuming *installdir* was ``C:\Users\User\solang-llvm``:
 Building Solang from crates.io
 ------------------------------
 
-The latest solang release is  on `crates.io <https://crates.io/crates/solang>`_. Once you have the
+The latest Solang release is  on `crates.io <https://crates.io/crates/solang>`_. Once you have the
 correct llvm version in your path, simply run:
 
 .. code-block:: bash

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -3097,7 +3097,7 @@ Tags
 
 Any contract, interface, library, event definition, struct definition, function, or contract variable
 may have tags associated with them. These are used for generating documentation for the contracts,
-when solang is run with the ``--doc`` command line option. This option generates some html which
+when Solang is run with the ``--doc`` command line option. This option generates some html which
 lists all the types, contracts, functions, and state variables along with their tags.
 
 The tags use a special comment format. They can either be specified in block comments or single

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -2695,8 +2695,10 @@ Here is an example:
     }
 
 .. note::
-    This uses the ``seal_call()`` mechanism rather than ``seal_transfer()``, since
-    Solidity expects the ``receive()`` function to be called on receipt.
+    On Subtrate, this uses the ``seal_transfer()`` mechanism rather than ``seal_call()``, since this
+    does not come with gas overhead. This means the ``receive()`` function is not required in the
+    receiving contract, and it will not be called if it is present. If you want the ``receive()``
+    function to be called, use ``address.call{value: 100}("")`` instead.
 
 
 Builtin Functions and Variables

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -146,7 +146,7 @@ Now you should have a file called ``flipper.contract``. The file contains both t
 It can be used directly in the
 `Polkadot UI <https://substrate.dev/substrate-contracts-workshop/#/0/deploying-your-contract?id=putting-your-code-on-the-blockchain>`_, as if the contract was written in ink!.
 
-Using solang with Solana
+Using Solang with Solana
 ------------------------
 
 The `Solana <https://www.solana.com/>`_ target is new and is limited right now, not all types are implemented

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -103,6 +103,12 @@ pub enum Instr {
         gas: Expression,
         callty: CallTy,
     },
+    /// Value transfer; either <address>.send() or <address>.transfer()
+    ValueTransfer {
+        success: Option<usize>,
+        address: Expression,
+        value: Expression,
+    },
     /// ABI decoder encoded data. If decoding fails, either jump to exception
     /// or abort if this is None.
     AbiDecode {
@@ -807,6 +813,21 @@ impl ControlFlowGraph {
                         self.expr_to_string(contract, ns, value),
                     )
                 }
+            }
+            Instr::ValueTransfer {
+                success,
+                address,
+                value,
+            } => {
+                format!(
+                    "{} = value transfer address:{} value:{}",
+                    match success {
+                        Some(i) => format!("%{}", self.vars[i].id.name),
+                        None => "_".to_string(),
+                    },
+                    self.expr_to_string(contract, ns, address),
+                    self.expr_to_string(contract, ns, value),
+                )
             }
             Instr::AbiDecode {
                 res,

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -780,18 +780,29 @@ pub fn expression(
                 &Type::Bool,
             );
 
-            cfg.add(
-                vartab,
-                Instr::ExternalCall {
-                    success: Some(success),
-                    address: Some(address),
-                    payload: Expression::BytesLiteral(*loc, Type::DynamicBytes, vec![]),
-                    args: Vec::new(),
-                    value,
-                    gas: Expression::NumberLiteral(*loc, Type::Uint(64), BigInt::zero()),
-                    callty: CallTy::Regular,
-                },
-            );
+            if ns.target == Target::Substrate {
+                cfg.add(
+                    vartab,
+                    Instr::ValueTransfer {
+                        success: Some(success),
+                        address,
+                        value,
+                    },
+                );
+            } else {
+                cfg.add(
+                    vartab,
+                    Instr::ExternalCall {
+                        success: Some(success),
+                        address: Some(address),
+                        payload: Expression::BytesLiteral(*loc, Type::DynamicBytes, vec![]),
+                        args: Vec::new(),
+                        value,
+                        gas: Expression::NumberLiteral(*loc, Type::Uint(64), BigInt::zero()),
+                        callty: CallTy::Regular,
+                    },
+                );
+            }
 
             Expression::Variable(*loc, Type::Bool, success)
         }
@@ -799,18 +810,29 @@ pub fn expression(
             let address = expression(&args[0], cfg, contract_no, ns, vartab);
             let value = expression(&args[1], cfg, contract_no, ns, vartab);
 
-            cfg.add(
-                vartab,
-                Instr::ExternalCall {
-                    success: None,
-                    address: Some(address),
-                    payload: Expression::BytesLiteral(*loc, Type::DynamicBytes, vec![]),
-                    args: Vec::new(),
-                    value,
-                    gas: Expression::NumberLiteral(*loc, Type::Uint(64), BigInt::zero()),
-                    callty: CallTy::Regular,
-                },
-            );
+            if ns.target == Target::Substrate {
+                cfg.add(
+                    vartab,
+                    Instr::ValueTransfer {
+                        success: None,
+                        address,
+                        value,
+                    },
+                );
+            } else {
+                cfg.add(
+                    vartab,
+                    Instr::ExternalCall {
+                        success: None,
+                        address: Some(address),
+                        payload: Expression::BytesLiteral(*loc, Type::DynamicBytes, vec![]),
+                        args: Vec::new(),
+                        value,
+                        gas: Expression::NumberLiteral(*loc, Type::Uint(64), BigInt::zero()),
+                        callty: CallTy::Regular,
+                    },
+                );
+            }
 
             Expression::Poison
         }

--- a/src/codegen/reaching_definitions.rs
+++ b/src/codegen/reaching_definitions.rs
@@ -136,6 +136,9 @@ fn instr_transfers(block_no: usize, block: &BasicBlock) -> Vec<Vec<Transfer>> {
             }
             | Instr::Constructor {
                 success: None, res, ..
+            }
+            | Instr::ValueTransfer {
+                success: Some(res), ..
             } => set_var(&[*res]),
             Instr::ClearStorage { storage: dest, .. }
             | Instr::SetStorageBytes { storage: dest, .. }

--- a/src/codegen/vector_to_slice.rs
+++ b/src/codegen/vector_to_slice.rs
@@ -97,7 +97,8 @@ fn find_writable_vectors(
             | Instr::Unreachable
             | Instr::Print { .. }
             | Instr::AbiEncodeVector { .. }
-            | Instr::AssertFailure { .. } => {
+            | Instr::AssertFailure { .. }
+            | Instr::ValueTransfer { .. } => {
                 apply_transfers(&block.transfers[instr_no], vars, writable);
             }
         }

--- a/tests/substrate_tests/value.rs
+++ b/tests/substrate_tests/value.rs
@@ -840,7 +840,8 @@ fn send_and_transfer() {
 
     runtime.function("step1", Vec::new());
 
-    assert_eq!(runtime.vm.output, false.encode());
+    // no receive() required for send/transfer
+    assert_eq!(runtime.vm.output, true.encode());
 
     for (address, account) in runtime.accounts {
         if address == runtime.vm.address {
@@ -906,7 +907,7 @@ fn send_and_transfer() {
 
     runtime.constructor(0, Vec::new());
 
-    runtime.function_expect_return("step1", Vec::new(), 1);
+    runtime.function("step1", Vec::new());
 
     for (address, account) in runtime.accounts {
         if address == runtime.vm.address {


### PR DESCRIPTION
Using the call interface rather than the substrate transfer interface is a bit odd anyway.

This may solve the issue in #370 