### PR TITLE
Make sure generated llvm IR is valid

### DIFF
--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -4598,15 +4598,11 @@ pub trait TargetRuntime<'a> {
 
     /// Emit the contract storage initializers
     fn emit_initializer(&mut self, contract: &mut Contract<'a>) -> FunctionValue<'a> {
-        let mut args = Vec::new();
-
-        if let Some(accounts) = contract.accounts {
-            args.push(accounts.get_type().into());
-        }
+        let function_ty = contract.function_type(&[], &[]);
 
         let function = contract.module.add_function(
             "storage_initializers",
-            contract.context.i32_type().fn_type(&args, false),
+            function_ty,
             Some(Linkage::Internal),
         );
 

--- a/src/emit/solana.rs
+++ b/src/emit/solana.rs
@@ -74,7 +74,13 @@ impl SolanaTarget {
 
         target.emit_dispatch(&mut con);
 
-        con.internalize(&["entrypoint", "sol_log_", "sol_alloc_free_"]);
+        con.internalize(&[
+            "entrypoint",
+            "sol_log_",
+            "sol_alloc_free_",
+            // This entry is produced by llvm due to merging of stdlib.bc with solidity llvm ir
+            "sol_alloc_free_.1",
+        ]);
 
         con
     }

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -86,6 +86,7 @@ impl SubstrateTarget {
             "seal_call",
             "seal_value_transferred",
             "seal_minimum_balance",
+            "seal_weight_to_fee",
             "seal_random",
             "seal_address",
             "seal_balance",


### PR DESCRIPTION
This ensures that the llvm IR is valid for llc or llvm-opt. Steps to
reproduce:

  solang --emit llvm-ir -v storage.sol
  llc storage.ll

Signed-off-by: Sean Young <sean@mess.org>