### PR TITLE
Parse and resolve uniswap v2

### DIFF
--- a/docs/language.rst
+++ b/docs/language.rst
@@ -1454,6 +1454,16 @@ values, for example.
         (b, , a) = (a, 5, b);
     }
 
+The right hand side of an destructure may contain the ternary conditional operator. The number
+of elements in both sides of the conditional must match the left hand side of the destructure statement.
+
+.. code-block:: javascript
+
+    function test(bool cond) public {
+        (int32 a, int32 b, int32 c) = cond ? (1, 2, 3) : (4, 5, 6)
+    }
+
+
 .. _try-catch:
 
 Try Catch Statement
@@ -1990,20 +2000,40 @@ retain their values between calls. These are declared so:
 .. code-block:: javascript
 
   contract hitcount {
-      uint counter = 1;
+      uint public counter = 1;
 
       function hit() public {
           counters++;
-      }
-
-      function count() public view returns (uint) {
-          return counter;
       }
   }
 
 The ``counter`` is maintained for each deployed ``hitcount`` contract. When the contract is deployed,
 the contract storage is set to 1. Contract storage variable do not need an initializer; when
 it is not present, it is initialized to 0, or ``false`` if it is a ``bool``.
+
+Accessor Functions
+__________________
+
+Any contract storage variable which is declared public, automatically gets an accessor function. This
+function has the same name as the variable name. So, in the example above, the value of counter can
+retrieved by calling a function called ``counter``, which returns ``uint``.
+
+If the type is either an array or a mapping, the key or array indices become arguments to the accessor
+function.
+
+.. code-block:: javascript
+
+    contract ethereum {
+        // As a public mapping,this creates accessor function called balance, which takes
+        // an address as an argument, and returns an uint
+        mapping(address => uint) public balances;
+
+        // A public array takes the index as an uint argument and returns the element,
+        // in this case string.
+        string[] users;
+    }
+
+
 
 How to clear Contract Storage
 _____________________________

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1012,7 +1012,7 @@ pub fn generate_cfg(
         }
     }
 
-    if func.ty == pt::FunctionTy::Modifier {
+    if func.ty == pt::FunctionTy::Modifier || !func.has_body {
         return;
     }
 

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -407,10 +407,7 @@ pub fn expression(
                         bigint_to_expression(loc, length, ns, &mut Vec::new(), Some(ty)).unwrap()
                     }
                 },
-                ty => {
-                    println!("what are you talking about {:?}", ty);
-                    unreachable!();
-                }
+                _ => unreachable!(),
             }
         }
         Expression::Builtin(loc, returns, Builtin::ExternalFunctionAddress, func) => {
@@ -1527,7 +1524,7 @@ pub fn emit_function_call(
     }
 }
 
-/// Resolve an array subscript expression
+/// Codegen for an array subscript expression
 fn array_subscript(
     loc: &pt::Loc,
     array_ty: &Type,

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -310,14 +310,9 @@ impl Symbol {
         }
     }
 
-    /// Is this symbol for an accessor function
-    pub fn is_accessor(&self, ns: &Namespace) -> bool {
-        if let Symbol::Function(func) = self {
-            func.iter()
-                .all(|(_, func_no)| ns.functions[*func_no].is_accessor)
-        } else {
-            false
-        }
+    /// Is this symbol for an event
+    pub fn is_event(&self) -> bool {
+        matches!(self, Symbol::Event(_))
     }
 
     /// Does this symbol have an accessor function

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -131,6 +131,8 @@ pub struct Function {
     // modifiers for functions
     pub modifiers: Vec<Expression>,
     pub is_virtual: bool,
+    /// Is this function an acccesor function created by a public variable
+    pub is_accessor: bool,
     pub is_override: Option<(pt::Loc, Vec<usize>)>,
     pub has_body: bool,
     pub body: Vec<Statement>,
@@ -172,6 +174,7 @@ impl Function {
             bases: HashMap::new(),
             modifiers: Vec::new(),
             is_virtual: false,
+            is_accessor: false,
             has_body: false,
             is_override: None,
             body: Vec::new(),
@@ -304,6 +307,28 @@ impl Symbol {
             Symbol::Event(events) => &events[0].0,
             Symbol::Contract(loc, _) => loc,
             Symbol::Import(loc, _) => loc,
+        }
+    }
+
+    /// Is this symbol for an accessor function
+    pub fn is_accessor(&self, ns: &Namespace) -> bool {
+        if let Symbol::Function(func) = self {
+            func.iter()
+                .all(|(_, func_no)| ns.functions[*func_no].is_accessor)
+        } else {
+            false
+        }
+    }
+
+    /// Does this symbol have an accessor function
+    pub fn has_accessor(&self, ns: &Namespace) -> bool {
+        if let Symbol::Variable(_, Some(contract_no), var_no) = self {
+            matches!(
+                ns.contracts[*contract_no].variables[*var_no].visibility,
+                pt::Visibility::Public(_)
+            )
+        } else {
+            false
         }
     }
 }

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -325,8 +325,10 @@ pub struct Namespace {
     /// value length in bytes
     pub value_length: usize,
     pub diagnostics: Vec<Diagnostic>,
+    /// There is a separate namespace for functions and non-functions
+    pub function_symbols: HashMap<(usize, Option<usize>, String), Symbol>,
     /// Symbol key is file_no, contract, identifier
-    pub symbols: HashMap<(usize, Option<usize>, String), Symbol>,
+    pub variable_symbols: HashMap<(usize, Option<usize>, String), Symbol>,
     // each variable in the symbol table should have a unique number
     pub next_id: usize,
     /// For a variable reference at a location, give the constant value

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -442,11 +442,14 @@ impl Contract {
 
     /// Return the constructor with no arguments
     pub fn no_args_constructor(&self, ns: &Namespace) -> Option<usize> {
-        self.functions.iter().position(|func_no| {
-            let func = &ns.functions[*func_no];
+        self.functions
+            .iter()
+            .find(|func_no| {
+                let func = &ns.functions[**func_no];
 
-            func.is_constructor() && func.params.is_empty()
-        })
+                func.is_constructor() && func.params.is_empty()
+            })
+            .cloned()
     }
 }
 

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -15,6 +15,8 @@ pub struct Prototype {
     pub ret: &'static [Type],
     pub target: Option<Target>,
     pub doc: &'static str,
+    // Can this function be called in constant context (e.g. hash functions)
+    pub constant: bool,
 }
 
 // A list of all Solidity builtins functions
@@ -27,6 +29,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Void],
         target: None,
         doc: "Abort execution if argument evaluates to false",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Print,
@@ -36,6 +39,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Void],
         target: None,
         doc: "log string for debugging purposes. Runs on development chain only",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Require,
@@ -45,6 +49,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Void],
         target: None,
         doc: "Abort execution if argument evaulates to false",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Require,
@@ -54,6 +59,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Void],
         target: None,
         doc: "Abort execution if argument evaulates to false. Report string when aborting",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Revert,
@@ -63,6 +69,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Unreachable],
         target: None,
         doc: "Revert execution",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Revert,
@@ -72,6 +79,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Unreachable],
         target: None,
         doc: "Revert execution and report string",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::SelfDestruct,
@@ -81,6 +89,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Unreachable],
         target: None,
         doc: "Destroys current account and deposits any remaining balance to address",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Keccak256,
@@ -90,6 +99,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Bytes(32)],
         target: None,
         doc: "Calculates keccak256 hash",
+        constant: true,
     },
     Prototype {
         builtin: Builtin::Ripemd160,
@@ -99,6 +109,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Bytes(20)],
         target: None,
         doc: "Calculates ripemd hash",
+        constant: true,
     },
     Prototype {
         builtin: Builtin::Sha256,
@@ -108,6 +119,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Bytes(32)],
         target: None,
         doc: "Calculates sha256 hash",
+        constant: true,
     },
     Prototype {
         builtin: Builtin::Blake2_128,
@@ -117,6 +129,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Bytes(16)],
         target: Some(Target::Substrate),
         doc: "Calculates blake2-128 hash",
+        constant: true,
     },
     Prototype {
         builtin: Builtin::Blake2_256,
@@ -126,6 +139,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Bytes(32)],
         target: Some(Target::Substrate),
         doc: "Calculates blake2-256 hash",
+        constant: true,
     },
     Prototype {
         builtin: Builtin::Gasleft,
@@ -135,6 +149,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Uint(64)],
         target: None,
         doc: "Return remaing gas left in current call",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::BlockHash,
@@ -144,6 +159,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Bytes(32)],
         target: Some(Target::Ewasm),
         doc: "Returns the block hash for given block number",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Random,
@@ -153,6 +169,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Bytes(32)],
         target: Some(Target::Substrate),
         doc: "Returns deterministic random bytes",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::AbiDecode,
@@ -162,6 +179,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[],
         target: None,
         doc: "Abi decode byte array with the given types",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::AbiEncode,
@@ -171,6 +189,8 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[],
         target: None,
         doc: "Abi encode given arguments",
+        // it should be allowed in constant context, but we don't supported that yet
+        constant: false,
     },
     Prototype {
         builtin: Builtin::AbiEncodePacked,
@@ -180,6 +200,8 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[],
         target: None,
         doc: "Abi encode given arguments using packed encoding",
+        // it should be allowed in constant context, but we don't supported that yet
+        constant: false,
     },
     Prototype {
         builtin: Builtin::AbiEncodeWithSelector,
@@ -189,6 +211,8 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[],
         target: None,
         doc: "Abi encode given arguments with selector",
+        // it should be allowed in constant context, but we don't supported that yet
+        constant: false,
     },
     Prototype {
         builtin: Builtin::AbiEncodeWithSignature,
@@ -198,6 +222,8 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[],
         target: None,
         doc: "Abi encode given arguments with function signature",
+        // it should be allowed in constant context, but we don't supported that yet
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Gasprice,
@@ -207,6 +233,7 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Value],
         target: None,
         doc: "Calculate price of given gas units",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::MulMod,
@@ -216,6 +243,8 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Uint(256)],
         target: None,
         doc: "Multiply first two arguments, and the modulo last argument. Does not overflow",
+        // it should be allowed in constant context, but we don't supported that yet
+        constant: false,
     },
     Prototype {
         builtin: Builtin::AddMod,
@@ -225,6 +254,8 @@ static BUILTIN_FUNCTIONS: [Prototype; 23] = [
         ret: &[Type::Uint(256)],
         target: None,
         doc: "Add first two arguments, and the modulo last argument. Does not overflow",
+        // it should be allowed in constant context, but we don't supported that yet
+        constant: false,
     },
 ];
 
@@ -238,6 +269,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Address(true)],
         target: Some(Target::Ewasm),
         doc: "The address of the current block miner",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::BlockDifficulty,
@@ -247,6 +279,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Uint(256)],
         target: Some(Target::Ewasm),
         doc: "The difficulty for current block",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::GasLimit,
@@ -256,6 +289,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Uint(64)],
         target: Some(Target::Ewasm),
         doc: "The gas limit",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::BlockNumber,
@@ -265,6 +299,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Uint(64)],
         target: None,
         doc: "Current block number",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Timestamp,
@@ -274,6 +309,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Uint(64)],
         target: None,
         doc: "Current timestamp in unix epoch (seconds since 1970)",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::TombstoneDeposit,
@@ -283,6 +319,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Value],
         target: Some(Target::Substrate),
         doc: "Deposit required for a tombstone",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::MinimumBalance,
@@ -292,6 +329,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Value],
         target: Some(Target::Substrate),
         doc: "Minimum balance required for an account",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Calldata,
@@ -301,6 +339,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::DynamicBytes],
         target: None,
         doc: "Raw input bytes to current call",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Sender,
@@ -309,6 +348,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         args: &[],
         ret: &[Type::Address(true)],
         target: None,
+        constant: false,
         doc: "Address of caller",
     },
     Prototype {
@@ -319,6 +359,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Bytes(4)],
         target: None,
         doc: "Function selector for current call",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Value,
@@ -328,6 +369,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Value],
         target: None,
         doc: "Value sent with current call",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Gasprice,
@@ -337,6 +379,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Value],
         target: None,
         doc: "gas price for one gas unit",
+        constant: false,
     },
     Prototype {
         builtin: Builtin::Origin,
@@ -346,6 +389,7 @@ static BUILTIN_VARIABLE: [Prototype; 13] = [
         ret: &[Type::Address(true)],
         target: Some(Target::Ewasm),
         doc: "Original address of sender current transaction",
+        constant: false,
     },
 ];
 
@@ -424,6 +468,7 @@ pub fn resolve_call(
     contract_no: Option<usize>,
     ns: &mut Namespace,
     symtable: &Symtable,
+    is_constant: bool,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Expression, ()> {
     let matches = BUILTIN_FUNCTIONS
@@ -434,6 +479,17 @@ pub fn resolve_call(
     let marker = diagnostics.len();
 
     for func in &matches {
+        if is_constant && !func.constant {
+            diagnostics.push(Diagnostic::error(
+                *loc,
+                format!(
+                    "cannot call function ‘{}’ in constant expression",
+                    func.name
+                ),
+            ));
+            return Err(());
+        }
+
         if func.args.len() != args.len() {
             diagnostics.push(Diagnostic::error(
                 *loc,
@@ -458,7 +514,7 @@ pub fn resolve_call(
                 contract_no,
                 ns,
                 symtable,
-                false,
+                is_constant,
                 diagnostics,
                 Some(&func.args[i]),
             ) {
@@ -548,6 +604,7 @@ pub fn resolve_method_call(
             contract_no,
             ns,
             symtable,
+            false,
             diagnostics,
         );
     }

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -310,7 +310,9 @@ fn layout_contract(contract_no: usize, ns: &mut ast::Namespace) {
         let contract_file_no = ns.contracts[base_contract_no].loc.0;
 
         // find all syms for this contract
-        for ((file_no, iter_contract_no, name), sym) in &ns.symbols {
+        for ((file_no, iter_contract_no, name), sym) in
+            ns.variable_symbols.iter().chain(ns.function_symbols.iter())
+        {
             if *iter_contract_no != Some(base_contract_no) || *file_no != contract_file_no {
                 continue;
             }

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -329,7 +329,13 @@ fn layout_contract(contract_no: usize, ns: &mut ast::Namespace) {
 
             if !done {
                 if let Some(prev) = variable_syms.get(name).or_else(|| function_syms.get(name)) {
-                    if !(prev.has_accessor(ns) || sym.has_accessor(ns)) {
+                    // events can be redefined, so allow duplicate event symbols
+                    // if a variable has an accessor function (i.e. public) then allow the variable sym,
+                    // check for duplicates will be on accessor function
+                    if !(prev.has_accessor(ns)
+                        || sym.has_accessor(ns)
+                        || prev.is_event() && sym.is_event())
+                    {
                         ns.diagnostics.push(ast::Diagnostic::error_with_note(
                             *sym.loc(),
                             format!("already defined ‘{}’", name),

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -629,7 +629,7 @@ fn layout_contract(contract_no: usize, ns: &mut ast::Namespace) {
                             ));
                             continue;
                         }
-                    } else {
+                    } else if cur.has_body {
                         if let Some(entry) = override_needed.get_mut(&signature) {
                             entry.push((base_contract_no, function_no));
                         } else {

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -4070,7 +4070,9 @@ fn enum_value(
 
     // last element in our namespace vector is first element
     while let Some(name) = namespace.last().map(|f| f.name.clone()) {
-        if let Some(Symbol::Import(_, import_file_no)) = ns.symbols.get(&(file_no, None, name)) {
+        if let Some(Symbol::Import(_, import_file_no)) =
+            ns.variable_symbols.get(&(file_no, None, name))
+        {
             file_no = *import_file_no;
             namespace.pop();
         } else {
@@ -4846,7 +4848,9 @@ pub fn available_functions(
     let mut list = Vec::new();
 
     if global {
-        if let Some(Symbol::Function(v)) = ns.symbols.get(&(file_no, None, name.to_owned())) {
+        if let Some(Symbol::Function(v)) =
+            ns.function_symbols.get(&(file_no, None, name.to_owned()))
+        {
             list.extend(v.iter().map(|(_, func_no)| *func_no));
         }
     }

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -1561,7 +1561,17 @@ pub fn expression(
                 return Ok(Expression::Builtin(id.loc, vec![ty], builtin, vec![]));
             }
 
-            match ns.resolve_var(file_no, contract_no, id) {
+            // are we trying to resolve a function type?
+            let function_first = if let Some(resolve_to) = resolve_to {
+                matches!(
+                    resolve_to,
+                    Type::InternalFunction { .. } | Type::ExternalFunction { .. }
+                )
+            } else {
+                false
+            };
+
+            match ns.resolve_var(file_no, contract_no, id, function_first) {
                 Some(Symbol::Variable(_, Some(var_contract_no), var_no)) => {
                     let var_contract_no = *var_contract_no;
                     let var_no = *var_no;
@@ -6829,7 +6839,7 @@ pub fn function_call_expr(
             // is there a local variable or contract variable with this name
             if symtable.find(&id.name).is_some()
                 || matches!(
-                    ns.resolve_var(file_no, contract_no, id),
+                    ns.resolve_var(file_no, contract_no, id, true),
                     Some(Symbol::Variable(_, _, _))
                 )
             {

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -4854,7 +4854,7 @@ pub fn available_functions(
                 .all_functions
                 .keys()
                 .filter_map(|func_no| {
-                    if ns.functions[*func_no].name == name {
+                    if ns.functions[*func_no].name == name && ns.functions[*func_no].has_body {
                         Some(*func_no)
                     } else {
                         None

--- a/src/sema/functions.rs
+++ b/src/sema/functions.rs
@@ -595,7 +595,7 @@ pub fn contract_function(
         ns.contracts[contract_no].functions.push(func_no);
 
         if let Some(Symbol::Function(ref mut v)) =
-            ns.symbols
+            ns.function_symbols
                 .get_mut(&(file_no, Some(contract_no), id.name.to_owned()))
         {
             v.push((func.loc, func_no));
@@ -760,7 +760,8 @@ pub fn function(
     ns.functions.push(fdecl);
 
     if let Some(Symbol::Function(ref mut v)) =
-        ns.symbols.get_mut(&(file_no, None, id.name.to_owned()))
+        ns.function_symbols
+            .get_mut(&(file_no, None, id.name.to_owned()))
     {
         v.push((func.loc, func_no));
     } else {

--- a/src/sema/functions.rs
+++ b/src/sema/functions.rs
@@ -729,7 +729,7 @@ pub fn function(
         ns,
     );
 
-    let fdecl = Function::new(
+    let mut fdecl = Function::new(
         func.loc,
         name,
         None,
@@ -741,6 +741,8 @@ pub fn function(
         returns,
         ns,
     );
+
+    fdecl.has_body = true;
 
     let id = func.name.as_ref().unwrap();
 

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -1187,6 +1187,7 @@ fn destructure(
             contract_no,
             ns,
             symtable,
+            false,
             diagnostics,
         )?,
         pt::Expression::NamedFunctionCall(loc, ty, args) => named_function_call_expr(
@@ -1497,6 +1498,7 @@ fn try_catch(
             contract_no,
             ns,
             symtable,
+            false,
             diagnostics,
         )?,
         pt::Expression::NamedFunctionCall(loc, ty, args) => named_function_call_expr(

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -170,13 +170,9 @@ pub fn resolve_fields(delay: ResolveFields, file_no: usize, ns: &mut Namespace) 
             continue;
         }
 
-        if let Some(prev) = global_signatures.get(&event.signature) {
-            ns.diagnostics.push(Diagnostic::error_with_note(
-                event.loc,
-                format!("event ‘{}’ already defined with same fields", event.name),
-                prev.loc,
-                format!("location of previous definition of ‘{}’", prev.name),
-            ));
+        if global_signatures.get(&event.signature).is_some() {
+            // already defined with the same fields
+            // solidiy 0.5 allows events to be redefined with the same fields, later version do not
         } else {
             global_signatures.insert(&event.signature, &event);
         }
@@ -189,23 +185,18 @@ pub fn resolve_fields(delay: ResolveFields, file_no: usize, ns: &mut Namespace) 
         let event = &ns.events[event_no];
 
         if let Some(contract_name) = &event.contract {
-            if let Some(prev) = global_signatures.get(&event.signature) {
-                ns.diagnostics.push(Diagnostic::error_with_note(
-                    event.loc,
-                    format!("event ‘{}’ already defined with same fields", event.name),
-                    prev.loc,
-                    format!("location of previous definition of ‘{}’", prev.name),
-                ));
+            if global_signatures.get(&event.signature).is_some() {
+                // already defined with the same fields
+                // solidiy 0.5 allows events to be redefined with the same fields, later version do not
                 continue;
             }
 
-            if let Some(prev) = contract_signatures.get(&(contract_name, &event.signature)) {
-                ns.diagnostics.push(Diagnostic::error_with_note(
-                    event.loc,
-                    format!("event ‘{}’ already defined with same fields", event.name),
-                    prev.loc,
-                    format!("location of previous definition of ‘{}’", prev.name),
-                ));
+            if contract_signatures
+                .get(&(contract_name, &event.signature))
+                .is_some()
+            {
+                // already defined with the same fields
+                // solidiy 0.5 allows events to be redefined with the same fields, later version do not
             } else {
                 contract_signatures.insert((contract_name, &event.signature), &event);
             }

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -65,7 +65,7 @@ pub fn resolve_typenames<'a>(
             }
             pt::SourceUnitPart::EventDefinition(def) => {
                 if let Some(Symbol::Event(events)) =
-                    ns.symbols
+                    ns.variable_symbols
                         .get_mut(&(file_no, None, def.name.name.to_owned()))
                 {
                     events.push((def.name.loc, delay.events.len()));
@@ -263,10 +263,11 @@ fn resolve_contract<'a>(
                 }
             }
             pt::ContractPart::EventDefinition(ref s) => {
-                if let Some(Symbol::Event(events)) =
-                    ns.symbols
-                        .get_mut(&(file_no, Some(contract_no), s.name.name.to_owned()))
-                {
+                if let Some(Symbol::Event(events)) = ns.variable_symbols.get_mut(&(
+                    file_no,
+                    Some(contract_no),
+                    s.name.name.to_owned(),
+                )) {
                     events.push((s.name.loc, delay.events.len()));
                 } else if !ns.add_symbol(
                     file_no,

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -934,13 +934,13 @@ impl Type {
         }
     }
 
-    pub fn ordered(&self) -> bool {
+    pub fn is_integer(&self) -> bool {
         match self {
             Type::Int(_) => true,
             Type::Uint(_) => true,
             Type::Value => true,
-            Type::Ref(r) => r.ordered(),
-            Type::StorageRef(r) => r.ordered(),
+            Type::Ref(r) => r.is_integer(),
+            Type::StorageRef(r) => r.is_integer(),
             _ => false,
         }
     }

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -278,12 +278,7 @@ pub fn var_decl(
         if let Some(contract_no) = contract_no {
             // The accessor function returns the value of the storage variable, constant or not.
             let mut expr = if is_constant {
-                Expression::ConstantVariable(
-                    pt::Loc(0, 0, 0),
-                    Type::StorageRef(Box::new(ty.clone())),
-                    Some(contract_no),
-                    pos,
-                )
+                Expression::ConstantVariable(pt::Loc(0, 0, 0), ty.clone(), Some(contract_no), pos)
             } else {
                 Expression::StorageVariable(
                     pt::Loc(0, 0, 0),
@@ -322,11 +317,11 @@ pub fn var_decl(
             // Create the implicit body - just return the value
             func.body = vec![Statement::Return(
                 pt::Loc(0, 0, 0),
-                vec![Expression::StorageLoad(
-                    pt::Loc(0, 0, 0),
-                    ty.clone(),
-                    Box::new(expr),
-                )],
+                vec![if is_constant {
+                    expr
+                } else {
+                    Expression::StorageLoad(pt::Loc(0, 0, 0), ty.clone(), Box::new(expr))
+                }],
             )];
             func.is_accessor = true;
             func.has_body = true;

--- a/tests/solana_tests/accessor.rs
+++ b/tests/solana_tests/accessor.rs
@@ -1,4 +1,4 @@
-use crate::build_solidity;
+use crate::{build_solidity, first_error, parse_and_resolve, Target};
 use ethabi::Token;
 
 #[test]
@@ -93,4 +93,91 @@ fn interfaces() {
     let returns = vm.function("f1", &[]);
 
     assert_eq!(returns, vec![Token::FixedBytes(b"ab".to_vec())]);
+}
+
+#[test]
+fn constant() {
+    let mut vm = build_solidity(
+        r#"
+        contract x {
+            bytes32 public constant z = keccak256("hey man");
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("z", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::FixedBytes(vec![
+            0, 91, 121, 69, 17, 39, 209, 87, 169, 94, 81, 10, 68, 17, 183, 52, 82, 28, 128, 159,
+            31, 73, 168, 235, 90, 61, 46, 198, 102, 241, 168, 79
+        ])]
+    );
+
+    let mut vm = build_solidity(
+        r#"
+        contract x {
+            bytes32 public constant z = sha256("hey man");
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("z", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::FixedBytes(vec![
+            190, 212, 99, 127, 110, 196, 102, 135, 47, 156, 116, 193, 201, 43, 100, 230, 152, 184,
+            58, 103, 63, 106, 217, 142, 143, 211, 220, 125, 255, 210, 48, 89
+        ])]
+    );
+
+    let mut vm = build_solidity(
+        r#"
+        contract x {
+            bytes20 public constant z = ripemd160("hey man");
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("z", &[]);
+
+    assert_eq!(
+        returns,
+        vec![Token::FixedBytes(vec![
+            255, 206, 178, 91, 165, 156, 178, 193, 7, 94, 233, 48, 117, 76, 48, 215, 255, 45, 61,
+            225
+        ])]
+    );
+
+    let ns = parse_and_resolve(
+        r#"
+        contract x {
+            bytes32 public constant z = blockhash(1);
+        }"#,
+        Target::Solana,
+    );
+
+    assert_eq!(
+        first_error(ns.diagnostics),
+        "cannot call function in constant expression"
+    );
+
+    let ns = parse_and_resolve(
+        r#"
+        contract x {
+            bytes foo;
+            bytes32 public constant z = keccak256(foo);
+        }"#,
+        Target::Solana,
+    );
+
+    assert_eq!(
+        first_error(ns.diagnostics),
+        "cannot read contract variable ‘foo’ in constant expression"
+    );
 }

--- a/tests/solana_tests/accessor.rs
+++ b/tests/solana_tests/accessor.rs
@@ -1,0 +1,96 @@
+use crate::build_solidity;
+use ethabi::Token;
+
+#[test]
+fn types() {
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            int64 public f1 = 102;
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("f1", &[]);
+
+    assert_eq!(returns, vec![Token::Int(ethereum_types::U256::from(102))]);
+
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            int64[4] public f1 = [1,3,5,7];
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("f1", &[Token::Uint(ethereum_types::U256::from(2))]);
+
+    assert_eq!(returns, vec![Token::Int(ethereum_types::U256::from(5))]);
+
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            int64[4][2] public f1;
+
+            constructor() {
+                f1[1][0] = 4;
+                f1[1][1] = 3;
+                f1[1][2] = 2;
+                f1[1][3] = 1;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function(
+        "f1",
+        &[
+            Token::Uint(ethereum_types::U256::from(1)),
+            Token::Uint(ethereum_types::U256::from(2)),
+        ],
+    );
+
+    assert_eq!(returns, vec![Token::Int(ethereum_types::U256::from(2))]);
+
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            mapping(int64 => uint64) public f1;
+
+            constructor() {
+                f1[2000] = 1;
+                f1[4000] = 2;
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("f1", &[Token::Int(ethereum_types::U256::from(4000))]);
+
+    assert_eq!(returns, vec![Token::Uint(ethereum_types::U256::from(2))]);
+}
+
+#[test]
+fn interfaces() {
+    let mut vm = build_solidity(
+        r#"
+        contract foo is bar {
+            bytes2 public f1 = "ab";
+        }
+
+        interface bar {
+            function f1() external returns (bytes2);
+        }
+        "#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("f1", &[]);
+
+    assert_eq!(returns, vec![Token::FixedBytes(b"ab".to_vec())]);
+}

--- a/tests/solana_tests/destructure.rs
+++ b/tests/solana_tests/destructure.rs
@@ -1,0 +1,59 @@
+use crate::build_solidity;
+use ethabi::Token;
+
+#[test]
+fn conditional_destructure() {
+    // test that the abi encoder can handle fixed arrays
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            function f(bool cond1, bool cond2) public returns (int, int) {
+                (int a, int b) = cond1 ? (cond2 ? (1, 2) : (3, 4)) : (5, 6);
+
+                return (a, b);
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    let returns = vm.function("f", &[Token::Bool(true), Token::Bool(true)]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Int(ethereum_types::U256::from(1)),
+            Token::Int(ethereum_types::U256::from(2)),
+        ]
+    );
+
+    let returns = vm.function("f", &[Token::Bool(true), Token::Bool(false)]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Int(ethereum_types::U256::from(3)),
+            Token::Int(ethereum_types::U256::from(4)),
+        ]
+    );
+
+    let returns = vm.function("f", &[Token::Bool(false), Token::Bool(false)]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Int(ethereum_types::U256::from(5)),
+            Token::Int(ethereum_types::U256::from(6)),
+        ]
+    );
+
+    let returns = vm.function("f", &[Token::Bool(false), Token::Bool(true)]);
+
+    assert_eq!(
+        returns,
+        vec![
+            Token::Int(ethereum_types::U256::from(5)),
+            Token::Int(ethereum_types::U256::from(6)),
+        ]
+    );
+}

--- a/tests/solana_tests/mod.rs
+++ b/tests/solana_tests/mod.rs
@@ -1,4 +1,5 @@
 mod abi;
+mod accessor;
 mod arrays;
 mod call;
 mod mappings;

--- a/tests/solana_tests/mod.rs
+++ b/tests/solana_tests/mod.rs
@@ -2,6 +2,7 @@ mod abi;
 mod accessor;
 mod arrays;
 mod call;
+mod destructure;
 mod mappings;
 mod primitives;
 mod simple;

--- a/tests/substrate_tests/events.rs
+++ b/tests/substrate_tests/events.rs
@@ -449,10 +449,7 @@ fn signatures() {
         Target::Substrate,
     );
 
-    assert_eq!(
-        first_error(ns.diagnostics),
-        "event ‘foo’ already defined with same fields"
-    );
+    no_errors(ns.diagnostics);
 
     let ns = parse_and_resolve(
         r#"
@@ -469,10 +466,7 @@ fn signatures() {
         Target::Substrate,
     );
 
-    assert_eq!(
-        first_error(ns.diagnostics),
-        "event ‘foo’ already defined with same fields"
-    );
+    no_errors(ns.diagnostics);
 
     let ns = parse_and_resolve(
         r#"
@@ -488,8 +482,5 @@ fn signatures() {
         Target::Substrate,
     );
 
-    assert_eq!(
-        first_error(ns.diagnostics),
-        "event ‘foo’ already defined with same fields"
-    );
+    no_errors(ns.diagnostics);
 }

--- a/tests/substrate_tests/expressions.rs
+++ b/tests/substrate_tests/expressions.rs
@@ -907,6 +907,10 @@ fn power() {
             function power(uint64 base, uint64 exp) public returns (uint64) {
                 return base ** exp;
             }
+
+            function power_with_cast() public returns (uint64) {
+                return uint64(2 ** 32);
+            }
         }",
     );
 
@@ -953,6 +957,10 @@ fn power() {
     runtime.function("power", args);
 
     assert_eq!(runtime.vm.output, Val(0).encode());
+
+    runtime.function("power_with_cast", Vec::new());
+
+    assert_eq!(runtime.vm.output, Val(0x1_0000_0000).encode());
 
     let ns = parse_and_resolve(
         "contract test {
@@ -1082,8 +1090,16 @@ fn multiply() {
             function multiply(uint a, uint b) public returns (uint) {
                 return a * b;
             }
+
+            function multiply_with_cast() public returns (uint64) {
+                return uint64(255 * 255);
+            }
         }",
     );
+
+    runtime.function("multiply_with_cast", Vec::new());
+
+    assert_eq!(runtime.vm.output, 65025u64.encode());
 
     let mut rand = || -> (BigInt, Vec<u8>) {
         let length = rng.gen::<usize>() % size;

--- a/tests/substrate_tests/function_types.rs
+++ b/tests/substrate_tests/function_types.rs
@@ -1,4 +1,4 @@
-use crate::{build_solidity, first_error, parse_and_resolve};
+use crate::{build_solidity, first_error, no_errors, parse_and_resolve};
 use parity_scale_codec::Encode;
 use parity_scale_codec_derive::{Decode, Encode};
 use solang::Target;
@@ -602,4 +602,31 @@ fn ext() {
 
     runtime.function("test1", Vec::new());
     runtime.function("test2", Vec::new());
+}
+
+// Depending on context, you may want to resolve a public variable as a variable or function.
+#[test]
+fn variable_or_func_type() {
+    let ns = parse_and_resolve(
+        "contract bar {
+            int public total;
+        }
+
+        interface I {
+            function total() external returns (int);
+        }
+
+        contract foo is I, bar {
+            function f1() public {
+                // now we want the variable
+                int variable = total;
+                // now we want the function type
+                function() internal returns (int) func_type = total;
+            }
+        }
+        ",
+        Target::Substrate,
+    );
+
+    no_errors(ns.diagnostics);
 }

--- a/tests/substrate_tests/inheritance.rs
+++ b/tests/substrate_tests/inheritance.rs
@@ -303,6 +303,32 @@ fn test_interface() {
         first_error(ns.diagnostics),
         "interface ‘bar’ is not allowed to have contract variable ‘x’"
     );
+
+    // 1. implementing an interface does not require an override
+
+    // 2. interface is function implemented by base
+    let ns = parse_and_resolve(
+        r#"
+        interface bar {
+            function f1(address a) external;
+        }
+
+        interface bar2 {
+            function f1(address a) external;
+        }
+
+        contract x is bar {
+            function f1(address a) public {}
+        }
+
+        contract y is bar2, x {
+            function f2(address a) public {}
+        }
+        "#,
+        Target::Substrate,
+    );
+
+    no_errors(ns.diagnostics);
 }
 
 #[test]

--- a/tests/substrate_tests/inheritance.rs
+++ b/tests/substrate_tests/inheritance.rs
@@ -1812,10 +1812,7 @@ fn simple_interface() {
         Target::Substrate,
     );
 
-    assert_eq!(
-        first_error(ns.diagnostics),
-        "function ‘bar’ should specify ‘override’"
-    );
+    no_errors(ns.diagnostics);
 
     let mut runtime = build_solidity(
         r##"

--- a/tests/substrate_tests/primitives.rs
+++ b/tests/substrate_tests/primitives.rs
@@ -387,10 +387,7 @@ fn address() {
         Target::Substrate,
     );
 
-    assert_eq!(
-        first_error(ns.diagnostics),
-        "expression of type address not allowed"
-    );
+    no_errors(ns.diagnostics);
 
     let ns = parse_and_resolve(
         "contract test {


### PR DESCRIPTION
The uniswap contracts fail to compile to due syntax which solang doesn't accept yet. This patch series adds the required syntax to make the contracts parse, and resolve (apart from `assembly { .. }` and `ecrecover()`). Successful code emitting and testing will happen in a later pr.