### PR TITLE
Unused variable detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Cargo.lock
 /target
 **/*.rs.bk
+.DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 Cargo.lock
 /target
 **/*.rs.bk
-.DS_Store
-.idea
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0"
 serde_derive = { version = "1.0" }
 inkwell = { version = "0.1.0-beta.2", features = ["target-webassembly", "target-bpf", "llvm11-0"] }
 blake2-rfc = "0.2.18"
-phf = { version = "0.8", features = ["macros"] }
+phf = { version = "0.9", features = ["macros"] }
 unicode-xid = "0.2.0"
 handlebars = "3.4"
 contract-metadata = "0.2.0"
@@ -54,7 +54,7 @@ ethereum-types = "0.10"
 wasmi = "0.9"
 rand = "0.8"
 sha2 = "0.9"
-solana_rbpf = "0.2"
+solana_rbpf = "^0.2.11"
 byteorder = "1.3"
 assert_cmd = "1.0"
 bincode = "1.3"

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() {
     let cxxflags = Command::new("llvm-config")
         .args(&["--cxxflags"])
         .output()
-        .unwrap();
+        .expect("could not execute llvm-config");
 
     let cxxflags = String::from_utf8(cxxflags.stdout).unwrap();
 

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -616,6 +616,12 @@ impl ControlFlowGraph {
                 ty.to_string(ns),
                 self.expr_to_string(contract, ns, e)
             ),
+            Expression::BytesCast(_, ty, from, e) => format!(
+                "{} from:{} ({})",
+                ty.to_string(ns),
+                from.to_string(ns),
+                self.expr_to_string(contract, ns, e)
+            ),
             Expression::Builtin(_, _, builtin, args) => format!(
                 "(builtin {:?} ({}))",
                 builtin,

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -1062,7 +1062,7 @@ fn expression(
         | Expression::FormatString { .. }
         | Expression::InternalFunctionCfg(_) => (expr.clone(), false),
         // nothing else is permitted in cfg
-        _ => unreachable!(),
+        _ => panic!("expr should not be in cfg: {:?}", expr),
     }
 }
 

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -708,6 +708,12 @@ pub fn expression(
                 )
             }
         }
+        Expression::BytesCast(loc, ty, from, e) => Expression::BytesCast(
+            *loc,
+            ty.clone(),
+            from.clone(),
+            Box::new(expression(e, cfg, contract_no, ns, vartab)),
+        ),
         Expression::Load(loc, ty, e) => Expression::Load(
             *loc,
             ty.clone(),
@@ -1784,24 +1790,25 @@ fn array_subscript(
             Type::Bytes(array_length) => {
                 let res_ty = Type::Bytes(1);
                 let from_ty = Type::Bytes(*array_length);
+                let index_ty = Type::Uint(*array_length as u16 * 8);
 
                 Expression::Trunc(
                     *loc,
                     res_ty,
                     Box::new(Expression::ShiftRight(
                         *loc,
-                        from_ty.clone(),
+                        from_ty,
                         Box::new(array),
                         // shift by (array_length - 1 - index) * 8
                         Box::new(Expression::ShiftLeft(
                             *loc,
-                            from_ty.clone(),
+                            index_ty.clone(),
                             Box::new(Expression::Subtract(
                                 *loc,
-                                from_ty.clone(),
+                                index_ty.clone(),
                                 Box::new(Expression::NumberLiteral(
                                     *loc,
-                                    from_ty.clone(),
+                                    index_ty.clone(),
                                     BigInt::from_u8(array_length - 1).unwrap(),
                                 )),
                                 Box::new(cast_shift_arg(
@@ -1814,7 +1821,7 @@ fn array_subscript(
                             )),
                             Box::new(Expression::NumberLiteral(
                                 *loc,
-                                from_ty,
+                                index_ty,
                                 BigInt::from_u8(3).unwrap(),
                             )),
                         )),

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -62,6 +62,7 @@ pub struct EventDecl {
     pub fields: Vec<Parameter>,
     pub signature: String,
     pub anonymous: bool,
+    pub used: bool,
 }
 
 impl fmt::Display for EventDecl {
@@ -284,6 +285,8 @@ pub struct Variable {
     pub visibility: pt::Visibility,
     pub constant: bool,
     pub initializer: Option<Expression>,
+    pub assigned: bool,
+    pub read: bool,
 }
 
 #[derive(Clone, PartialEq)]

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -467,7 +467,7 @@ pub fn resolve_call(
     args: &[pt::Expression],
     contract_no: Option<usize>,
     ns: &mut Namespace,
-    symtable: &Symtable,
+    symtable: &mut Symtable,
     is_constant: bool,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Expression, ()> {
@@ -590,7 +590,7 @@ pub fn resolve_method_call(
     args: &[pt::Expression],
     contract_no: Option<usize>,
     ns: &mut Namespace,
-    symtable: &Symtable,
+    symtable: &mut Symtable,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Expression, ()> {
     // The abi.* functions need special handling, others do not

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -870,9 +870,9 @@ fn resolve_bodies(
         {
             broken = true;
         } else {
-            for (_, variable) in &ns.functions[function_no].symtable.vars {
+            for variable in ns.functions[function_no].symtable.vars.values() {
                 if let Some(warning) = emit_warning_local_variable(&variable) {
-                    ns.diagnostics.push(*warning);
+                    ns.diagnostics.push(warning);
                 }
             }
         }

--- a/src/sema/format.rs
+++ b/src/sema/format.rs
@@ -18,7 +18,7 @@ pub fn string_format(
     file_no: usize,
     contract_no: Option<usize>,
     ns: &mut Namespace,
-    symtable: &Symtable,
+    symtable: &mut Symtable,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Expression, ()> {
     // first resolve the arguments. We can't say anything about the format string if the args are broken

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -41,16 +41,18 @@ pub const SOLANA_BUCKET_SIZE: u64 = 251;
 pub const SOLANA_FIRST_OFFSET: u64 = 16;
 pub const SOLANA_SPARSE_ARRAY_SIZE: u64 = 1024;
 
-/// Performs semantic analysis and checks for unused variables
+/// Load a file file from the cache, parse and resolve it. The file must be present in
+/// the cache.
 pub fn sema(file: ResolvedFile, cache: &mut FileCache, ns: &mut ast::Namespace) {
-    perform_sema(file, cache, ns);
+    sema_file(file, cache, ns);
+
+    // Checks for unused variables
     check_unused_namespace_variables(ns);
     check_unused_events(ns);
 }
 
-/// Load a file file from the cache, parse and resolve it. The file must be present in
-/// the cache. This function is recursive for imports.
-pub fn perform_sema(file: ResolvedFile, cache: &mut FileCache, ns: &mut ast::Namespace) {
+/// Parse and resolve a file and its imports in a recursive manner.
+fn sema_file(file: ResolvedFile, cache: &mut FileCache, ns: &mut ast::Namespace) {
     let file_no = ns.files.len();
 
     let source_code = cache.get_file_contents(&file.full_path);
@@ -177,7 +179,7 @@ fn resolve_import(
         }
         Ok(file) => {
             if !ns.files.iter().any(|f| *f == file.full_path) {
-                perform_sema(file.clone(), cache, ns);
+                sema_file(file.clone(), cache, ns);
 
                 // give up if we failed
                 if diagnostics::any_errors(&ns.diagnostics) {

--- a/src/sema/symtable.rs
+++ b/src/sema/symtable.rs
@@ -12,6 +12,21 @@ pub struct Variable {
     pub ty: Type,
     pub pos: usize,
     pub slice: bool,
+    pub assigned: bool,
+    pub read: bool,
+    pub usage_type: VariableUsage,
+}
+
+#[derive(Clone)]
+pub enum VariableUsage {
+    Parameter,
+    ReturnVariable,
+    AnonymousReturnVariable,
+    StateVariable,
+    DestructureVariable,
+    TryCatchReturns,
+    TryCatchErrorString,
+    TryCatchErrorBytes,
 }
 
 struct VarScope(HashMap<String, usize>, Option<HashSet<usize>>);
@@ -36,7 +51,14 @@ impl Symtable {
         }
     }
 
-    pub fn add(&mut self, id: &pt::Identifier, ty: Type, ns: &mut Namespace) -> Option<usize> {
+    pub fn add(
+        &mut self,
+        id: &pt::Identifier,
+        ty: Type,
+        ns: &mut Namespace,
+        assigned: bool,
+        usage_type: VariableUsage,
+    ) -> Option<usize> {
         let pos = ns.next_id;
         ns.next_id += 1;
 
@@ -47,6 +69,9 @@ impl Symtable {
                 ty,
                 pos,
                 slice: false,
+                assigned,
+                usage_type,
+                read: false,
             },
         );
 

--- a/src/sema/symtable.rs
+++ b/src/sema/symtable.rs
@@ -22,7 +22,7 @@ pub enum VariableUsage {
     Parameter,
     ReturnVariable,
     AnonymousReturnVariable,
-    StateVariable,
+    LocalVariable,
     DestructureVariable,
     TryCatchReturns,
     TryCatchErrorString,

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -85,6 +85,7 @@ pub fn resolve_typenames<'a>(
                     fields: Vec::new(),
                     anonymous: def.anonymous,
                     signature: String::new(),
+                    used: false,
                 });
 
                 delay.events.push((pos, def, None));
@@ -279,6 +280,7 @@ fn resolve_contract<'a>(
                     fields: Vec::new(),
                     anonymous: s.anonymous,
                     signature: String::new(),
+                    used: false,
                 });
 
                 delay.events.push((pos, s, Some(contract_no)));

--- a/src/sema/unused_variable.rs
+++ b/src/sema/unused_variable.rs
@@ -1,0 +1,366 @@
+use crate::parser::pt::Loc;
+use crate::sema::ast::{
+    Builtin, Diagnostic, ErrorType, Expression, Level, Namespace, Note, Statement,
+};
+use crate::sema::symtable::{Symtable, VariableUsage};
+use crate::sema::{ast, symtable};
+
+/// Mark variables as assigned, either in the symbol table (for state variables) or in the
+/// Namespace (for storage variables)
+pub fn assigned_variable(ns: &mut Namespace, exp: &Expression, symtable: &mut Symtable) {
+    match &exp {
+        Expression::StorageVariable(_, _, contract_no, offset) => {
+            ns.contracts[*contract_no].variables[*offset].assigned = true;
+        }
+
+        Expression::Variable(_, _, offset) => {
+            let var = symtable.vars.get_mut(offset).unwrap();
+            (*var).assigned = true;
+        }
+
+        Expression::StructMember(_, _, str, _) => {
+            assigned_variable(ns, str, symtable);
+        }
+
+        Expression::Subscript(_, _, array, index)
+        | Expression::DynamicArraySubscript(_, _, array, index)
+        | Expression::StorageBytesSubscript(_, array, index) => {
+            assigned_variable(ns, array, symtable);
+            used_variable(ns, index, symtable);
+        }
+
+        _ => {}
+    }
+}
+
+/// Mark variables as used, either in the symbol table (for state variables) or in the
+/// Namespace (for global constants and storage variables)
+/// The functions handles complex expressions in a recursive fashion, such as array length call,
+/// assign expressions and array subscripts.
+pub fn used_variable(ns: &mut Namespace, exp: &Expression, symtable: &mut Symtable) {
+    match &exp {
+        Expression::StorageVariable(_, _, contract_no, offset) => {
+            ns.contracts[*contract_no].variables[*offset].read = true;
+        }
+
+        Expression::Variable(_, _, offset) => {
+            let var = symtable.vars.get_mut(offset).unwrap();
+            (*var).read = true;
+        }
+
+        Expression::ConstantVariable(_, _, Some(contract_no), offset) => {
+            ns.contracts[*contract_no].variables[*offset].read = true;
+        }
+
+        Expression::ConstantVariable(_, _, None, offset) => {
+            ns.constants[*offset].read = true;
+        }
+
+        Expression::ZeroExt(_, _, variable) => {
+            used_variable(ns, variable, symtable);
+        }
+
+        Expression::StructMember(_, _, str, _) => {
+            used_variable(ns, str, symtable);
+        }
+
+        Expression::Subscript(_, _, array, index)
+        | Expression::DynamicArraySubscript(_, _, array, index)
+        | Expression::StorageBytesSubscript(_, array, index) => {
+            used_variable(ns, array, symtable);
+            used_variable(ns, index, symtable);
+        }
+
+        Expression::Assign(_, _, assigned, assignee) => {
+            assigned_variable(ns, assigned, symtable);
+            used_variable(ns, assignee, symtable);
+        }
+
+        Expression::DynamicArrayLength(_, array) => {
+            used_variable(ns, array, symtable);
+        }
+
+        Expression::StorageArrayLength {
+            loc: _,
+            ty: _,
+            array,
+            ..
+        } => {
+            used_variable(ns, array, symtable);
+        }
+
+        Expression::StorageLoad(_, _, expr) => {
+            used_variable(ns, expr, symtable);
+        }
+
+        _ => {}
+    }
+}
+
+/// Mark function arguments as used. If the function is an attribute of another variable, mark the
+/// usage of the latter as well
+pub fn check_function_call(ns: &mut Namespace, exp: &Expression, symtable: &mut Symtable) {
+    match &exp {
+        Expression::InternalFunctionCall {
+            loc: _,
+            returns: _,
+            function,
+            args,
+        }
+        | Expression::ExternalFunctionCall {
+            loc: _,
+            returns: _,
+            function,
+            args,
+            ..
+        } => {
+            for arg in args {
+                used_variable(ns, arg, symtable);
+            }
+            check_function_call(ns, function, symtable);
+        }
+
+        Expression::Constructor {
+            loc: _,
+            contract_no: _,
+            constructor_no: _,
+            args,
+            ..
+        } => {
+            for arg in args {
+                used_variable(ns, arg, symtable);
+            }
+        }
+
+        Expression::ExternalFunctionCallRaw {
+            loc: _,
+            ty: _,
+            address: function,
+            args,
+            ..
+        } => {
+            used_variable(ns, args, symtable);
+            check_function_call(ns, function, symtable);
+        }
+
+        Expression::ExternalFunction {
+            loc: _,
+            ty: _,
+            address,
+            function_no,
+        } => {
+            used_variable(ns, address, symtable);
+            if ns.functions[*function_no].is_accessor {
+                let body = ns.functions[*function_no].body[0].clone();
+                if let Statement::Return(_, exprs) = &body {
+                    used_variable(ns, &exprs[0], symtable);
+                }
+            }
+        }
+
+        Expression::Builtin(_, _, expr_type, args) => match expr_type {
+            Builtin::ArrayPush => {
+                assigned_variable(ns, &args[0], symtable);
+                if args.len() > 1 {
+                    used_variable(ns, &args[1], symtable);
+                }
+            }
+
+            Builtin::ArrayPop => {
+                used_variable(ns, &args[0], symtable);
+            }
+            _ => {}
+        },
+
+        Expression::DynamicArrayPush(_, array, _, arg) => {
+            assigned_variable(ns, array, symtable);
+            used_variable(ns, arg, symtable);
+        }
+
+        Expression::DynamicArrayPop(_, array, _) => {
+            used_variable(ns, array, symtable);
+        }
+
+        _ => {}
+    }
+}
+
+/// Marks as used variables that appear in an expression with right and left hand side.
+pub fn check_var_usage_expression(
+    ns: &mut Namespace,
+    left: &Expression,
+    right: &Expression,
+    symtable: &mut Symtable,
+) {
+    used_variable(ns, left, symtable);
+    used_variable(ns, right, symtable);
+}
+
+/// Generate warnings for unused varibles
+fn generate_unused_warning(loc: Loc, text: &String, notes: Vec<Note>) -> Box<Diagnostic> {
+    Box::new(Diagnostic {
+        level: Level::Warning,
+        ty: ErrorType::Warning,
+        pos: Some(loc),
+        message: text.clone(),
+        notes,
+    })
+}
+
+/// Emit different warning types according to the state variable usage
+pub fn emit_warning_local_variable(variable: &symtable::Variable) -> Option<Box<Diagnostic>> {
+    match &variable.usage_type {
+        VariableUsage::Parameter => {
+            if !variable.read {
+                return Some(generate_unused_warning(
+                    variable.id.loc,
+                    &format!(
+                        "Function parameter '{}' has never been used.",
+                        variable.id.name
+                    ),
+                    vec![],
+                ));
+            }
+            None
+        }
+
+        VariableUsage::ReturnVariable => {
+            if !variable.assigned {
+                return Some(generate_unused_warning(
+                    variable.id.loc,
+                    &format!(
+                        "Return variable '{}' has never been assigned",
+                        variable.id.name
+                    ),
+                    vec![],
+                ));
+            }
+            None
+        }
+
+        VariableUsage::StateVariable => {
+            if !variable.assigned && !variable.read {
+                return Some(generate_unused_warning(
+                    variable.id.loc,
+                    &format!(
+                        "State variable '{}' has never been read nor assigned",
+                        variable.id.name
+                    ),
+                    vec![],
+                ));
+            } else if variable.assigned && !variable.read {
+                return Some(generate_unused_warning(
+                    variable.id.loc,
+                    &format!(
+                        "State variable '{}' has been assigned, but never read.",
+                        variable.id.name
+                    ),
+                    vec![],
+                ));
+            } else if !variable.assigned && variable.read {
+                return Some(generate_unused_warning(
+                    variable.id.loc,
+                    &format!(
+                        "State variable '{}' has never been assigned a value, but has been read.",
+                        variable.id.name
+                    ),
+                    vec![],
+                ));
+            }
+            None
+        }
+
+        VariableUsage::DestructureVariable => {
+            if !variable.read {
+                return Some(generate_unused_warning(
+                    variable.id.loc,
+                    &format!(
+                        "Destructure variable '{}' has never been used.",
+                        variable.id.name
+                    ),
+                    vec![],
+                ));
+            }
+
+            None
+        }
+
+        VariableUsage::TryCatchReturns => {
+            if !variable.read {
+                return Some(generate_unused_warning(
+                    variable.id.loc,
+                    &format!(
+                        "Try catch returns variable '{}' has never been read.",
+                        variable.id.name
+                    ),
+                    vec![],
+                ));
+            }
+
+            None
+        }
+
+        VariableUsage::AnonymousReturnVariable
+        | VariableUsage::TryCatchErrorBytes
+        | VariableUsage::TryCatchErrorString => None,
+    }
+}
+
+/// Emit warnings depending on the state variable usage
+fn emit_warning_contract_variables(variable: &ast::Variable) -> Option<Box<Diagnostic>> {
+    if !variable.assigned && !variable.read {
+        return Some(generate_unused_warning(
+            variable.loc,
+            &format!(
+                "Storage variable '{}' has been assigned, but never used.",
+                variable.name
+            ),
+            vec![],
+        ));
+    } else if variable.assigned && !variable.read {
+        return Some(generate_unused_warning(
+            variable.loc,
+            &format!("Storage variable '{}' has never been used.", variable.name),
+            vec![],
+        ));
+    }
+    //Solidity attributes zero value to contract values that have never been assigned
+    //There is no need to raise warning if we use them, as they have a valid value.
+
+    None
+}
+
+/// Check for unused constants and storage variables
+pub fn check_unused_namespace_variables(ns: &mut Namespace) {
+    for contract in &ns.contracts {
+        for variable in &contract.variables {
+            if let Some(warning) = emit_warning_contract_variables(variable) {
+                ns.diagnostics.push(*warning);
+            }
+        }
+    }
+
+    //Global constants should have been initialized during declaration
+    for constant in &ns.constants {
+        if !constant.read {
+            ns.diagnostics.push(*generate_unused_warning(
+                constant.loc,
+                &format!("Global constant '{}' has never been used.", constant.name),
+                vec![],
+            ))
+        }
+    }
+}
+
+/// Check for unused events
+pub fn check_unused_events(ns: &mut Namespace) {
+    for event in &ns.events {
+        if !event.used {
+            ns.diagnostics.push(*generate_unused_warning(
+                event.loc,
+                &format!("Event '{}' has never been emitted.", event.name),
+                vec![],
+            ))
+        }
+    }
+}

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -98,7 +98,6 @@ pub fn var_decl(
 
     let mut is_constant = false;
     let mut visibility: Option<pt::Visibility> = None;
-    let mut initialized = false;
 
     for attr in attrs {
         match &attr {
@@ -179,7 +178,6 @@ pub fn var_decl(
 
     let initializer = if let Some(initializer) = &s.initializer {
         let mut diagnostics = Vec::new();
-        initialized = true;
 
         let res = match expression(
             &initializer,
@@ -251,9 +249,9 @@ pub fn var_decl(
         visibility: visibility.clone(),
         ty: ty.clone(),
         constant: is_constant,
+        assigned: initializer.is_some(),
         initializer,
         read: false,
-        assigned: initialized,
     };
 
     let pos = if let Some(contract_no) = contract_no {

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -98,6 +98,7 @@ pub fn var_decl(
 
     let mut is_constant = false;
     let mut visibility: Option<pt::Visibility> = None;
+    let mut initialized = false;
 
     for attr in attrs {
         match &attr {
@@ -178,13 +179,14 @@ pub fn var_decl(
 
     let initializer = if let Some(initializer) = &s.initializer {
         let mut diagnostics = Vec::new();
+        initialized = true;
 
         let res = match expression(
             &initializer,
             file_no,
             contract_no,
             ns,
-            &symtable,
+            symtable,
             is_constant,
             &mut diagnostics,
             Some(&ty),
@@ -250,6 +252,8 @@ pub fn var_decl(
         ty: ty.clone(),
         constant: is_constant,
         initializer,
+        read: false,
+        assigned: initialized,
     };
 
     let pos = if let Some(contract_no) = contract_no {

--- a/tests/substrate_tests/arrays.rs
+++ b/tests/substrate_tests/arrays.rs
@@ -2,7 +2,7 @@ use parity_scale_codec::Encode;
 use parity_scale_codec_derive::{Decode, Encode};
 use rand::Rng;
 
-use crate::{build_solidity, first_error, parse_and_resolve};
+use crate::{build_solidity, first_error, no_errors, parse_and_resolve};
 use solang::Target;
 
 #[derive(Debug, PartialEq, Encode, Decode)]
@@ -1915,4 +1915,35 @@ fn alloc_size_from_storage() {
     runtime.constructor(0, Vec::new());
     runtime.function("contfunc", Vec::new());
     assert_eq!(runtime.vm.output, vec![0u64].encode());
+}
+
+#[test]
+fn lucas() {
+    let ns = parse_and_resolve(
+        r#"contract Test {
+        bytes byteArr;
+        bytes32 baRR;
+
+        function get() public  {
+            string memory s = "Test";
+            byteArr = bytes(s);
+            uint16 a = 1;
+            uint8 b;
+            b = uint8(a);
+
+            uint256 c;
+            c = b;
+            bytes32 b32;
+            b32 = bytes32(byteArr);
+            baRR = bytes32(c);
+            uint i1 = 1;
+            uint i2 = 1;
+            assert(b32[(i1*i2)-i1] == bytes1(baRR));
+        }
+    }
+    "#,
+        Target::Substrate,
+    );
+
+    no_errors(ns.diagnostics);
 }

--- a/tests/substrate_tests/tags.rs
+++ b/tests/substrate_tests/tags.rs
@@ -401,7 +401,7 @@ fn functions() {
         Target::Substrate,
     );
 
-    assert_eq!(ns.diagnostics.len(), 3);
+    assert_eq!(ns.diagnostics.len(), 5);
 
     assert_eq!(ns.functions[0].tags[0].tag, "param");
     assert_eq!(ns.functions[0].tags[0].value, "sadad");

--- a/tests/substrate_tests/tags.rs
+++ b/tests/substrate_tests/tags.rs
@@ -184,7 +184,8 @@ fn event_tag() {
         Target::Substrate,
     );
 
-    assert_eq!(ns.diagnostics.len(), 0);
+    //Event never emitted generates a warning
+    assert_eq!(ns.diagnostics.len(), 1);
 
     assert_eq!(ns.events[0].tags[0].tag, "param");
     assert_eq!(ns.events[0].tags[0].value, "asdad");
@@ -208,7 +209,8 @@ fn event_tag() {
         Target::Substrate,
     );
 
-    assert_eq!(ns.diagnostics.len(), 1);
+    //Event never emitted generates a warning
+    assert_eq!(ns.diagnostics.len(), 2);
 
     assert_eq!(ns.events[0].tags[0].tag, "title");
     assert_eq!(ns.events[0].tags[0].value, "foo bar");
@@ -399,7 +401,7 @@ fn functions() {
         Target::Substrate,
     );
 
-    assert_eq!(ns.diagnostics.len(), 2);
+    assert_eq!(ns.diagnostics.len(), 3);
 
     assert_eq!(ns.functions[0].tags[0].tag, "param");
     assert_eq!(ns.functions[0].tags[0].value, "sadad");
@@ -441,7 +443,8 @@ fn variables() {
         Target::Substrate,
     );
 
-    assert_eq!(ns.diagnostics.len(), 2);
+    //Variable 'y' has never been used (one item error in diagnostic)
+    assert_eq!(ns.diagnostics.len(), 3);
 
     assert_eq!(ns.contracts[0].variables[0].tags[0].tag, "notice");
     assert_eq!(ns.contracts[0].variables[0].tags[0].value, "so here we are");

--- a/tests/unused_variable_detection.rs
+++ b/tests/unused_variable_detection.rs
@@ -1,0 +1,901 @@
+use itertools::Itertools;
+use solang::file_cache::FileCache;
+use solang::sema::ast;
+use solang::sema::ast::{Diagnostic, Level};
+use solang::{parse_and_resolve, Target};
+
+fn generic_target_parse(src: &'static str) -> ast::Namespace {
+    let mut cache = FileCache::new();
+    cache.set_file_contents("test.sol", src.to_string());
+
+    parse_and_resolve("test.sol", &mut cache, Target::Generic)
+}
+
+fn generic_parse_two_files(src1: &'static str, src2: &'static str) -> ast::Namespace {
+    let mut cache = FileCache::new();
+    cache.set_file_contents("test.sol", src1.to_string());
+    cache.set_file_contents("test2.sol", src2.to_string());
+
+    parse_and_resolve("test.sol", &mut cache, Target::Generic)
+}
+
+fn count_warnings(diagnostics: &[Diagnostic]) -> usize {
+    diagnostics
+        .iter()
+        .filter(|&x| x.level == Level::Warning)
+        .count()
+}
+
+fn get_first_warning(diagnostics: &[Diagnostic]) -> &Diagnostic {
+    diagnostics
+        .iter()
+        .find_or_first(|&x| x.level == Level::Warning)
+        .unwrap()
+}
+
+fn get_warnings(diagnostics: &[Diagnostic]) -> Vec<&Diagnostic> {
+    let mut res = Vec::new();
+    for elem in diagnostics {
+        if elem.level == Level::Warning {
+            res.push(elem);
+        }
+    }
+
+    res
+}
+
+fn assert_message_in_warnings(diagnostics: &[Diagnostic], message: &str) -> bool {
+    let warnings = get_warnings(diagnostics);
+    for warning in warnings {
+        if warning.message == message {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[test]
+fn emit_event() {
+    //Used event
+    let case_1 = r#"
+    contract usedEvent {
+        event Hey(uint8 n);
+        function emitEvent(uint8 n) public {
+            emit Hey(n);
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(case_1);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+
+    // Unused event
+    let case_2 = r#"
+    contract usedEvent {
+        event Hey(uint8 n);
+        event Hello(uint8 n);
+        function emitEvent(uint8 n) public {
+            emit Hey(n);
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(case_2);
+    assert_eq!(count_warnings(&ns.diagnostics), 1);
+    assert_eq!(
+        get_first_warning(&ns.diagnostics).message,
+        "event 'Hello' has never been emitted"
+    );
+}
+
+#[test]
+fn constant_variable() {
+    let file_2 = r#"
+        uint32 constant outside = 2;
+    "#;
+
+    let file_1 = r#"
+        import "test2.sol";
+        contract Testing {
+            uint32 test;
+            uint32 constant cte = 5;
+            constructor() {
+                test = outside;
+                test = cte;
+            }
+
+            function get() public view returns (uint32) {
+                return test;
+            }
+        }
+    "#;
+
+    //Constant properly read
+    let ns = generic_parse_two_files(file_1, file_2);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+
+    let file_1 = r#"
+        import "test2.sol";
+        contract Testing {
+            uint32 test;
+            uint32 constant cte = 5;
+            constructor() {
+                test = 45;
+            }
+
+            function get() public view returns (uint32) {
+                return test;
+            }
+        }
+    "#;
+
+    let ns = generic_parse_two_files(file_1, file_2);
+    assert_eq!(count_warnings(&ns.diagnostics), 2);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'cte' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "global constant 'outside' has never been used"
+    ));
+}
+
+#[test]
+fn storage_variable() {
+    let file = r#"
+        contract Test {
+            string str = "This is a test";
+            string str2;
+            constructor() {
+                str = "This is another test";
+            }
+        }
+    "#;
+
+    let ns = generic_target_parse(file);
+    let warnings = get_warnings(&ns.diagnostics);
+    assert_eq!(warnings.len(), 2);
+    assert_eq!(
+        warnings[0].message,
+        "storage variable 'str' has been assigned, but never read"
+    );
+    assert_eq!(
+        warnings[1].message,
+        "storage variable 'str2' has never been used"
+    );
+
+    let file = r#"
+        contract Test {
+            string str = "This is a test";
+            string str2;
+            constructor() {
+                str = "This is another test";
+                str2 = str;
+            }
+        }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 1);
+    assert_eq!(
+        get_first_warning(&ns.diagnostics).message,
+        "storage variable 'str2' has been assigned, but never read"
+    );
+
+    let file = r#"
+        contract Test {
+            string str = "This is a test";
+            constructor() {
+                str = "This is another test";
+            }
+        }
+
+        contract Test2 is Test {
+            function get() public view returns (string) {
+                return str;
+            }
+        }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn state_variable() {
+    let file = r#"
+        contract Test {
+            function get() public pure {
+                uint32 a = 1;
+                uint32 b;
+                b = 1;
+                uint32 c;
+
+                uint32 d;
+                d = 1;
+                uint32 e;
+                e = d*5;
+                d = e/5;
+            }
+        }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 3);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'b' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'a' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'c' has never been read nor assigned"
+    ));
+}
+
+#[test]
+fn struct_usage() {
+    let file = r#"
+        struct testing {
+            uint8 it;
+            bool tf;
+        }
+
+        contract Test {
+            testing t1;
+            testing t4;
+            testing t6;
+            constructor() {
+                t1 = testing(8, false);
+            }
+
+            function modify() public returns (uint8) {
+                testing memory t2;
+                t2.it = 4;
+
+
+                t4 = testing(1, true);
+                testing storage t3 = t4;
+                uint8 k = 2*4/t3.it;
+                testing t5;
+
+               return k;
+            }
+        }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 4);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 't2' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 't1' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 't5' has never been read nor assigned"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 't6' has never been used"
+    ));
+}
+
+#[test]
+fn subscript() {
+    let file = r#"
+        contract Test {
+            int[] arr1;
+            int[4] arr2;
+            int[4] arr3;
+            bytes byteArr;
+
+            uint constant e = 1;
+
+            function get() public {
+                uint8 a = 1;
+                uint8 b = 2;
+
+                arr1[a] = 1;
+                arr2[a+b] = 2;
+
+                uint8 c = 1;
+                uint8 d = 1;
+                int[] memory arr4;
+                arr4[0] = 1;
+                int[4] storage arr5 = arr3;
+                arr5[c*d] = 1;
+
+                byteArr[e] = 0x05;
+            }
+        }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 5);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'arr4' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'arr5' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'arr1' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'arr2' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'byteArr' has been assigned, but never read"
+    ));
+
+    let file = r#"
+        contract Test {
+            int[] arr1;
+            int[4] arr2;
+            int[4] arr3;
+            bytes byteArr;
+
+            uint constant e = 1;
+
+            function get() public {
+                uint8 a = 1;
+                uint8 b = 2;
+
+                arr1[a] = 1;
+                arr2[a+b] = 2;
+                assert(arr1[a] == arr2[b]);
+
+                uint8 c = 1;
+                uint8 d = 1;
+                int[] memory arr4;
+                arr4[0] = 1;
+                int[4] storage arr5 = arr3;
+                arr5[c*d] = 1;
+                assert(arr4[c] == arr5[d]);
+                assert(arr3[c] == arr5[d]);
+
+                byteArr[e] = 0x05;
+                assert(byteArr[e] == byteArr[e]);
+            }
+        }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn assign_trunc_cast() {
+    //This covers ZeroExt as well
+    let file = r#"
+    contract Test {
+        bytes byteArr;
+        bytes32 baRR;
+
+        function get() public  {
+            string memory s = "Test";
+            byteArr = bytes(s);
+            uint16 a = 1;
+            uint8 b;
+            b = uint8(a);
+
+            uint256 c;
+            c = b;
+            bytes32 b32;
+            bytes memory char = bytes(bytes32(uint(a) * 2 ** (8 * b)));
+            baRR = bytes32(c);
+            bytes32 cdr = bytes32(char);
+            assert(b32 == baRR);
+            if(b32 != cdr) {
+
+            }
+        }
+    }
+"#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 2);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'b32' has never been assigned a value, but has been read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'byteArr' has been assigned, but never read"
+    ));
+}
+
+#[test]
+fn array_length() {
+    let file = r#"
+        contract Test {
+        int[5] arr1;
+        int[] arr2;
+
+        function get() public view returns (bool) {
+            int[5] memory arr3;
+            int[] memory arr4;
+
+            bool test = false;
+            if(arr1.length == arr2.length) {
+                test = true;
+            }
+            else if(arr3.length != arr4.length) {
+                test = false;
+            }
+
+            return test;
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 2);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'arr3' has never been assigned a value, but has been read",
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'arr4' has never been assigned a value, but has been read"
+    ));
+}
+
+#[test]
+fn sign_ext_storage_load() {
+    let file = r#"
+        contract Test {
+        bytes a;
+
+        function use(bytes memory b) pure public {
+            assert(b[0] == b[1]);
+        }
+
+        function get() public pure returns (int16 ret) {
+            use(a);
+
+            int8 b = 1;
+            int16 c = 1;
+            int16 d;
+            d = c << b;
+            ret = d;
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn statements() {
+    let file = r#"
+    contract AddNumbers { function add(uint256 a, uint256 b) external pure returns (uint256 c) {c = b;} }
+    contract Example {
+        AddNumbers addContract;
+        event StringFailure(string stringFailure);
+        event BytesFailure(bytes bytesFailure);
+
+        function exampleFunction(uint256 _a, uint256 _b) public returns (uint256 _c) {
+
+            try addContract.add(_a, _b) returns (uint256 _value) {
+                return (_value);
+            } catch Error(string memory _err) {
+                // This may occur if there is an overflow with the two numbers and the `AddNumbers` contract explicitly fails with a `revert()`
+                emit StringFailure(_err);
+            } catch (bytes memory _err) {
+                emit BytesFailure(_err);
+            }
+        }
+
+        function testFunction() pure public {
+            int three = 3;
+             {
+                 int test = 2;
+                 int c = test*3;
+
+                 while(c != test) {
+                     c -= three;
+                 }
+             }
+
+             int four = 4;
+             int test = 3;
+             do {
+                int ct = 2;
+             } while(four > test);
+
+        }
+
+         function bytesToUInt(uint v) public pure returns (uint ret) {
+        if (v == 0) {
+            ret = 0;
+        }
+        else {
+            while (v > 0) {
+                ret = uint(uint(ret) / (2 ** 8));
+                ret |= uint(((v % 10) + 48) * 2 ** (8 * 31));
+                v /= 10;
+            }
+        }
+        return ret;
+    }
+
+        function stringToUint(string s) public pure returns (uint result) {
+            bytes memory b = bytes(s);
+            uint i;
+            result = 0;
+            for (i = 0; i < b.length; i++) {
+                uint c = uint(b[i]);
+                if (c >= 48 && c <= 57) {
+                    result = result * 10 + (c - 48);
+                }
+            }
+        }
+    }
+    "#;
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 2);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "function parameter 'a' has never been read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'ct' has been assigned, but never read",
+    ));
+}
+
+#[test]
+fn function_call() {
+    let file = r#"
+    contract Test1 {
+        uint32 public a;
+
+        constructor(uint32 b) {
+            a = b;
+        }
+
+    }
+
+    contract Test2{
+        function test(uint32 v1, uint32 v2) private returns (uint32) {
+            uint32 v = 1;
+            Test1 t = new Test1(v);
+            uint32[2] memory vec = [v2, v1];
+
+            return vec[0] + t.a();
+        }
+
+        function callTest() public {
+            uint32 ta = 1;
+            uint32 tb = 2;
+
+            ta = test(ta, tb);
+        }
+    }
+
+    contract C {
+        uint public data;
+        function x() public returns (uint) {
+            data = 3;
+            return this.data();
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+
+    let file = r#"
+    contract Test1 {
+        uint32 public a;
+
+        constructor(uint32 b) {
+            a = b;
+        }
+
+    }
+
+    contract Test2 is Test1{
+
+        constructor(uint32 val) Test1(val) {}
+
+        function test(uint32 v1, uint32 v2) private returns (uint32) {
+            uint32 v = 1;
+            Test1 t = new Test1(v);
+            uint32[2] memory vec = [v2, v1];
+
+            return vec[0] + t.a();
+        }
+
+        function callTest() public {
+            uint32 ta = 1;
+            uint32 tb = 2;
+
+            ta = test(ta, tb);
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn array_push_pop() {
+    let file = r#"
+        contract Test1 {
+        uint32[] vec1;
+
+        function testVec() public {
+            uint32 a = 1;
+            uint32 b = 2;
+            uint32[] memory vec2;
+
+            vec1.push(a);
+            vec2.push(b);
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 2);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'vec2' has been assigned, but never read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'vec1' has been assigned, but never read"
+    ));
+
+    let file = r#"
+        contract Test1 {
+        uint32[] vec1;
+
+        function testVec() public {
+            uint32 a = 1;
+            uint32 b = 2;
+            uint32[] memory vec2;
+
+            vec1.push(a);
+            vec2.push(b);
+            vec1.pop();
+            vec2.pop();
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn return_variable() {
+    let file = r#"
+    contract Test1 {
+    string testing;
+
+    function test1() public pure returns (uint32 ret, string memory ret2) {
+        return (2, "Testing is fun");
+    }
+
+    function test2() public returns (uint32 hey) {
+
+        (uint32 a, string memory t) = test1();
+        testing = t;
+
+    }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 3);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "destructure variable 'a' has never been used"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "return variable 'hey' has never been assigned"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'testing' has been assigned, but never read"
+    ));
+}
+
+#[test]
+fn try_catch() {
+    let file = r#"
+    contract CalledContract {}
+
+    contract TryCatcher {
+
+       event SuccessEvent(bool t);
+       event CatchEvent(bool t);
+
+        function execute() public {
+
+            try new CalledContract() returns(CalledContract returnedInstance) {
+                emit SuccessEvent(true);
+            }  catch Error(string memory revertReason) {
+                emit CatchEvent(true);
+            } catch (bytes memory returnData) {
+                emit CatchEvent(false);
+            }
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 3);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "try-catch error bytes 'returnData' has never been used"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "try-catch returns variable 'returnedInstance' has never been read"
+    ));
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "try-catch error string 'revertReason' has never been used"
+    ));
+
+    let file = r#"
+    contract CalledContract {
+        bool public ok = true;
+        bool public notOk = false;
+    }
+
+    contract TryCatcher {
+
+       event SuccessEvent(bool t);
+       event CatchEvent(string t);
+       event CatchBytes(bytes t);
+
+        function execute() public {
+
+            try new CalledContract() returns(CalledContract returnedInstance) {
+                // returnedInstance can be used to obtain the address of the newly deployed contract
+                emit SuccessEvent(returnedInstance.ok());
+            }  catch Error(string memory revertReason) {
+                emit CatchEvent(revertReason);
+            } catch (bytes memory returnData) {
+                emit CatchBytes(returnData);
+            }
+        }
+      }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 1);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'notOk' has been assigned, but never read"
+    ));
+}
+
+#[test]
+fn destructure() {
+    let file = r#"
+       contract Test2{
+
+            function callTest() public view returns (uint32 ret) {
+                uint32 ta = 1;
+                uint32 tb = 2;
+                uint32 te = 3;
+
+                string memory tc = "hey";
+                bytes memory td = bytes(tc);
+                address nameReg = address(this);
+                (bool tf,) = nameReg.call(td);
+
+
+                ta = tf? tb : te;
+                uint8 tg = 1;
+                uint8 th = 2;
+                (tg, th) = (th, tg);
+                return ta;
+            }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn struct_initialization() {
+    let file = r#"
+        contract Test1{
+        struct Test2{
+            uint8 a;
+            uint8 b;
+        }
+
+        function callTest() public pure returns (uint32 ret) {
+            uint8 tg = 1;
+            uint8 th = 2;
+
+            Test2 memory t2;
+            t2 = Test2(tg, th);
+            ret = t2.a;
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn subarray_mapping_struct_literal() {
+    let file = r#"
+        contract T {
+        int p;
+        constructor(int b) {
+            p = b;
+        }
+
+        function sum(int a, int b) virtual public returns (int){
+            uint8 v1 = 1;
+            uint8 v2 = 2;
+            uint8 v3 = 3;
+            uint8 v4 = 4;
+            uint8[2][2] memory v = [[v1, v2], [v3, v4]];
+            return a + b * p/v[0][1];
+        }
+    }
+
+    contract Test is T(2){
+
+        struct fooStruct {
+            int foo;
+            int figther;
+        }
+        mapping(string => int) public mp;
+        enum FreshJuiceSize{ SMALL, MEDIUM, LARGE }
+        FreshJuiceSize choice;
+
+        function sum(int a, int b) override public returns (int) {
+            choice = FreshJuiceSize.LARGE;
+            return a*b;
+        }
+
+        function test() public returns (int){
+            int a = 1;
+            int b = 2;
+            int c = super.sum(a, b);
+            int d = 3;
+            fooStruct memory myStruct = fooStruct({foo: c, figther: d});
+            string memory t = "Do some tests";
+            mp[t] = myStruct.figther;
+            return mp[t];
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 1);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "storage variable 'choice' has been assigned, but never read"
+    ));
+}


### PR DESCRIPTION
This pull request implements unused variable detection for the Solang compiler.
It generates warnings for unused state variables, global constants and contract storage.
As a bonus, I implemented the detection of events that have never been emitted.

This PR also implements tests for the new code.

This is the first milestone for the Linux Foundation mentorship on the Solang compiler.
For more information, please refer to the [project plan](https://wiki.hyperledger.org/display/INTERN/Project+plan+-+Solang+compiler+passes+2021).