### PR TITLE
New pass: remove dead or load to/from contract storage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: test
 on: [push, pull_request]
 jobs:
+  repolinter:
+    name: Repolinter
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Run repolinter
+        run: npx repolinter --rulesetUrl https://raw.githubusercontent.com/hyperledger-labs/hyperledger-community-management-tools/master/repo_structure/repolint.json
+
   lints:
     name: Lints
     runs-on: ubuntu-18.04

--- a/docs/optimizer.rst
+++ b/docs/optimizer.rst
@@ -7,6 +7,8 @@ several optimizations which LLVM cannot do, since it is not aware of higher-leve
 Arithmetic of large integers (larger than 64 bit) has special handling, since LLVM cannot generate them.
 So we need to do our own optimizations for these types, and we cannot rely on LLVM.
 
+.. _constant-folding:
+
 Constant Folding Pass
 ---------------------
 
@@ -21,6 +23,8 @@ are constant. For example:
 
 This is evaluated at compile time. You can see this in the Visual Studio Code extension by hover over `hash`;
 the hover will tell you the value of the hash.
+
+.. _strength-reduce:
 
 Strength Reduction Pass
 -----------------------
@@ -51,3 +55,72 @@ Solang uses reaching definitions to track the known bits of the variables; here 
 the values 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 and the other operand is always 100. So, the multiplication can be
 done using a single 64 bit multiply instruction. If you hover over the ``*`` in the Visual Studio Code you
 will see this noted.
+
+.. _dead-storage:
+
+Dead Storage pass
+-----------------
+
+Loading from contract storage, or storing to contract storage is expensive. This optimization removes any
+redundant load from and store to contract storage. If the same variable is read twice, then the value from
+the first load is re-used. Similarly, if there is are two successive stores to the same variable, the first
+one is removed as it is redundant. For example:
+
+.. code-block:: javascript
+
+    contract test {
+        int a;
+
+        // this function reads a twice; this can be reduced to one load
+        function redundant_load() public returns (int) {
+            return a + a;
+        }
+
+        // this function writes to contract storage thrice. This can be reduced to one
+        function redundant_store() public {
+            delete a;
+            a = 1;
+            a = 2;
+        }
+    }
+
+This optimization pass can be disabled by running `solang --no-dead-storage`. You can see the difference between
+having this optimization pass on by comparing the output of `solang --no-dead-storage --emit cfg foo.sol` with
+`solang --emit cfg foo.sol`.
+
+.. _vector-to-slice:
+
+Vector to Slice Pass
+--------------------
+
+A `bytes` or `string` variable can be stored in a vector, which is a modifyable in-memory buffer, and a slice
+which is a pointer to readonly memory and an a length. Since a vector is modifyable, each instance requires
+a allocation. For example:
+
+.. code-block:: javascript
+
+    contract test {
+        function can_be_slice() public {
+            // v can just be a pointer to constant memory and an a length indicator
+            string v = "Hello, World!";
+
+            print(v);
+        }
+
+        function must_be_vector() public {
+            // if v is a vector, then it needs to allocated and default value copied.
+            string v = "Hello, World!";
+
+            // bs is copied by reference is now modifyable
+            bytes bs = v;
+
+
+            bs[1] = 97;
+
+            print(v);
+        }
+    }
+
+This optimization pass can be disabled by running `solang --no-vector-to-slice`. You can see the difference between
+having this optimization pass on by comparing the output of `solang --no-vector-to-slice --emit cfg foo.sol` with
+`solang --emit cfg foo.sol`.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -82,6 +82,19 @@ Options:
   object
     Output wasm object file; this is the contract before final linking.
 
+\\-\\-no\\-constant\\-folding
+   Disable the :ref:`constant-folding` codegen optimization
+
+\\-\\-no\\-strength\\-reduce
+   Disable the :ref:`strength-reduce` codegen optimization
+
+\\-\\-no\\-dead\\-storage
+   Disable the :ref:`dead-storage` optimization
+
+\\-\\-no\\-vector\\-to\\-slice
+   Disable the :ref:`vector-to-slice` optimization
+
+
 Running Solang from docker image
 ________________________________
 

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -73,7 +73,7 @@ impl SolangServer {
 
             // codegen all the contracts; some additional errors/warnings will be detected here
             for contract_no in 0..ns.contracts.len() {
-                codegen(contract_no, &mut ns);
+                codegen(contract_no, &mut ns, &Default::default());
             }
 
             let offsets = ns.file_offset(&mut filecache);

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -49,6 +49,13 @@ pub enum Instr {
     AssertFailure { expr: Option<Expression> },
     /// Print to log message
     Print { expr: Expression },
+    /// Load storage (this is an instruction rather than an expression
+    /// so that it can be moved around by the dead storage pass
+    LoadStorage {
+        res: usize,
+        ty: Type,
+        storage: Expression,
+    },
     /// Clear storage at slot for ty (might span multiple slots)
     ClearStorage { ty: Type, storage: Expression },
     /// Set storage value at slot
@@ -678,13 +685,19 @@ impl ControlFlowGraph {
                 true_block,
                 false_block,
             ),
+            Instr::LoadStorage { ty, res, storage } => format!(
+                "%{} = load storage slot({}) ty:{}",
+                self.vars[res].id.name,
+                self.expr_to_string(contract, ns, storage),
+                ty.to_string(ns),
+            ),
             Instr::ClearStorage { ty, storage } => format!(
                 "clear storage slot({}) ty:{}",
                 self.expr_to_string(contract, ns, storage),
                 ty.to_string(ns),
             ),
             Instr::SetStorage { ty, value, storage } => format!(
-                "set storage slot({}) ty:{} = %{}",
+                "store storage slot({}) ty:{} = %{}",
                 self.expr_to_string(contract, ns, storage),
                 ty.to_string(ns),
                 self.expr_to_string(contract, ns, value),

--- a/src/codegen/dead_storage.rs
+++ b/src/codegen/dead_storage.rs
@@ -1,0 +1,714 @@
+use super::cfg::{BasicBlock, ControlFlowGraph, Instr};
+use crate::parser::pt::Loc;
+use crate::sema::ast::{Expression, Namespace};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+struct InstrDef {
+    pub block_no: usize,
+    pub instr_no: usize,
+}
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, PartialEq)]
+enum Transfer {
+    Gen {
+        def: InstrDef,
+        var_no: usize,
+    },
+    Copy {
+        var_no: usize,
+        src: usize,
+    },
+    Kill {
+        var_no: usize,
+    },
+    Store {
+        def: InstrDef,
+        expr: Option<Expression>,
+    },
+}
+
+impl fmt::Display for Transfer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Transfer::Gen { def, var_no } => {
+                write!(f, "Gen %{} = ({}, {})", var_no, def.block_no, def.instr_no)
+            }
+            Transfer::Copy { var_no, src } => {
+                write!(f, "Copy %{} from %{}", var_no, src)
+            }
+            Transfer::Kill { var_no } => {
+                write!(f, "Kill %{}", var_no)
+            }
+            Transfer::Store { def, expr } => {
+                write!(
+                    f,
+                    "Storage: {:?} at ({}, {})",
+                    expr, def.block_no, def.instr_no
+                )
+            }
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+struct ReachingDefs {
+    vars: HashMap<usize, HashMap<InstrDef, Option<Expression>>>,
+    stores: Vec<(InstrDef, Expression)>,
+}
+
+type BlockVars = HashMap<usize, Vec<ReachingDefs>>;
+
+/// Calculate all the reaching definitions for the contract. This is a flow
+/// analysis which is used for further optimizations
+#[allow(clippy::map_entry)]
+fn reaching_definitions(cfg: &mut ControlFlowGraph) -> (Vec<Vec<Vec<Transfer>>>, BlockVars) {
+    // the transfers
+    let mut block_transfers: Vec<Vec<Vec<Transfer>>> = Vec::new();
+    let mut block_vars: BlockVars = HashMap::new();
+
+    // calculate the per-instruction reaching defs
+    for (block_no, block) in cfg.blocks.iter().enumerate() {
+        let transfer = instr_transfers(block_no, block);
+
+        debug_assert_eq!(block_no, block_transfers.len());
+
+        block_transfers.push(transfer);
+
+        debug_assert_eq!(
+            cfg.blocks[block_no].instr.len(),
+            block_transfers[block_no].len()
+        );
+    }
+
+    let mut blocks_todo: HashSet<usize> = HashSet::new();
+    blocks_todo.insert(0);
+
+    while let Some(block_no) = blocks_todo.iter().next() {
+        let block_no = *block_no;
+        blocks_todo.remove(&block_no);
+
+        let mut vars = if let Some(vars) = block_vars.get(&block_no) {
+            vars[0].clone()
+        } else {
+            ReachingDefs {
+                vars: HashMap::new(),
+                stores: Vec::new(),
+            }
+        };
+
+        apply_transfers(
+            &block_transfers[block_no],
+            &mut vars,
+            cfg,
+            block_no,
+            &mut block_vars,
+        );
+
+        for edge in block_edges(&cfg.blocks[block_no]) {
+            if !block_vars.contains_key(&edge) {
+                blocks_todo.insert(edge);
+                block_vars.insert(edge, vec![vars.clone()]);
+            } else if block_vars[&edge][0] != vars {
+                blocks_todo.insert(edge);
+                if let Some(block_vars) = block_vars.get_mut(&edge) {
+                    // merge incoming vars
+                    for (var_no, defs) in &vars.vars {
+                        if let Some(entry) = block_vars[0].vars.get_mut(var_no) {
+                            for (incoming_def, storage) in defs {
+                                if !entry.contains_key(incoming_def) {
+                                    entry.insert(*incoming_def, storage.clone());
+                                }
+                            }
+                        } else {
+                            block_vars[0].vars.insert(*var_no, defs.clone());
+                        }
+                    }
+
+                    // merge storage stores
+                    for store in &vars.stores {
+                        if !block_vars[0].stores.iter().any(|(def, _)| *def == store.0) {
+                            block_vars[0].stores.push(store.clone());
+                        }
+                    }
+                } else {
+                    unreachable!();
+                }
+            }
+        }
+    }
+
+    (block_transfers, block_vars)
+}
+
+/// Instruction defs
+fn instr_transfers(block_no: usize, block: &BasicBlock) -> Vec<Vec<Transfer>> {
+    let mut transfers = Vec::new();
+
+    for (instr_no, instr) in block.instr.iter().enumerate() {
+        let def = InstrDef { block_no, instr_no };
+
+        let set_var = |var_nos: &[usize]| {
+            let mut transfer = Vec::new();
+
+            for var_no in var_nos.iter() {
+                transfer.insert(0, Transfer::Kill { var_no: *var_no });
+
+                transfer.push(Transfer::Gen {
+                    def,
+                    var_no: *var_no,
+                });
+            }
+
+            transfer
+        };
+
+        transfers.push(match instr {
+            Instr::Set {
+                res,
+                expr: Expression::Variable(_, _, src),
+                ..
+            } => {
+                vec![
+                    Transfer::Kill { var_no: *res },
+                    Transfer::Copy {
+                        var_no: *res,
+                        src: *src,
+                    },
+                ]
+            }
+            Instr::Set { res, .. } => set_var(&[*res]),
+            Instr::Call { res, .. } => {
+                // We don't know what this function does to storage, so clear all storage
+                // possibly we should check if the function is pure/view and not clear storage references
+                let mut v = set_var(res);
+
+                v.push(Transfer::Store { def, expr: None });
+
+                v
+            }
+            Instr::AbiDecode { res, .. } => set_var(res),
+            Instr::LoadStorage { res, .. } => set_var(&[*res]),
+            Instr::PushMemory { array, res, .. } => {
+                let mut v = set_var(&[*res]);
+                v.push(Transfer::Kill { var_no: *array });
+
+                v
+            }
+            Instr::PopMemory { array, .. } => {
+                vec![Transfer::Kill { var_no: *array }]
+            }
+            Instr::AbiEncodeVector { res, .. }
+            | Instr::ExternalCall {
+                success: Some(res), ..
+            }
+            | Instr::Constructor {
+                success: None, res, ..
+            }
+            | Instr::ValueTransfer {
+                success: Some(res), ..
+            } => {
+                // A constructor/external call can call us back and modify storage
+                vec![
+                    Transfer::Kill { var_no: *res },
+                    Transfer::Store { def, expr: None },
+                ]
+            }
+            Instr::Store { dest, .. } => {
+                let mut v = Vec::new();
+
+                if let Some(var_no) = array_var(dest) {
+                    v.push(Transfer::Kill { var_no });
+                }
+
+                v
+            }
+            Instr::Constructor {
+                success: Some(success),
+                res,
+                ..
+            } => {
+                // A constructor can call us back and modify storage
+                vec![
+                    Transfer::Kill { var_no: *res },
+                    Transfer::Kill { var_no: *success },
+                    Transfer::Store { def, expr: None },
+                ]
+            }
+            Instr::SetStorageBytes { storage, .. }
+            | Instr::ClearStorage { storage, .. }
+            | Instr::SetStorage { storage, .. } => {
+                vec![Transfer::Store {
+                    def,
+                    expr: Some(storage.clone()),
+                }]
+            }
+            Instr::PopStorage { res, storage, .. } | Instr::PushStorage { res, storage, .. } => {
+                vec![
+                    Transfer::Kill { var_no: *res },
+                    Transfer::Gen { def, var_no: *res },
+                    Transfer::Store {
+                        def,
+                        expr: Some(storage.clone()),
+                    },
+                ]
+            }
+            Instr::Return { .. } => {
+                vec![Transfer::Store { def, expr: None }]
+            }
+            _ => Vec::new(),
+        });
+    }
+
+    debug_assert_eq!(transfers.len(), block.instr.len());
+
+    transfers
+}
+
+fn array_var(expr: &Expression) -> Option<usize> {
+    match expr {
+        Expression::Variable(_, _, var_no) => Some(*var_no),
+        Expression::DynamicArraySubscript(_, _, expr, _)
+        | Expression::Subscript(_, _, expr, _)
+        | Expression::StructMember(_, _, expr, _) => array_var(expr),
+        _ => None,
+    }
+}
+
+fn apply_transfers(
+    transfers: &[Vec<Transfer>],
+    vars: &mut ReachingDefs,
+    cfg: &ControlFlowGraph,
+    block_no: usize,
+    block_vars: &mut BlockVars,
+) {
+    let mut res = Vec::new();
+
+    debug_assert_eq!(transfers.len(), cfg.blocks[block_no].instr.len());
+
+    // this is done in two paseses. The first pass just deals with variables.
+    // The second pass deals with storage stores
+
+    // for each instruction
+    for transfers in transfers {
+        res.push(vars.clone());
+
+        // each instruction has a list of transfers
+        for transfer in transfers {
+            match transfer {
+                Transfer::Kill { var_no } => {
+                    vars.vars.remove(var_no);
+                }
+                Transfer::Copy { var_no, src } => {
+                    if let Some(defs) = vars.vars.get(src) {
+                        let defs = defs.clone();
+
+                        vars.vars.insert(*var_no, defs);
+                    }
+                }
+                Transfer::Gen { var_no, def } => {
+                    if let Some(entry) = vars.vars.get_mut(var_no) {
+                        entry.insert(*def, None);
+                    } else {
+                        let mut v = HashMap::new();
+                        v.insert(*def, None);
+                        vars.vars.insert(*var_no, v);
+                    }
+                }
+                // For the second pass
+                Transfer::Store { .. } => (),
+            }
+        }
+    }
+
+    block_vars.insert(block_no, res.clone());
+
+    *vars = res[0].clone();
+    let mut res = Vec::new();
+
+    // 2nd pass
+    for transfers in transfers {
+        res.push(vars.clone());
+
+        // each instruction has a list of transfers
+        for transfer in transfers {
+            match transfer {
+                Transfer::Kill { var_no } => {
+                    vars.vars.remove(var_no);
+                }
+                Transfer::Copy { var_no, src } => {
+                    if let Some(defs) = vars.vars.get(src) {
+                        let defs = defs.clone();
+
+                        vars.vars.insert(*var_no, defs);
+                    }
+                }
+                Transfer::Gen { var_no, def } => {
+                    if let Some(entry) = vars.vars.get_mut(var_no) {
+                        entry.insert(*def, None);
+                    } else {
+                        let mut v = HashMap::new();
+                        v.insert(*def, None);
+                        vars.vars.insert(*var_no, v);
+                    }
+                }
+                Transfer::Store { def, expr } => {
+                    // store to contract storage. This should kill any equal
+                    let mut eliminated_vars = Vec::new();
+
+                    for (var_no, def) in vars.vars.iter() {
+                        for def in def.keys() {
+                            if let Some((_, storage)) = get_storage_definition(def, &cfg) {
+                                if let Some(expr) = expr {
+                                    let storage_vars = get_vars_at(def, block_vars);
+
+                                    if expression_compare(
+                                        expr,
+                                        &vars,
+                                        storage,
+                                        &storage_vars,
+                                        cfg,
+                                        block_vars,
+                                    ) != ExpressionCmp::NotEqual
+                                    {
+                                        eliminated_vars.push(*var_no);
+                                    }
+                                } else {
+                                    // all storage references must be killed
+                                    eliminated_vars.push(*var_no);
+                                }
+                            }
+                        }
+                    }
+
+                    for var_no in eliminated_vars {
+                        vars.vars.remove(&var_no);
+                    }
+
+                    // Now handle the reaching storage stores
+                    if let Some(expr) = expr {
+                        // all stores should are no longer reaching if they are clobbered by this store
+                        let mut eliminated_stores = Vec::new();
+
+                        for (no, (def, storage)) in vars.stores.iter().enumerate() {
+                            let storage_vars = get_vars_at(def, block_vars);
+
+                            if expression_compare(
+                                expr,
+                                &vars,
+                                storage,
+                                &storage_vars,
+                                cfg,
+                                block_vars,
+                            ) == ExpressionCmp::Equal
+                            {
+                                eliminated_stores.push(no);
+                            }
+                        }
+
+                        for no in eliminated_stores.into_iter().rev() {
+                            vars.stores.remove(no);
+                        }
+
+                        vars.stores.push((*def, expr.clone()));
+                    } else {
+                        // flush all reaching stores
+                        vars.stores.truncate(0);
+                    }
+                }
+            }
+        }
+    }
+
+    assert_eq!(res.len(), transfers.len());
+    assert_eq!(res.len(), cfg.blocks[block_no].instr.len());
+
+    block_vars.insert(block_no, res);
+}
+
+fn block_edges(block: &BasicBlock) -> Vec<usize> {
+    let mut out = Vec::new();
+
+    // out cfg has edge as the last instruction in a block; EXCEPT
+    // Instr::AbiDecode() which has an edge when decoding fails
+    for instr in &block.instr {
+        match instr {
+            Instr::Branch { block } => {
+                out.push(*block);
+            }
+            Instr::BranchCond {
+                true_block,
+                false_block,
+                ..
+            } => {
+                out.push(*true_block);
+                out.push(*false_block);
+            }
+            Instr::AbiDecode {
+                exception_block: Some(block),
+                ..
+            } => {
+                out.push(*block);
+            }
+            _ => (),
+        }
+    }
+
+    out
+}
+
+/// Eliminate dead storage load/store.
+pub fn dead_storage(cfg: &mut ControlFlowGraph, _ns: &mut Namespace) {
+    // first calculate reaching definitions. We use a special case reaching definitions, which we track
+    let (blocktransfers, block_vars) = reaching_definitions(cfg);
+
+    let mut redundant_stores = HashMap::new();
+
+    // for each block, instruction
+    for block_no in 0..cfg.blocks.len() {
+        for instr_no in 0..cfg.blocks[block_no].instr.len() {
+            if !block_vars.contains_key(&block_no) {
+                // do not consider unreachable blocks
+                continue;
+            }
+
+            let vars = &block_vars[&block_no][instr_no];
+
+            match &cfg.blocks[block_no].instr[instr_no] {
+                Instr::LoadStorage { res, ty, storage } => {
+                    // is there a definition which has the same storage expression
+                    let mut found = None;
+
+                    for var_no in vars.vars.keys() {
+                        let defs = &vars.vars[var_no];
+
+                        if defs.len() == 1 {
+                            let (def, _) = defs.iter().next().unwrap();
+
+                            if let Some((other, def_storage)) = get_storage_definition(def, &cfg) {
+                                let def_vars = get_vars_at(def, &block_vars);
+
+                                if expression_compare(
+                                    storage,
+                                    &vars,
+                                    def_storage,
+                                    &def_vars,
+                                    cfg,
+                                    &block_vars,
+                                ) == ExpressionCmp::Equal
+                                    && other != *res
+                                {
+                                    found = Some(other);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(var_no) = found {
+                        cfg.blocks[block_no].instr[instr_no] = Instr::Set {
+                            loc: Loc(0, 0, 0),
+                            res: *res,
+                            expr: Expression::Variable(Loc(0, 0, 0), ty.clone(), var_no),
+                        };
+                    } else {
+                        for (def, expr) in &vars.stores {
+                            let def_vars = get_vars_at(def, &block_vars);
+
+                            if expression_compare(storage, &vars, expr, &def_vars, cfg, &block_vars)
+                                != ExpressionCmp::NotEqual
+                            {
+                                if let Some(entry) = redundant_stores.get_mut(def) {
+                                    *entry = false;
+                                }
+                            }
+                        }
+                    }
+                }
+                Instr::PushStorage { storage, .. } | Instr::PopStorage { storage, .. } => {
+                    for (def, expr) in &vars.stores {
+                        let def_vars = get_vars_at(def, &block_vars);
+
+                        if expression_compare(storage, &vars, expr, &def_vars, cfg, &block_vars)
+                            != ExpressionCmp::NotEqual
+                        {
+                            if let Some(entry) = redundant_stores.get_mut(def) {
+                                *entry = false;
+                            }
+                        }
+                    }
+                }
+                Instr::SetStorage { .. }
+                | Instr::SetStorageBytes { .. }
+                | Instr::ClearStorage { .. } => {
+                    let def = InstrDef { block_no, instr_no };
+
+                    // add an entry if there is not one there already
+                    redundant_stores.entry(def).or_insert(true);
+                }
+                _ => (),
+            }
+
+            let transfers = &blocktransfers[block_no][instr_no];
+
+            if transfers
+                .iter()
+                .any(|t| matches!(t, Transfer::Store { expr: None, .. }))
+            {
+                for (def, _) in &vars.stores {
+                    // insert new entry or override existing one
+                    redundant_stores.insert(*def, false);
+                }
+            }
+        }
+    }
+
+    // remove all stores which are marked as still redundant
+    for (def, redundant) in &redundant_stores {
+        if *redundant {
+            cfg.blocks[def.block_no].instr[def.instr_no] = Instr::Nop;
+        }
+    }
+}
+
+fn get_storage_definition<'a>(
+    def: &InstrDef,
+    cfg: &'a ControlFlowGraph,
+) -> Option<(usize, &'a Expression)> {
+    match &cfg.blocks[def.block_no].instr[def.instr_no] {
+        Instr::LoadStorage { storage, res, .. } => Some((*res, storage)),
+        _ => None,
+    }
+}
+
+fn get_definition<'a>(def: &InstrDef, cfg: &'a ControlFlowGraph) -> Option<&'a Expression> {
+    match &cfg.blocks[def.block_no].instr[def.instr_no] {
+        Instr::LoadStorage { storage, .. } => Some(storage),
+        Instr::Set { expr, .. } => Some(expr),
+        _ => None,
+    }
+}
+
+fn get_vars_at(def: &InstrDef, block_vars: &BlockVars) -> ReachingDefs {
+    let vars = if let Some(vars) = block_vars.get(&def.block_no) {
+        vars[def.instr_no].clone()
+    } else {
+        ReachingDefs {
+            vars: HashMap::new(),
+            stores: Vec::new(),
+        }
+    };
+
+    vars
+}
+
+#[derive(PartialEq, Copy, Clone, Debug)]
+enum ExpressionCmp {
+    Equal,
+    NotEqual,
+    Unknown,
+}
+
+/// Compare two expressions that express storage locations. There are a limited amount of expressions needed here
+fn expression_compare(
+    left: &Expression,
+    left_vars: &ReachingDefs,
+    right: &Expression,
+    right_vars: &ReachingDefs,
+    cfg: &ControlFlowGraph,
+    block_vars: &BlockVars,
+) -> ExpressionCmp {
+    let v = match (left, right) {
+        (Expression::NumberLiteral(_, _, left), Expression::NumberLiteral(_, _, right)) => {
+            if left == right {
+                ExpressionCmp::Equal
+            } else {
+                ExpressionCmp::NotEqual
+            }
+        }
+        (Expression::Keccak256(_, _, left), Expression::Keccak256(_, _, right)) => {
+            // This could be written with fold_first() rather than collect(), but that is an unstable feature.
+            // Also fold first does not short circuit
+            let cmps: Vec<ExpressionCmp> = left
+                .iter()
+                .zip(right.iter())
+                .map(|(left, right)| {
+                    expression_compare(left, left_vars, right, right_vars, cfg, block_vars)
+                })
+                .collect();
+
+            let first = cmps[0];
+
+            if cmps.into_iter().any(|c| c != first) {
+                ExpressionCmp::Unknown
+            } else {
+                first
+            }
+        }
+        (Expression::ZeroExt(_, _, left), Expression::ZeroExt(_, _, right))
+        | (Expression::Trunc(_, _, left), Expression::Trunc(_, _, right)) => {
+            expression_compare(left, left_vars, right, right_vars, cfg, block_vars)
+        }
+        (Expression::FunctionArg(_, _, left), Expression::FunctionArg(_, _, right)) => {
+            if left == right {
+                ExpressionCmp::Equal
+            } else {
+                // two function arguments can have the same value
+                ExpressionCmp::Unknown
+            }
+        }
+        (Expression::Add(_, _, l1, r1), Expression::Add(_, _, l2, r2))
+        | (Expression::Multiply(_, _, l1, r1), Expression::Multiply(_, _, l2, r2))
+        | (Expression::Subtract(_, _, l1, r1), Expression::Subtract(_, _, l2, r2))
+        | (Expression::Subscript(_, _, l1, r1), Expression::Subscript(_, _, l2, r2)) => {
+            let l = expression_compare(l1, left_vars, l2, right_vars, cfg, block_vars);
+
+            let r = expression_compare(r1, left_vars, r2, right_vars, cfg, block_vars);
+
+            if l == r {
+                l
+            } else if (l == ExpressionCmp::Equal && r == ExpressionCmp::NotEqual)
+                || (l == ExpressionCmp::NotEqual && r == ExpressionCmp::Equal)
+            {
+                ExpressionCmp::NotEqual
+            } else {
+                ExpressionCmp::Unknown
+            }
+        }
+        (Expression::Variable(_, _, left), Expression::Variable(_, _, right)) => {
+            // let's check that the variable left has the same reaching definitions as right
+            let left = &left_vars.vars[left];
+            let right = &right_vars.vars[right];
+
+            if left == right {
+                ExpressionCmp::Equal
+            } else if left.len() == 1 && right.len() == 1 {
+                let left = left.iter().next().unwrap();
+                let right = right.iter().next().unwrap();
+
+                match (get_definition(&left.0, cfg), get_definition(&right.0, cfg)) {
+                    (Some(left_expr), Some(right_expr)) => {
+                        let left_vars = get_vars_at(&left.0, block_vars);
+                        let right_vars = get_vars_at(&right.0, block_vars);
+
+                        expression_compare(
+                            left_expr,
+                            &left_vars,
+                            right_expr,
+                            &right_vars,
+                            cfg,
+                            block_vars,
+                        )
+                    }
+                    _ => ExpressionCmp::Unknown,
+                }
+            } else {
+                ExpressionCmp::Unknown
+            }
+        }
+        _ => ExpressionCmp::Unknown,
+    };
+
+    v
+}

--- a/src/codegen/reaching_definitions.rs
+++ b/src/codegen/reaching_definitions.rs
@@ -120,7 +120,7 @@ fn instr_transfers(block_no: usize, block: &BasicBlock) -> Vec<Vec<Transfer>> {
             Instr::Set { res, .. } => set_var(&[*res]),
             Instr::Call { res, .. } => set_var(res),
             Instr::AbiDecode { res, .. } => set_var(res),
-            Instr::PopStorage { res, .. } => set_var(&[*res]),
+            Instr::LoadStorage { res, .. } | Instr::PopStorage { res, .. } => set_var(&[*res]),
             Instr::PushMemory { array, res, .. } => {
                 let mut v = set_var(&[*res]);
                 v.push(Transfer::Mod { var_no: *array });

--- a/src/codegen/vector_to_slice.rs
+++ b/src/codegen/vector_to_slice.rs
@@ -84,6 +84,7 @@ fn find_writable_vectors(
             | Instr::Branch { .. }
             | Instr::BranchCond { .. }
             | Instr::PopMemory { .. }
+            | Instr::LoadStorage { .. }
             | Instr::SetStorage { .. }
             | Instr::ClearStorage { .. }
             | Instr::SetStorageBytes { .. }

--- a/src/codegen/vector_to_slice.rs
+++ b/src/codegen/vector_to_slice.rs
@@ -81,6 +81,7 @@ fn find_writable_vectors(
             }
             // These instructions are fine with vectors
             Instr::Set { .. }
+            | Instr::Nop
             | Instr::Branch { .. }
             | Instr::BranchCond { .. }
             | Instr::PopMemory { .. }

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -1919,12 +1919,10 @@ pub trait TargetRuntime<'a> {
                     value
                 }
             }
-            Expression::StorageLoad(_, ty, e) => {
-                let mut slot = self
-                    .expression(contract, e, vartab, function)
-                    .into_int_value();
-
-                self.storage_load(contract, ty, &mut slot, function)
+            Expression::StorageLoad(_, _, _) => {
+                // this should be covered by the Instr::LoadStorage instruction; if we reach this
+                // point the code generation is broken.
+                unreachable!();
             }
             Expression::ZeroExt(_, t, e) => {
                 let e = self
@@ -3220,6 +3218,14 @@ pub trait TargetRuntime<'a> {
                             bb_true,
                             bb_false,
                         );
+                    }
+                    Instr::LoadStorage { res, ty, storage } => {
+                        let mut slot = self
+                            .expression(contract, storage, &w.vars, function)
+                            .into_int_value();
+
+                        w.vars.get_mut(res).unwrap().value =
+                            self.storage_load(contract, ty, &mut slot, function);
                     }
                     Instr::ClearStorage { ty, storage } => {
                         let mut slot = self

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -3111,6 +3111,7 @@ pub trait TargetRuntime<'a> {
 
             for ins in &cfg.blocks[w.block_no].instr {
                 match ins {
+                    Instr::Nop => (),
                     Instr::Return { value } if value.is_empty() => {
                         contract
                             .builder

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub fn compile(
 
     // codegen all the contracts
     for contract_no in 0..ns.contracts.len() {
-        codegen::codegen(contract_no, &mut ns);
+        codegen::codegen(contract_no, &mut ns, &Default::default());
     }
 
     let results = (0..ns.contracts.len())

--- a/tests/codegen_testcases/dead_storage.sol
+++ b/tests/codegen_testcases/dead_storage.sol
@@ -1,0 +1,143 @@
+// RUN: --emit cfg
+contract deadstorage {
+    int a;
+
+    // simple test. Two references to "a" must result in a single loadstorage
+
+// BEGIN-CHECK: deadstorage::test1
+	function test1() public view returns (int) {
+        return a + a;
+	}
+// CHECK: load storage slot(uint256 0) ty:int256
+// NOT-CHECK: load storage slot(uint256 0) ty:int256
+
+    // Two references to "a" with a write to A in between must result in two loadstorage
+// BEGIN-CHECK: deadstorage::test2
+	function test2() public returns (int) {
+        int x = a;
+        a = 2;
+        x += a;
+        return x;
+	}
+// CHECK: load storage slot(uint256 0) ty:int256
+// CHECK: load storage slot(uint256 0) ty:int256
+
+    // make sure that reachable stores are not eliminated
+// BEGIN-CHECK: deadstorage::test3
+	function test3(bool c) public {
+		a = 1;
+		if (c) {
+			a = 2;
+		}
+	}
+// CHECK: store storage slot(uint256 0)
+// CHECK: store storage slot(uint256 0)
+
+   // two successive stores are redundant
+// BEGIN-CHECK: deadstorage::test4
+    int b;
+	function test4() public {
+		b = 511;
+	    b = 512;
+	}
+// CHECK: store storage slot(uint256 1)
+// NOT-CHECK: store storage slot(uint256 1)
+
+   // stores in a previous block are always redundant
+// BEGIN-CHECK: deadstorage::test5
+    int test5var;
+	function test5(bool c) public {
+        if (c) {
+            test5var = 1;
+        } else {
+            test5var = 2;
+        }
+        test5var = 3;
+	}
+// CHECK: store storage slot(uint256 2)
+// NOT-CHECK: store storage slot(uint256 2)
+
+// BEGIN-CHECK: deadstorage::test6
+    // store/load are not merged yet. Make sure that we have a store before a load
+    int test6var;
+    function test6() public {
+        test6var = 1;
+        int f = test6var;
+        test6var = 2;
+    }
+// CHECK: store storage slot(uint256 3)
+// CHECK: store storage slot(uint256 3)
+
+// BEGIN-CHECK: deadstorage::test7
+    // storage should be flushed before function call
+    int test7var;
+    function test7() public {
+        test7var = 1;
+        test6();
+        test7var = 2;
+    }
+// CHECK: store storage slot(uint256 4)
+// CHECK: store storage slot(uint256 4)
+
+// BEGIN-CHECK: deadstorage::test8
+    // clear before store is redundant
+    int test8var;
+    function test8() public {
+        delete test8var;
+        test8var = 2;
+    }
+// NOT-CHECK: clear storage slot(uint256 5)
+// CHECK: store storage slot(uint256 5)
+
+// BEGIN-CHECK: deadstorage::test9
+    // push should make both load/stores not redundant
+    bytes test9var;
+    function test9() public {
+        test9var = "a";
+        bytes f = test9var;
+        test9var.push(hex"01");
+        f = test9var;
+        test9var = "c";
+    }
+// CHECK: store storage slot(uint256 6)
+// CHECK: load storage slot(uint256 6)
+// CHECK: push storage slot(uint256 6)
+// CHECK: load storage slot(uint256 6)
+// CHECK: store storage slot(uint256 6)
+
+// BEGIN-CHECK: deadstorage::test10
+    // pop should make both load/stores not redundant
+    bytes test10var;
+    function test10() public {
+        test10var = "a";
+        bytes f = test10var;
+        test10var.pop();
+        f = test10var;
+        test10var = "c";
+    }
+// CHECK: store storage slot(uint256 7)
+// CHECK: load storage slot(uint256 7)
+// CHECK: pop storage ty:bytes1 slot(uint256 7)
+// CHECK: load storage slot(uint256 7)
+// CHECK: store storage slot(uint256 7)
+
+// BEGIN-CHECK: deadstorage::test11
+    // some array tests
+    int[11] test11var;
+    function test11(uint index, uint index2) public view returns (int) {
+        return test11var[index] + test11var[index2];
+    }
+
+// CHECK: load storage slot((uint256 8
+// CHECK: load storage slot((uint256 8
+
+// BEGIN-CHECK: deadstorage::test12
+    // one load needed for this
+    int[11] test12var;
+    function test12(uint index) public view returns (int) {
+        return test12var[index] + test12var[index];
+
+    }
+// CHECK: load storage slot((uint256 19
+// NOT-CHECK: load storage slot((uint256 19
+}


### PR DESCRIPTION
Copying a field or structure from contract storage is expensive and this is done each time a constract storage variable is used; so, remove dead stores and loads from contract storage.
