### PR TITLE
Attempt to resolve expressions to the expected types

### DIFF
--- a/docs/language.rst
+++ b/docs/language.rst
@@ -177,8 +177,7 @@ The largest value an ``uint8`` can hold is (2 :superscript:`8`) - 1 = 255. So, t
 
 .. code-block:: none
 
-    implicit conversion would truncate from uint16 to uint8
-
+    literal 300 is too large to fit into type ‘uint8’
 
 .. tip::
 
@@ -533,14 +532,13 @@ known as arrays of arrays). For example:
     }
 
 Note the length of the array can be read with the ``.length`` member. The length is readonly.
-Arrays can be initialized with an array literal. The first element of the array should be
-cast to the correct element type. For example:
+Arrays can be initialized with an array literal. For example:
 
 .. code-block:: javascript
 
     contract primes {
         function primenumber(uint32 n) public pure returns (uint64) {
-            uint64[10] primes = [ uint64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29 ];
+            uint64[10] primes = [ 2, 3, 5, 7, 11, 13, 17, 19, 23, 29 ];
 
             return primes[n];
         }

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -1415,7 +1415,8 @@ fn array_subscript(
 
     let array_length = match array_ty.deref_any() {
         Type::Bytes(n) => {
-            bigint_to_expression(&array.loc(), &BigInt::from(*n), &mut Vec::new()).unwrap()
+            bigint_to_expression(&array.loc(), &BigInt::from(*n), ns, &mut Vec::new(), None)
+                .unwrap()
         }
         Type::Array(_, _) => match array_ty.array_length() {
             None => {
@@ -1430,7 +1431,7 @@ fn array_subscript(
                     Expression::DynamicArrayLength(*loc, Box::new(array.clone()))
                 }
             }
-            Some(l) => bigint_to_expression(loc, l, &mut Vec::new()).unwrap(),
+            Some(l) => bigint_to_expression(loc, l, ns, &mut Vec::new(), None).unwrap(),
         },
         Type::DynamicBytes => Expression::DynamicArrayLength(*loc, Box::new(array.clone())),
         _ => {

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -7,7 +7,7 @@ use crate::parser::pt;
 use crate::sema::ast::{
     CallTy, DestructureField, Expression, Function, Namespace, Parameter, Statement, Type,
 };
-use crate::sema::expression::try_cast;
+use crate::sema::expression::cast;
 
 /// Resolve a statement, which might be a block of statements or an entire body of a function
 pub fn statement(
@@ -452,7 +452,7 @@ pub fn statement(
                     }
                     DestructureField::VariableDecl(res, param) => {
                         // the resolver did not cast the expression
-                        let expr = try_cast(&param.loc, right, &param.ty, true, ns)
+                        let expr = cast(&param.loc, right, &param.ty, true, ns, &mut Vec::new())
                             .expect("sema should have checked cast");
 
                         cfg.add(
@@ -468,8 +468,15 @@ pub fn statement(
                         // the resolver did not cast the expression
                         let loc = left.loc();
 
-                        let expr = try_cast(&loc, right, left.ty().deref_any(), true, ns)
-                            .expect("sema should have checked cast");
+                        let expr = cast(
+                            &loc,
+                            right,
+                            left.ty().deref_any(),
+                            true,
+                            ns,
+                            &mut Vec::new(),
+                        )
+                        .expect("sema should have checked cast");
 
                         assign_single(left, &expr, cfg, contract_no, ns, vartab);
                     }

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -874,6 +874,16 @@ pub enum DestructureField {
     VariableDecl(usize, Parameter),
 }
 
+impl DestructureField {
+    pub fn loc(&self) -> Option<pt::Loc> {
+        match self {
+            DestructureField::None => None,
+            DestructureField::Expression(e) => Some(e.loc()),
+            DestructureField::VariableDecl(_, p) => Some(p.loc),
+        }
+    }
+}
+
 impl Statement {
     /// recurse over the statement
     pub fn recurse<T>(&self, cx: &mut T, f: fn(stmt: &Statement, ctx: &mut T) -> bool) {

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use super::ast;
-use super::expression::{expression, match_constructor_to_args};
+use super::expression::match_constructor_to_args;
 use super::functions;
 use super::statements;
 use super::symtable::Symtable;
@@ -233,29 +233,17 @@ fn resolve_base_args(
                     .position(|e| e.contract_no == base_no)
                 {
                     if let Some(args) = &base.args {
-                        let mut resolved_args = Vec::new();
                         let symtable = Symtable::new();
-
-                        for arg in args {
-                            if let Ok(e) = expression(
-                                &arg,
-                                file_no,
-                                Some(*contract_no),
-                                ns,
-                                &symtable,
-                                true,
-                                &mut diagnostics,
-                            ) {
-                                resolved_args.push(e);
-                            }
-                        }
 
                         // find constructor which matches this
                         if let Ok((Some(constructor_no), args)) = match_constructor_to_args(
                             &base.loc,
-                            resolved_args,
+                            args,
+                            file_no,
                             base_no,
+                            *contract_no,
                             ns,
+                            &symtable,
                             &mut diagnostics,
                         ) {
                             ns.contracts[*contract_no].bases[pos].constructor =

--- a/src/sema/eval.rs
+++ b/src/sema/eval.rs
@@ -108,6 +108,7 @@ pub fn eval_const_number(
         Expression::NumberLiteral(loc, _, n) => Ok((*loc, n.clone())),
         Expression::ZeroExt(loc, _, n) => Ok((*loc, eval_const_number(n, contract_no, ns)?.1)),
         Expression::SignExt(loc, _, n) => Ok((*loc, eval_const_number(n, contract_no, ns)?.1)),
+        Expression::Cast(loc, _, n) => Ok((*loc, eval_const_number(n, contract_no, ns)?.1)),
         Expression::Not(loc, n) => Ok((*loc, !eval_const_number(n, contract_no, ns)?.1)),
         Expression::Complement(loc, _, n) => Ok((*loc, !eval_const_number(n, contract_no, ns)?.1)),
         Expression::UnaryMinus(loc, _, n) => Ok((*loc, -eval_const_number(n, contract_no, ns)?.1)),

--- a/src/sema/format.rs
+++ b/src/sema/format.rs
@@ -25,7 +25,17 @@ pub fn string_format(
     let mut resolved_args = Vec::new();
 
     for arg in args {
-        let expr = expression(arg, file_no, contract_no, ns, symtable, false, diagnostics)?;
+        let expr = expression(
+            arg,
+            file_no,
+            contract_no,
+            ns,
+            symtable,
+            false,
+            diagnostics,
+            None,
+        )?;
+
         let ty = expr.ty();
 
         resolved_args.push(cast(&arg.loc(), expr, ty.deref_any(), true, ns, diagnostics).unwrap());

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -1344,6 +1344,7 @@ impl ast::Namespace {
             &symtable,
             true,
             diagnostics,
+            Some(&ast::Type::Uint(256)),
         )?;
 
         match size_expr.ty() {

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -306,9 +306,12 @@ pub fn struct_decl(
     let mut fields: Vec<Parameter> = Vec::new();
 
     for field in &def.fields {
-        let ty = match ns.resolve_type(file_no, contract_no, false, &field.ty) {
+        let mut diagnostics = Vec::new();
+
+        let ty = match ns.resolve_type(file_no, contract_no, false, &field.ty, &mut diagnostics) {
             Ok(s) => s,
             Err(()) => {
+                ns.diagnostics.extend(diagnostics);
                 valid = false;
                 continue;
             }
@@ -396,9 +399,12 @@ pub fn event_decl(
     let mut indexed_fields = 0;
 
     for field in &def.fields {
-        let ty = match ns.resolve_type(file_no, contract_no, false, &field.ty) {
+        let mut diagnostics = Vec::new();
+
+        let ty = match ns.resolve_type(file_no, contract_no, false, &field.ty, &mut diagnostics) {
             Ok(s) => s,
             Err(()) => {
+                ns.diagnostics.extend(diagnostics);
                 valid = false;
                 continue;
             }

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -756,6 +756,7 @@ impl Type {
             Type::Int(_) => true,
             Type::Uint(_) => true,
             Type::Bytes(_) => true,
+            Type::Value => true,
             Type::Ref(r) => r.is_primitive(),
             Type::StorageRef(r) => r.is_primitive(),
             _ => false,
@@ -935,8 +936,7 @@ impl Type {
         match self {
             Type::Int(_) => true,
             Type::Uint(_) => true,
-            Type::Struct(_) => unreachable!(),
-            Type::Array(_, _) => unreachable!(),
+            Type::Value => true,
             Type::Ref(r) => r.ordered(),
             Type::StorageRef(r) => r.ordered(),
             _ => false,

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -182,6 +182,7 @@ pub fn var_decl(
             &symtable,
             is_constant,
             &mut diagnostics,
+            Some(&ty),
         ) {
             Ok(res) => res,
             Err(()) => {

--- a/tests/substrate_tests/arrays.rs
+++ b/tests/substrate_tests/arrays.rs
@@ -522,7 +522,10 @@ fn array_dimensions() {
         Target::Substrate,
     );
 
-    assert_eq!(first_error(ns.diagnostics), "zero size array not permitted");
+    assert_eq!(
+        first_error(ns.diagnostics),
+        "negative literal -10 not allowed for unsigned type ‘uint256’"
+    );
 
     let ns = parse_and_resolve(
         r#"
@@ -775,7 +778,7 @@ fn memory_dynamic_array_new() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "new size argument must be unsigned integer, not ‘int8’"
+        "negative literal -1 not allowed for unsigned type ‘uint32’"
     );
 
     let ns = parse_and_resolve(
@@ -839,7 +842,7 @@ fn memory_dynamic_array_deref() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "array subscript must be an unsigned integer, not ‘int8’"
+        "negative literal -1 not allowed for unsigned type ‘uint32’"
     );
 
     let ns = parse_and_resolve(

--- a/tests/substrate_tests/contracts.rs
+++ b/tests/substrate_tests/contracts.rs
@@ -206,7 +206,7 @@ fn contract_type() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion from uint8 to address not allowed"
+        "expected ‘address’, found integer"
     );
 
     let ns = parse_and_resolve(
@@ -227,7 +227,7 @@ fn contract_type() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "conversion from uint8 to contract printer not possible"
+        "expected ‘contract printer’, found integer"
     );
 
     let ns = parse_and_resolve(
@@ -335,6 +335,32 @@ fn external_call() {
         first_error(ns.diagnostics),
         "duplicate argument with name ‘t’"
     );
+
+    let ns = parse_and_resolve(
+        r##"
+        contract c {
+            b x;
+            constructor() public {
+                x = new b({ a: 1, a: 2 });
+            }
+            function test() public returns (int32) {
+                return x.get_x({ t: 10 });
+            }
+        }
+
+        contract b {
+            int32 x;
+            constructor(int32 a) public {
+                x = a;
+            }
+            function get_x(int32 t) public returns (int32) {
+                return x * t;
+            }
+        }"##,
+        Target::Substrate,
+    );
+
+    assert_eq!(first_error(ns.diagnostics), "duplicate argument name ‘a’");
 
     #[derive(Debug, PartialEq, Encode, Decode)]
     struct Ret(u32);

--- a/tests/substrate_tests/functions.rs
+++ b/tests/substrate_tests/functions.rs
@@ -798,7 +798,7 @@ fn positional_argument_call() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "conversion from uint8 to bool not possible"
+        "expected ‘bool’, found integer"
     );
 
     let mut runtime = build_solidity(

--- a/tests/substrate_tests/primitives.rs
+++ b/tests/substrate_tests/primitives.rs
@@ -96,7 +96,7 @@ fn test_literal_overflow() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion would truncate from uint16 to uint8"
+        "literal 300 is too large to fit into type ‘uint8’"
     );
 
     let ns = parse_and_resolve(
@@ -108,7 +108,7 @@ fn test_literal_overflow() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion would truncate from uint24 to uint16"
+        "literal 65536 is too large to fit into type ‘uint16’"
     );
 
     let ns = parse_and_resolve(
@@ -120,7 +120,19 @@ fn test_literal_overflow() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion would truncate from uint8 to int8"
+        "literal 128 is too large to fit into type ‘int8’"
+    );
+
+    let ns = parse_and_resolve(
+        "contract test {
+            int8 foo = -129;
+        }",
+        Target::Substrate,
+    );
+
+    assert_eq!(
+        first_error(ns.diagnostics),
+        "literal -129 is too large to fit into type ‘int8’"
     );
 
     let ns = parse_and_resolve(
@@ -159,7 +171,7 @@ fn test_literal_overflow() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion cannot change negative number to uint8"
+        "negative literal -130 not allowed for unsigned type ‘uint8’"
     );
 
     let ns = parse_and_resolve(
@@ -171,7 +183,7 @@ fn test_literal_overflow() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion would truncate from uint72 to int64"
+        "literal 18446744073709551616 is too large to fit into type ‘int64’"
     );
 
     let ns = parse_and_resolve(
@@ -183,7 +195,7 @@ fn test_literal_overflow() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion from constant 3 bytes to bytes4 not possible"
+        "hex literal 0xf12233 must be 8 digits for type ‘bytes4’"
     );
 
     let ns = parse_and_resolve(
@@ -195,8 +207,17 @@ fn test_literal_overflow() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion from constant 5 bytes to bytes4 not possible"
+        "hex literal 0x0122334455 must be 8 digits for type ‘bytes4’"
     );
+
+    let ns = parse_and_resolve(
+        "contract test {
+            bytes4 foo = 0x00223344;
+        }",
+        Target::Substrate,
+    );
+
+    no_errors(ns.diagnostics);
 }
 
 #[test]
@@ -295,7 +316,7 @@ fn address() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion from uint80 to address not allowed"
+        "expected ‘address’, found integer"
     );
 
     let ns = parse_and_resolve(
@@ -307,7 +328,7 @@ fn address() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "implicit conversion from uint256 to address not allowed"
+        "expected ‘address’, found integer"
     );
 
     let ns = parse_and_resolve(


### PR DESCRIPTION
This PR resolves a number of issues around resolving types, for example:
 - The elements of an array literal should be resolved to the expected type; do not just take the type of the first element

To be completed:
 - [x] fn expression() should not modify Namespace
 - [x] fn expression() should take Option<&Type> argument telling it what type to resolve to (if known)
 - [x] Handle ``bytes3 x = 0x001133;`` correctly and remove previous hack
 - [x] Handle duplicate argument to constructor call by name
