### PR TITLE
Check used variables in Load expression and length call

### DIFF
--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -4415,6 +4415,9 @@ fn member_access(
     match expr_ty {
         Type::Bytes(n) => {
             if id.name == "length" {
+                //We should not eliminate an array from the code when 'length' is called
+                //So the variable is also assigned a value to be read from 'length'
+                assigned_variable(ns, &expr, symtable);
                 used_variable(ns, &expr, symtable);
                 return Ok(Expression::NumberLiteral(
                     *loc,
@@ -4428,6 +4431,9 @@ fn member_access(
                 return match dim.last().unwrap() {
                     None => Ok(Expression::DynamicArrayLength(*loc, Box::new(expr))),
                     Some(d) => {
+                        //We should not eliminate an array from the code when 'length' is called
+                        //So the variable is also assigned a value to be read from 'length'
+                        assigned_variable(ns, &expr, symtable);
                         used_variable(ns, &expr, symtable);
                         bigint_to_expression(loc, d, ns, diagnostics, Some(&Type::Uint(32)))
                     }

--- a/src/sema/unused_variable.rs
+++ b/src/sema/unused_variable.rs
@@ -80,10 +80,14 @@ pub fn used_variable(ns: &mut Namespace, exp: &Expression, symtable: &mut Symtab
             array,
             ..
         } => {
+            //We should not eliminate an array from the code when 'length' is called
+            //So the variable is also assigned
+            assigned_variable(ns, array, symtable);
             used_variable(ns, array, symtable);
         }
 
         Expression::StorageLoad(_, _, expr)
+        | Expression::Load(_, _, expr)
         | Expression::SignExt(_, _, expr)
         | Expression::ZeroExt(_, _, expr)
         | Expression::Trunc(_, _, expr)

--- a/tests/unused_variable_detection.rs
+++ b/tests/unused_variable_detection.rs
@@ -444,15 +444,7 @@ fn array_length() {
     "#;
 
     let ns = generic_target_parse(file);
-    assert_eq!(count_warnings(&ns.diagnostics), 2);
-    assert!(assert_message_in_warnings(
-        &ns.diagnostics,
-        "local variable 'arr3' has never been assigned a value, but has been read",
-    ));
-    assert!(assert_message_in_warnings(
-        &ns.diagnostics,
-        "local variable 'arr4' has never been assigned a value, but has been read"
-    ));
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
 }
 
 #[test]
@@ -940,6 +932,30 @@ fn delete_statement() {
         function test8() public {
             delete test8var;
         test8var = 2;
+        }
+    }
+    "#;
+
+    let ns = generic_target_parse(file);
+    assert_eq!(count_warnings(&ns.diagnostics), 0);
+}
+
+#[test]
+fn load_length() {
+    let file = r#"
+        contract foo {
+        function f(uint i1) public pure returns (int) {
+            int[8] bar = [ int(10), 20, 30, 4, 5, 6, 7, 8 ];
+
+            bar[2] = 0x7_f;
+
+            return bar[i1];
+        }
+
+        function barfunc() public pure returns (uint) {
+            uint[2][3][4] array;
+
+            return array.length;
         }
     }
     "#;


### PR DESCRIPTION
This PR implements the used variable detection for the `Load` expression and marks arrays as assigned when there is a `length` call. The latter is necessary to prevent array being removed from the intermediary representation.