### PR TITLE
Allow reference types to be null and improve ethereum abi encoder for arrays

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1297,14 +1297,16 @@ fn function_cfg(
     // named returns should be populated
     for (i, pos) in func.symtable.returns.iter().enumerate() {
         if !func.returns[i].name.is_empty() {
-            cfg.add(
-                &mut vartab,
-                Instr::Set {
-                    loc: func.returns[i].name_loc.unwrap(),
-                    res: *pos,
-                    expr: func.returns[i].ty.default(ns),
-                },
-            );
+            if let Some(expr) = func.returns[i].ty.default(ns) {
+                cfg.add(
+                    &mut vartab,
+                    Instr::Set {
+                        loc: func.returns[i].name_loc.unwrap(),
+                        res: *pos,
+                        expr,
+                    },
+                );
+            }
         }
     }
 

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -1039,6 +1039,8 @@ impl LoopScopes {
 }
 
 impl Type {
+    /// Default value for a type, e.g. an empty string. Some types cannot have a default value,
+    /// for example a reference to a variable in storage.
     pub fn default(&self, ns: &Namespace) -> Option<Expression> {
         match self {
             Type::Address(_) | Type::Uint(_) | Type::Int(_) => Some(Expression::NumberLiteral(

--- a/src/emit/ethabiencoder.rs
+++ b/src/emit/ethabiencoder.rs
@@ -13,8 +13,9 @@ pub struct EthAbiEncoder {
 }
 
 impl EthAbiEncoder {
-    /// recursively encode argument. The encoded data is written to the data pointer,
-    /// and the pointer is updated point after the encoded data.
+    /// Recursively encode a value in arg. The load argument specifies if the arg is a pointer
+    /// to the value, or the value itself. The fixed pointer points to the fixed, non-dynamic part
+    /// of the encoded data. The offset is current offset for dynamic fields.
     pub fn encode_ty<'a>(
         &self,
         contract: &Contract<'a>,

--- a/src/emit/loop_builder.rs
+++ b/src/emit/loop_builder.rs
@@ -5,6 +5,8 @@ use inkwell::values::{BasicValueEnum, FunctionValue, IntValue, PhiValue};
 use inkwell::IntPredicate;
 use std::collections::HashMap;
 
+/// This is for generating a simple loop, iterating over a number to a higher number (not inclusive). This
+/// builder helps with the creation of the phi nodes.
 pub struct LoopBuilder<'a> {
     phis: HashMap<&'static str, PhiValue<'a>>,
     entry_block: BasicBlock<'a>,
@@ -16,6 +18,8 @@ pub struct LoopBuilder<'a> {
 }
 
 impl<'a> LoopBuilder<'a> {
+    /// Create a new loop. This creates the basic blocks and inserts a branch to start of the loop at
+    /// the current location. This function should be called first.
     pub fn new(contract: &Contract<'a>, function: FunctionValue) -> Self {
         let entry_block = contract.builder.get_insert_block().unwrap();
         let condition_block = contract.context.append_basic_block(function, "cond");
@@ -37,6 +41,9 @@ impl<'a> LoopBuilder<'a> {
         }
     }
 
+    /// Once LoopBuilder::new() has been called, we need to create the phi nodes for all the variables
+    /// we wish to use and modify. The initial value which it will have on entry to the condition/body
+    /// must be given.
     pub fn add_loop_phi<T: BasicType<'a>>(
         &mut self,
         contract: &Contract<'a>,
@@ -53,6 +60,11 @@ impl<'a> LoopBuilder<'a> {
         phi.as_basic_value()
     }
 
+    /// Once all the phi nodes are created with add_loop_phi(), then call over(). This must be given
+    /// the two loop bounds (lower and higher). The higher bound is not inclusive. This function
+    /// builds the condition and then jumps to do the body; the return value is in the index
+    /// which can be used in the body. The body of the loop can be inserted after calling this
+    /// function.
     pub fn over(
         &mut self,
         contract: &Contract<'a>,
@@ -87,6 +99,7 @@ impl<'a> LoopBuilder<'a> {
         loop_phi.as_basic_value().into_int_value()
     }
 
+    /// Use this function to set the loop phis to their values at the end of the body
     pub fn set_loop_phi_value(
         &self,
         contract: &Contract<'a>,
@@ -98,10 +111,13 @@ impl<'a> LoopBuilder<'a> {
         self.phis[name].add_incoming(&[(&value, block)]);
     }
 
+    /// Can you use this to get the value of a phi in the body or after the loop exits
     pub fn get_loop_phi(&self, name: &'static str) -> BasicValueEnum<'a> {
         self.phis[name].as_basic_value()
     }
 
+    /// Call this once the body of the loop has been generated. This will close the loop
+    /// and ensure the exit block has been reached.
     pub fn finish(&self, contract: &Contract<'a>) {
         let block = contract.builder.get_insert_block().unwrap();
 

--- a/src/emit/loop_builder.rs
+++ b/src/emit/loop_builder.rs
@@ -1,0 +1,96 @@
+use super::Contract;
+use inkwell::basic_block::BasicBlock;
+use inkwell::types::BasicType;
+use inkwell::values::{BasicValueEnum, FunctionValue, IntValue, PhiValue};
+use inkwell::IntPredicate;
+use std::collections::HashMap;
+
+pub struct LoopBuilder<'a> {
+    phis: HashMap<&'static str, PhiValue<'a>>,
+    entry_block: BasicBlock<'a>,
+    condition_block: BasicBlock<'a>,
+    body_block: BasicBlock<'a>,
+    done_block: BasicBlock<'a>,
+}
+
+impl<'a> LoopBuilder<'a> {
+    pub fn new(contract: &'a Contract, function: FunctionValue) -> Self {
+        let entry_block = contract.builder.get_insert_block().unwrap();
+        let condition_block = contract.context.append_basic_block(function, "cond");
+        let body_block = contract.context.append_basic_block(function, "body");
+        let done_block = contract.context.append_basic_block(function, "done");
+
+        contract.builder.build_unconditional_branch(condition_block);
+
+        contract.builder.position_at_end(condition_block);
+
+        LoopBuilder {
+            phis: HashMap::new(),
+            entry_block,
+            condition_block,
+            body_block,
+            done_block,
+        }
+    }
+
+    pub fn add_loop_phi<T: BasicType<'a>>(
+        &mut self,
+        contract: &'a Contract,
+        name: &'static str,
+        ty: T,
+        initial_value: &BasicValueEnum<'a>,
+    ) {
+        let phi = contract.builder.build_phi(ty, name);
+
+        phi.add_incoming(&[(initial_value, self.entry_block)]);
+
+        self.phis.insert(name, phi);
+    }
+
+    pub fn over(&self, contract: &'a Contract, from: IntValue<'a>, to: IntValue<'a>) {
+        let loop_ty = from.get_type();
+        let loop_phi = contract.builder.build_phi(loop_ty, "index");
+
+        let loop_var = loop_phi.as_basic_value().into_int_value();
+
+        let next =
+            contract
+                .builder
+                .build_int_add(loop_var, loop_ty.const_int(1, false), "next_index");
+
+        let comp = contract
+            .builder
+            .build_int_compare(IntPredicate::ULT, loop_var, to, "loop_cond");
+
+        contract
+            .builder
+            .build_conditional_branch(comp, self.body_block, self.done_block);
+
+        loop_phi.add_incoming(&[(&from, self.entry_block), (&next, self.body_block)]);
+
+        contract.builder.position_at_end(self.body_block);
+    }
+
+    pub fn get_loop_phi(&self, name: &'static str) -> BasicValueEnum {
+        self.phis[name].as_basic_value()
+    }
+
+    pub fn set_loop_phi(
+        &self,
+        contract: &'a Contract,
+        name: &'static str,
+        value: &BasicValueEnum<'a>,
+    ) {
+        let block = contract.builder.get_insert_block().unwrap();
+
+        self.phis[name].add_incoming(&[(value, block)]);
+    }
+
+    pub fn finish(&self, contract: &'a Contract) {
+        contract
+            .builder
+            .build_unconditional_branch(self.condition_block);
+
+        contract.builder.position_at_end(self.done_block);
+    }
+}

--- a/src/emit/loop_builder.rs
+++ b/src/emit/loop_builder.rs
@@ -11,10 +11,12 @@ pub struct LoopBuilder<'a> {
     condition_block: BasicBlock<'a>,
     body_block: BasicBlock<'a>,
     done_block: BasicBlock<'a>,
+    loop_phi: Option<PhiValue<'a>>,
+    next_index: Option<IntValue<'a>>,
 }
 
 impl<'a> LoopBuilder<'a> {
-    pub fn new(contract: &'a Contract, function: FunctionValue) -> Self {
+    pub fn new(contract: &Contract<'a>, function: FunctionValue) -> Self {
         let entry_block = contract.builder.get_insert_block().unwrap();
         let condition_block = contract.context.append_basic_block(function, "cond");
         let body_block = contract.context.append_basic_block(function, "body");
@@ -30,24 +32,33 @@ impl<'a> LoopBuilder<'a> {
             condition_block,
             body_block,
             done_block,
+            loop_phi: None,
+            next_index: None,
         }
     }
 
     pub fn add_loop_phi<T: BasicType<'a>>(
         &mut self,
-        contract: &'a Contract,
+        contract: &Contract<'a>,
         name: &'static str,
         ty: T,
-        initial_value: &BasicValueEnum<'a>,
-    ) {
+        initial_value: BasicValueEnum<'a>,
+    ) -> BasicValueEnum<'a> {
         let phi = contract.builder.build_phi(ty, name);
 
-        phi.add_incoming(&[(initial_value, self.entry_block)]);
+        phi.add_incoming(&[(&initial_value, self.entry_block)]);
 
         self.phis.insert(name, phi);
+
+        phi.as_basic_value()
     }
 
-    pub fn over(&self, contract: &'a Contract, from: IntValue<'a>, to: IntValue<'a>) {
+    pub fn over(
+        &mut self,
+        contract: &Contract<'a>,
+        from: IntValue<'a>,
+        to: IntValue<'a>,
+    ) -> IntValue<'a> {
         let loop_ty = from.get_type();
         let loop_phi = contract.builder.build_phi(loop_ty, "index");
 
@@ -66,27 +77,38 @@ impl<'a> LoopBuilder<'a> {
             .builder
             .build_conditional_branch(comp, self.body_block, self.done_block);
 
-        loop_phi.add_incoming(&[(&from, self.entry_block), (&next, self.body_block)]);
+        loop_phi.add_incoming(&[(&from, self.entry_block)]);
 
         contract.builder.position_at_end(self.body_block);
+
+        self.loop_phi = Some(loop_phi);
+        self.next_index = Some(next);
+
+        loop_phi.as_basic_value().into_int_value()
     }
 
-    pub fn get_loop_phi(&self, name: &'static str) -> BasicValueEnum {
-        self.phis[name].as_basic_value()
-    }
-
-    pub fn set_loop_phi(
+    pub fn set_loop_phi_value(
         &self,
-        contract: &'a Contract,
+        contract: &Contract<'a>,
         name: &'static str,
-        value: &BasicValueEnum<'a>,
+        value: BasicValueEnum<'a>,
     ) {
         let block = contract.builder.get_insert_block().unwrap();
 
-        self.phis[name].add_incoming(&[(value, block)]);
+        self.phis[name].add_incoming(&[(&value, block)]);
     }
 
-    pub fn finish(&self, contract: &'a Contract) {
+    pub fn get_loop_phi(&self, name: &'static str) -> BasicValueEnum<'a> {
+        self.phis[name].as_basic_value()
+    }
+
+    pub fn finish(&self, contract: &Contract<'a>) {
+        let block = contract.builder.get_insert_block().unwrap();
+
+        let loop_phi = self.loop_phi.unwrap();
+
+        loop_phi.add_incoming(&[(self.next_index.as_ref().unwrap(), block)]);
+
         contract
             .builder
             .build_unconditional_branch(self.condition_block);

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -6339,7 +6339,7 @@ impl<'a> Contract<'a> {
         index: IntValue<'a>,
     ) -> PointerValue<'a> {
         match array_ty {
-            ast::Type::Array(elem_ty, dim) => {
+            ast::Type::Array(_, dim) => {
                 if dim[0].is_some() {
                     // fixed size array
                     unsafe {
@@ -6350,6 +6350,7 @@ impl<'a> Contract<'a> {
                         )
                     }
                 } else {
+                    let elem_ty = array_ty.array_deref();
                     let llvm_elem_ty = self.llvm_var(&elem_ty);
 
                     // dynamic length array or vector

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -5596,7 +5596,7 @@ fn method_call_pos_args(
                 _ => unreachable!(),
             };
             let val = match args.len() {
-                0 => elem_ty.default(ns),
+                0 => elem_ty.default(ns).unwrap(),
                 1 => {
                     let val_expr = expression(
                         &args[0],

--- a/tests/ewasm.rs
+++ b/tests/ewasm.rs
@@ -1579,8 +1579,7 @@ fn struct_dynamic_array_encode() {
 
                 return x;
             }
-        }
-        "##,
+        }"##,
     );
 
     runtime.constructor(&[]);

--- a/tests/solana_tests/arrays.rs
+++ b/tests/solana_tests/arrays.rs
@@ -162,11 +162,11 @@ fn dynamic_array_fixed_elements() {
                 return sum;
             }
 
-            function set() public returns (uint x, uint32[] f, uint g) {
+            function set() public returns (uint x, uint32[] f, string g) {
                 x = 12123123;
                 f = new uint32[](4);
                 f[0] = 3; f[1] = 5; f[2] = 7; f[3] = 11;
-                g = 102;
+                g = "abcd";
             }
         }"#,
     );
@@ -202,7 +202,7 @@ fn dynamic_array_fixed_elements() {
                 Token::Uint(ethereum_types::U256::from(7)),
                 Token::Uint(ethereum_types::U256::from(11)),
             ]),
-            Token::Uint(ethereum_types::U256::from(102)),
+            Token::String(String::from("abcd")),
         ]
     );
 }
@@ -293,14 +293,14 @@ fn dynamic_array_dynamic_elements() {
                 return sum;
             }
 
-            function set() public returns (uint x, bytes[] f, uint g) {
+            function set() public returns (uint x, bytes[] f, string g) {
                 x = 12123123;
                 f = new bytes[](4);
                 f[0] = hex"030507";
                 f[1] = hex"0b0d11";
                 f[2] = hex"1317";
                 f[3] = hex"1d";
-                g = 102;
+                g = "feh";
             }
         }"#,
     );
@@ -335,7 +335,7 @@ fn dynamic_array_dynamic_elements() {
                 Token::Bytes(vec![19, 23]),
                 Token::Bytes(vec![29]),
             ]),
-            Token::Uint(ethereum_types::U256::from(102)),
+            Token::String(String::from("feh")),
         ]
     );
 }

--- a/tests/solana_tests/arrays.rs
+++ b/tests/solana_tests/arrays.rs
@@ -1,0 +1,341 @@
+use crate::build_solidity;
+use ethabi::Token;
+
+#[test]
+fn fixed_array() {
+    // test that the abi encoder can handle fixed arrays
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            function get() public returns (uint32[4] f, bytes1 g) {
+                f[0] = 1;
+                f[1] = 102;
+                f[2] = 300331;
+                f[3] = 12313231;
+                g = 0xfe;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("get", &[]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::FixedArray(vec![
+                Token::Uint(ethereum_types::U256::from(1)),
+                Token::Uint(ethereum_types::U256::from(102)),
+                Token::Uint(ethereum_types::U256::from(300331)),
+                Token::Uint(ethereum_types::U256::from(12313231))
+            ]),
+            Token::FixedBytes(vec!(0xfe))
+        ]
+    );
+
+    // let's make it more interesting. Return some structs, some of which will be null pointers
+    // when they get to the abi encoder
+    let mut vm = build_solidity(
+        r#"
+        struct X {
+            uint32 f1;
+            bool f2;
+        }
+
+        contract foo {
+            function get() public returns (X[4] f) {
+                f[1].f1 = 102;
+                f[1].f2 = true;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("get", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::FixedArray(vec![
+            Token::Tuple(vec![
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::Bool(false)
+            ]),
+            Token::Tuple(vec![
+                Token::Uint(ethereum_types::U256::from(102)),
+                Token::Bool(true)
+            ]),
+            Token::Tuple(vec![
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::Bool(false)
+            ]),
+            Token::Tuple(vec![
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::Bool(false)
+            ])
+        ])]
+    );
+
+    // Now let's try it the other way round; an struct with an array in it
+
+    let mut vm = build_solidity(
+        r#"
+        struct X {
+            bool f0;
+            uint32[4] f1;
+            bool f2;
+        }
+
+        contract foo {
+            function get() public returns (X f) {
+                f.f0 = true;
+                f.f2 = true;
+            }
+
+            function set(X f) public returns (uint32) {
+                assert(f.f0 == true);
+                assert(f.f2 == true);
+
+                uint32 sum = 0;
+
+                for (uint32 i = 0; i < f.f1.length; i++) {
+                    sum += f.f1[i];
+                }
+
+                return sum;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("get", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::Tuple(vec![
+            Token::Bool(true),
+            Token::FixedArray(vec![
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::Uint(ethereum_types::U256::from(0)),
+                Token::Uint(ethereum_types::U256::from(0)),
+            ]),
+            Token::Bool(true)
+        ])],
+    );
+
+    let returns = vm.function(
+        "set",
+        &[Token::Tuple(vec![
+            Token::Bool(true),
+            Token::FixedArray(vec![
+                Token::Uint(ethereum_types::U256::from(3)),
+                Token::Uint(ethereum_types::U256::from(5)),
+                Token::Uint(ethereum_types::U256::from(7)),
+                Token::Uint(ethereum_types::U256::from(11)),
+            ]),
+            Token::Bool(true),
+        ])],
+    );
+
+    assert_eq!(returns, vec![Token::Uint(ethereum_types::U256::from(26))]);
+}
+
+#[test]
+fn dynamic_array_fixed_elements() {
+    // test that the abi decoder can handle fixed arrays
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            function get(uint x, uint32[] f, uint g) public returns (uint32) {
+                assert(x == 12123123);
+                assert(g == 102);
+
+                uint32 sum = 0;
+
+                for (uint32 i = 0; i < f.length; i++) {
+                    sum += f[i];
+                }
+
+                return sum;
+            }
+
+            function set() public returns (uint x, uint32[] f, uint g) {
+                x = 12123123;
+                f = new uint32[](4);
+                f[0] = 3; f[1] = 5; f[2] = 7; f[3] = 11;
+                g = 102;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function(
+        "get",
+        &[
+            Token::Uint(ethereum_types::U256::from(12123123)),
+            Token::Array(vec![
+                Token::Uint(ethereum_types::U256::from(3)),
+                Token::Uint(ethereum_types::U256::from(5)),
+                Token::Uint(ethereum_types::U256::from(7)),
+                Token::Uint(ethereum_types::U256::from(11)),
+            ]),
+            Token::Uint(ethereum_types::U256::from(102)),
+        ],
+    );
+
+    assert_eq!(returns, vec![Token::Uint(ethereum_types::U256::from(26))]);
+
+    // test that the abi encoder can handle fixed arrays
+    let returns = vm.function("set", &[]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Uint(ethereum_types::U256::from(12123123)),
+            Token::Array(vec![
+                Token::Uint(ethereum_types::U256::from(3)),
+                Token::Uint(ethereum_types::U256::from(5)),
+                Token::Uint(ethereum_types::U256::from(7)),
+                Token::Uint(ethereum_types::U256::from(11)),
+            ]),
+            Token::Uint(ethereum_types::U256::from(102)),
+        ]
+    );
+}
+
+#[test]
+fn fixed_array_dynamic_elements() {
+    // test that the abi decoder can handle fixed arrays
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            function get(uint x, bytes[4] f, uint g) public returns (uint32) {
+                assert(x == 12123123);
+                assert(g == 102);
+
+                uint32 sum = 0;
+
+                for (uint32 i = 0; i < f.length; i++) {
+                    for (uint32 j = 0; j < f[i].length; j++)
+                        sum += f[i][j];
+                }
+
+                return sum;
+            }
+
+            function set() public returns (uint x, bytes[4] f, uint g) {
+                x = 12123123;
+                f[0] = hex"030507";
+                f[1] = hex"0b0d11";
+                f[2] = hex"1317";
+                f[3] = hex"1d";
+                g = 102;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function(
+        "get",
+        &[
+            Token::Uint(ethereum_types::U256::from(12123123)),
+            Token::FixedArray(vec![
+                Token::Bytes(vec![3, 5, 7]),
+                Token::Bytes(vec![11, 13, 17]),
+                Token::Bytes(vec![19, 23]),
+                Token::Bytes(vec![29]),
+            ]),
+            Token::Uint(ethereum_types::U256::from(102)),
+        ],
+    );
+
+    assert_eq!(returns, vec![Token::Uint(ethereum_types::U256::from(127))]);
+
+    let returns = vm.function("set", &[]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Uint(ethereum_types::U256::from(12123123)),
+            Token::FixedArray(vec![
+                Token::Bytes(vec![3, 5, 7]),
+                Token::Bytes(vec![11, 13, 17]),
+                Token::Bytes(vec![19, 23]),
+                Token::Bytes(vec![29]),
+            ]),
+            Token::Uint(ethereum_types::U256::from(102)),
+        ]
+    );
+}
+
+#[test]
+fn dynamic_array_dynamic_elements() {
+    // test that the abi decoder can handle fixed arrays
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            function get(uint x, bytes[] f, uint g) public returns (uint32) {
+                assert(x == 12123123);
+                assert(g == 102);
+
+                uint32 sum = 0;
+
+                for (uint32 i = 0; i < f.length; i++) {
+                    for (uint32 j = 0; j < f[i].length; j++)
+                        sum += f[i][j];
+                }
+
+                return sum;
+            }
+
+            function set() public returns (uint x, bytes[] f, uint g) {
+                x = 12123123;
+                f = new bytes[](4);
+                f[0] = hex"030507";
+                f[1] = hex"0b0d11";
+                f[2] = hex"1317";
+                f[3] = hex"1d";
+                g = 102;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function(
+        "get",
+        &[
+            Token::Uint(ethereum_types::U256::from(12123123)),
+            Token::Array(vec![
+                Token::Bytes(vec![3, 5, 7]),
+                Token::Bytes(vec![11, 13, 17]),
+                Token::Bytes(vec![19, 23]),
+                Token::Bytes(vec![29]),
+            ]),
+            Token::Uint(ethereum_types::U256::from(102)),
+        ],
+    );
+
+    assert_eq!(returns, vec![Token::Uint(ethereum_types::U256::from(127))]);
+
+    let returns = vm.function("set", &[]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Uint(ethereum_types::U256::from(12123123)),
+            Token::Array(vec![
+                Token::Bytes(vec![3, 5, 7]),
+                Token::Bytes(vec![11, 13, 17]),
+                Token::Bytes(vec![19, 23]),
+                Token::Bytes(vec![29]),
+            ]),
+            Token::Uint(ethereum_types::U256::from(102)),
+        ]
+    );
+}

--- a/tests/solana_tests/mod.rs
+++ b/tests/solana_tests/mod.rs
@@ -1,3 +1,4 @@
+mod arrays;
 mod primitives;
 mod simple;
 mod storage;


### PR DESCRIPTION
 When a struct or array is allocated, this is done with a single malloc. For example an array of 4 structs is allocated in with a single malloc, and the pointer to the structs are all set to null.
    
When dereferencing the array elements or structure members, now the structs are automagically allocated.

This also fixes a number of issues around the abi encoders and array types.