### PR TITLE
Add detection of variables in builtin calls and function calls with gas and value

### DIFF
--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -7,7 +7,7 @@ use super::expression::{
 use super::symtable::{LoopScopes, Symtable};
 use crate::parser::pt;
 use crate::sema::symtable::VariableUsage;
-use crate::sema::unused_variable::{check_function_call, used_variable};
+use crate::sema::unused_variable::{assigned_variable, check_function_call, used_variable};
 use std::collections::HashMap;
 
 pub fn resolve_function_body(
@@ -1189,6 +1189,8 @@ fn destructure(
                         }
                     },
                 }
+
+                assigned_variable(ns, &e, symtable);
                 left_tys.push(Some(e.ty()));
                 fields.push(DestructureField::Expression(e));
             }

--- a/tests/unused_variable_detection.rs
+++ b/tests/unused_variable_detection.rs
@@ -899,3 +899,33 @@ fn subarray_mapping_struct_literal() {
         "storage variable 'choice' has been assigned, but never read"
     ));
 }
+
+#[test]
+fn builtin_call_destructure() {
+    let file = r#"
+        contract Test {
+
+        function test() public returns(bool p) {
+            uint128 b = 1;
+            uint64 g = 2;
+            address payable ad = payable(address(this));
+            bytes memory by;
+            (p, ) = ad.call{value: b, gas: g}(by);
+            uint c = 1;
+            abi.encodeWithSignature("hey", c);
+
+            uint128 amount = 2;
+            ad.send(amount);
+            uint128 amount2 = 1;
+            ad.transfer(amount2);
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 1);
+    assert!(assert_message_in_warnings(
+        &ns.diagnostics,
+        "local variable 'by' has never been assigned a value, but has been read"
+    ));
+}


### PR DESCRIPTION
This PR adds the detection of used variables in builtin calls (like transfer and send) and function calls with gas and value.
These cases were not covered in the [original PR](https://github.com/hyperledger-labs/solang/pull/429) that implements unused variable detection, thus Solang are detecting variables used in such cases as unused.

