### PR TITLE
Upgrade to tower-lsp 0.14 and tokio 1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,8 @@ contract-metadata = "0.2.0"
 semver = { version = "0.11.0", features = ["serde"] }
 tempfile = "3.1"
 libc = "0.2"
-tower-lsp = "0.13"
-lsp-types = "0.81"
-tokio = { version = "0.2", features = ["rt-core", "io-std"] }
+tower-lsp = "0.14"
+tokio = { version = "1.6", features = ["rt", "io-std", "macros"] }
 base58 = "0.1.0"
 sha2 = "0.9"
 ripemd160 = "0.9"


### PR DESCRIPTION
### Changed

* Upgrade to `tower-lsp` 0.14.0 ([release notes](https://github.com/ebkalderon/tower-lsp/releases/tag/v0.14.0)).
* Upgrade to `tokio` 1.6 (single-threaded flavor, like before).

### Fixed

* Use async-aware `tokio::sync::Mutex` instead of `std::sync::Mutex` in order to avoid stalling the executor.

### Removed

* Remove redundant direct dependency on `lsp-types`, since it's already re-exported by `tower-lsp`.