### PR TITLE
Check used variables in delete statement

### DIFF
--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -767,7 +767,7 @@ fn statement(
                     diagnostics,
                     None,
                 )?;
-
+                used_variable(ns, &expr, symtable);
                 return if let Type::StorageRef(ty) = expr.ty() {
                     if expr.ty().is_mapping() {
                         ns.diagnostics.push(Diagnostic::error(

--- a/tests/unused_variable_detection.rs
+++ b/tests/unused_variable_detection.rs
@@ -929,3 +929,21 @@ fn builtin_call_destructure() {
         "local variable 'by' has never been assigned a value, but has been read"
     ));
 }
+
+#[test]
+fn delete_statement() {
+    let file = r#"
+    pragma solidity 0;
+
+    contract Test1{
+        int test8var;
+        function test8() public {
+            delete test8var;
+        test8var = 2;
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}


### PR DESCRIPTION
This PR detects used variables in a `delete` statement. This is a fix for the[ Unused variable detection PR](https://github.com/hyperledger-labs/solang/pull/429).