### PR TITLE
When generating ewasm call, gas should not be 0.

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -9,7 +9,6 @@ use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 use num_traits::One;
 use num_traits::ToPrimitive;
-use num_traits::Zero;
 use std::collections::HashSet;
 use std::ops::Mul;
 
@@ -798,7 +797,11 @@ pub fn expression(
                         payload: Expression::BytesLiteral(*loc, Type::DynamicBytes, vec![]),
                         args: Vec::new(),
                         value,
-                        gas: Expression::NumberLiteral(*loc, Type::Uint(64), BigInt::zero()),
+                        gas: Expression::NumberLiteral(
+                            *loc,
+                            Type::Uint(64),
+                            BigInt::from(i64::MAX),
+                        ),
                         callty: CallTy::Regular,
                     },
                 );
@@ -828,7 +831,11 @@ pub fn expression(
                         payload: Expression::BytesLiteral(*loc, Type::DynamicBytes, vec![]),
                         args: Vec::new(),
                         value,
-                        gas: Expression::NumberLiteral(*loc, Type::Uint(64), BigInt::zero()),
+                        gas: Expression::NumberLiteral(
+                            *loc,
+                            Type::Uint(64),
+                            BigInt::from(i64::MAX),
+                        ),
                         callty: CallTy::Regular,
                     },
                 );

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -6627,7 +6627,12 @@ fn parse_call_args(
         gas: Box::new(Expression::NumberLiteral(
             pt::Loc(0, 0, 0),
             Type::Uint(64),
-            BigInt::zero(),
+            // See EIP150
+            if ns.target == Target::Ewasm {
+                BigInt::from(i64::MAX)
+            } else {
+                BigInt::zero()
+            },
         )),
         value: None,
         salt: None,


### PR DESCRIPTION
Set to signed int64 max value, according to EIP-150 this is fine.

Signed-off-by: Sean Young <sean@mess.org>