### PR TITLE
Constant folding pass and fixes all over

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, 2020 Sean Young <sean@mess.org>'
 author = 'Sean Young <sean@mess.org>'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.6'
+release = '0.1.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,22 +8,22 @@ Download release binaries
 
 For Linux x86-64, there is a binary available in the github releases:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.6/solang_linux>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.7/solang-linux>`_
 
 For Windows x64, there is a binary available:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.6/solang.exe>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.7/solang.exe>`_
 
 For MacOS, there is a binary available:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.6/solang_mac>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.7/solang-mac>`_
 
 Using hyperledgerlabs/solang docker hub images
 ----------------------------------------------
 
 New images are automatically made available on
 `docker hub <https://hub.docker.com/repository/docker/hyperledgerlabs/solang/>`_.
-There is a release `v0.1.6` tag and a `latest` tag:
+There is a release `v0.1.7` tag and a `latest` tag:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Added
- Added a constant folding optimization pass to improve codegen. When variables fold
  to constant values, they are visible in the hover in the extension
- For Substrate and Solana, address literals can specified with their base58 notation, e.g.
  `address foo = address"5GBWmgdFAMqm8ZgAHGobqDqX6tjLxJhv53ygjNtaaAn3sjeZ";`
- Solana account storage implemented for ``bytes``, ``string``, and structs
- Implemented ``delete`` for Solana

Changed
- The Substrate target produces a single .contract file
- The Substrate target now uses the salt argument for seal_instantiate()

Fixed
- Libraries are allowed to have constant variables
- Fixed ethereum abi encoding/decoding of structs and enums
- Solana now returns an error if account data is not large enough
- Fixed storage bytes push() and pop()
- Ewasm uses precompiles for keccak hashing
- Various ewasm fixes for Hyperledger Burrow

Signed-off-by: Sean Young <sean@mess.org>