### PR TITLE
Push docker images to docker hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
     container: hyperledgerlabs/solang:ci
     steps:
     - name: Checkout sources
-      # Make sure "git describe --tags" works for solang --version
       # checkout@v2 requires git 2.18 or higher, which is not in our image
       uses: actions/checkout@v1
     - name: Rust stable
@@ -35,9 +34,6 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-      with:
-        # Make sure "git describe --tags" works for solang --version
-        fetch-depth: 0
     - name: Download LLVM
       run: curl -sS -o c:\llvm.zip https://solang.io/download/llvm10.0-win.zip
     - name: Extract LLVM
@@ -62,9 +58,6 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-      with:
-        # Make sure "git describe --tags" works for solang --version
-        fetch-depth: 0
     - name: Download LLVM
       run: curl -sS -o llvm10.0-mac.tar.gz https://solang.io/download/llvm10.0-mac.tar.gz
     - name: Extract LLVM
@@ -82,3 +75,17 @@ jobs:
         file: target/release/solang
         asset_name: solang-mac
         tag: ${{ github.ref }}
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - run: docker build . -t hyperledgerlabs/solang:${{ github.ref }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DH_USER }}
+        password: ${{ secrets.DH_KEY }}
+    - run: docker push hyperledgerlabs/solang:${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,8 +89,18 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-    - name: Build dockerfile
-      run: docker build .
+      with:
+        # Make sure "git describe --tags" works for solang --version
+        fetch-depth: 0
+    - run: docker build . -t hyperledgerlabs/solang:latest
+    - name: Login to DockerHub
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DH_USER }}
+        password: ${{ secrets.DH_KEY }}
+    - run: docker push hyperledgerlabs/solang:latest
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
   solana:
     name: Solana Integration test


### PR DESCRIPTION
Rather than docker hub building the image, just build push the one
built by github actions.

This makes it much clearer when the new docker image will be available,
and this is also much faster, as docker hub is taking 2 to 3 hours to
do a build.

Signed-off-by: Sean Young <sean@mess.org>