### PR TITLE
Ensure that mappings in structs are handled correctly

### DIFF
--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -368,7 +368,7 @@ fn gen_abi(contract_no: usize, ns: &ast::Namespace) -> Abi {
         .filter_map(|layout| {
             let var = &ns.contracts[layout.contract_no].variables[layout.var_no];
 
-            if !var.ty.is_mapping() {
+            if !var.ty.contains_mapping(ns) {
                 Some(StorageLayout {
                     name: var.name.to_string(),
                     layout: LayoutField {

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -1047,6 +1047,11 @@ pub fn expression(
 
             Expression::FormatString(*loc, args)
         }
+        Expression::AllocDynamicArray(loc, ty, size, init) => {
+            let size = expression(size, cfg, contract_no, ns, vartab);
+
+            Expression::AllocDynamicArray(*loc, ty.clone(), Box::new(size), init.clone())
+        }
         _ => expr.clone(),
     }
 }

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -3505,29 +3505,8 @@ pub fn new(
         diagnostics,
         Some(&Type::Uint(32)),
     )?;
-    let size_ty = size_expr.ty();
 
-    let size_width = match &size_ty {
-        Type::Uint(n) => n,
-        _ => {
-            diagnostics.push(Diagnostic::error(
-                size_loc,
-                format!(
-                    "new size argument must be unsigned integer, not ‘{}’",
-                    size_ty.to_string(ns)
-                ),
-            ));
-            return Err(());
-        }
-    };
-
-    // TODO: should we check an upper bound? Large allocations will fail anyway,
-    // and ethereum solidity does not check at compile time
-    let size = match size_width.cmp(&32) {
-        Ordering::Greater => Expression::Trunc(size_loc, Type::Uint(32), Box::new(size_expr)),
-        Ordering::Less => Expression::ZeroExt(size_loc, Type::Uint(32), Box::new(size_expr)),
-        Ordering::Equal => size_expr,
-    };
+    let size = cast(&size_loc, size_expr, &Type::Uint(32), true, ns, diagnostics)?;
 
     Ok(Expression::AllocDynamicArray(
         *loc,

--- a/tests/substrate_tests/arrays.rs
+++ b/tests/substrate_tests/arrays.rs
@@ -761,7 +761,7 @@ fn memory_dynamic_array_new() {
 
     assert_eq!(
         first_error(ns.diagnostics),
-        "new size argument must be unsigned integer, not ‘bytes1’"
+        "implicit conversion to uint32 from bytes1 not allowed"
     );
 
     let ns = parse_and_resolve(
@@ -1896,4 +1896,23 @@ fn large_index_ty_in_bounds() {
     runtime.function_expect_return("test", 17u128.encode(), 1);
 
     runtime.function_expect_return("test", 0xfffffffffffffu128.encode(), 1);
+}
+
+#[test]
+fn alloc_size_from_storage() {
+    let mut runtime = build_solidity(
+        r#"
+        contract Test {
+            uint32 length = 1;
+
+            function contfunc() public view returns (uint64[] memory) {
+                uint64[] memory values = new uint64[](length);
+                return values;
+            }
+        }"#,
+    );
+
+    runtime.constructor(0, Vec::new());
+    runtime.function("contfunc", Vec::new());
+    assert_eq!(runtime.vm.output, vec![0u64].encode());
 }

--- a/tests/substrate_tests/mappings.rs
+++ b/tests/substrate_tests/mappings.rs
@@ -180,6 +180,41 @@ fn basic() {
     );
 
     runtime.function("test", Vec::new());
+
+    let mut runtime = build_solidity(
+        r##"
+        contract Test {
+            using TestLib for TestLib.data;
+
+            TestLib.data libdata;
+
+            function contfunc(uint64 num) public {
+                libdata.libfunc(num);
+            }
+        }
+
+        library TestLib {
+            using TestLib for TestLib.data;
+
+            struct pair {
+                uint64 a;
+                uint64 b;
+            }
+
+            struct data {
+                mapping(uint64 => pair) pairmap;
+            }
+
+            function libfunc(data storage self, uint64 value) internal {
+                self.pairmap[self.pairmap[value].a].a = 1;
+                //self.pairmap[self.pairmap[value].b].b = 2;
+            }
+        }
+        "##,
+    );
+
+    runtime.constructor(0, Vec::new());
+    runtime.function("contfunc", 1u64.encode());
 }
 
 #[test]


### PR DESCRIPTION
Substrate storage does not understand solidity mappings, so drop them
from the abi file.

Signed-off-by: Sean Young <sean@mess.org>