### PR TITLE
Unused variable elimination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,13 +60,13 @@ jobs:
     - name: Add LLVM to Path
       run: echo "c:\llvm11.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --release
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --release
     - uses: actions/upload-artifact@master
       with:
         name: solang.exe
-        path: ./target/debug/solang.exe
+        path: ./target/release/solang.exe
 
   mac:
     name: Mac

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1258,7 +1258,8 @@ fn function_cfg(
                     .iter()
                     .enumerate()
                     .map(|(i, a)| {
-                        let expr = expression(a, &mut cfg, contract_no, ns, &mut vartab);
+                        let expr =
+                            expression(a, &mut cfg, contract_no, Some(func), ns, &mut vartab);
 
                         if let Some(id) = &func.symtable.arguments[i] {
                             let ty = expr.ty();
@@ -1400,7 +1401,7 @@ pub fn generate_modifier_dispatch(
     // now set the modifier args
     for (i, arg) in modifier.symtable.arguments.iter().enumerate() {
         if let Some(pos) = arg {
-            let expr = expression(&args[i], &mut cfg, contract_no, ns, &mut vartab);
+            let expr = expression(&args[i], &mut cfg, contract_no, Some(func), ns, &mut vartab);
             cfg.add(
                 &mut vartab,
                 Instr::Set {

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -172,6 +172,7 @@ pub fn expression(
                 .collect(),
         ),
         Expression::Assign(_, _, left, right) => {
+            // If we reach this condition, the assignment is inside an expression.
             if let Some(function) = func {
                 if should_remove_assignment(ns, left, function) {
                     return expression(right, cfg, contract_no, func, ns, vartab);
@@ -1080,9 +1081,9 @@ pub fn expression(
         Expression::Ternary(loc, ty, cond, left, right) => Expression::Ternary(
             *loc,
             ty.clone(),
-            Box::new(expression(cond, cfg, contract_no, ns, vartab)),
-            Box::new(expression(left, cfg, contract_no, ns, vartab)),
-            Box::new(expression(right, cfg, contract_no, ns, vartab)),
+            Box::new(expression(cond, cfg, contract_no, func, ns, vartab)),
+            Box::new(expression(left, cfg, contract_no, func, ns, vartab)),
+            Box::new(expression(right, cfg, contract_no, func, ns, vartab)),
         ),
         _ => expr.clone(),
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -7,6 +7,7 @@ mod reaching_definitions;
 mod statements;
 mod storage;
 mod strength_reduce;
+mod unused_variable;
 mod vector_to_slice;
 
 use self::cfg::{optimize, ControlFlowGraph, Instr, Vartable};
@@ -104,7 +105,7 @@ fn storage_initializer(contract_no: usize, ns: &mut Namespace, opt: &Options) ->
             let storage =
                 ns.contracts[contract_no].get_storage_slot(layout.contract_no, layout.var_no, ns);
 
-            let value = expression(&init, &mut cfg, contract_no, ns, &mut vartab);
+            let value = expression(&init, &mut cfg, contract_no, None, ns, &mut vartab);
 
             cfg.add(
                 &mut vartab,

--- a/src/codegen/unused_variable.rs
+++ b/src/codegen/unused_variable.rs
@@ -1,0 +1,86 @@
+use crate::codegen::cfg::{ControlFlowGraph, Vartable};
+use crate::parser::pt;
+use crate::sema::ast::{Expression, Function, Namespace};
+use crate::sema::symtable::VariableUsage;
+
+pub struct SideEffectsCheckParameters<'a> {
+    pub cfg: &'a mut ControlFlowGraph,
+    pub contract_no: usize,
+    pub func: Option<&'a Function>,
+    pub ns: &'a Namespace,
+    pub vartab: &'a mut Vartable,
+}
+
+pub fn should_remove_assignment(ns: &Namespace, exp: &Expression, func: &Function) -> bool {
+    match &exp {
+        Expression::StorageVariable(_, _, contract_no, offset) => {
+            let var = &ns.contracts[*contract_no].variables[*offset];
+            if matches!(
+                var.visibility,
+                pt::Visibility::Public(_) | pt::Visibility::External(_)
+            ) {
+                return false;
+            }
+
+            !var.read
+        }
+
+        Expression::Variable(_, _, offset) => should_remove_variable(
+            offset,
+            func,
+            func.symtable.vars.get(offset).unwrap().initializer.as_ref(),
+        ),
+
+        Expression::StructMember(_, _, str, _) => should_remove_assignment(ns, str, func),
+
+        Expression::Subscript(_, _, array, _)
+        | Expression::DynamicArraySubscript(_, _, array, _)
+        | Expression::StorageBytesSubscript(_, array, _) => {
+            should_remove_assignment(ns, array, func)
+        }
+
+        Expression::StorageLoad(_, _, expr)
+        | Expression::Load(_, _, expr)
+        | Expression::Trunc(_, _, expr)
+        | Expression::Cast(_, _, expr)
+        | Expression::BytesCast(_, _, _, expr) => should_remove_assignment(ns, expr, func),
+
+        _ => true,
+    }
+}
+
+pub fn should_remove_variable(
+    pos: &usize,
+    func: &Function,
+    initializer: Option<&Expression>,
+) -> bool {
+    let var = func.symtable.vars.get(pos).unwrap();
+    if !var.read && !var.assigned {
+        return true;
+    }
+
+    if !var.read
+        && var.assigned
+        && matches!(
+            var.usage_type,
+            VariableUsage::DestructureVariable | VariableUsage::LocalVariable
+        )
+    {
+        if !matches!(
+            var.storage_location,
+            Some(pt::StorageLocation::Memory(_)) | Some(pt::StorageLocation::Storage(_))
+        ) {
+            return true;
+        } else if let Some(expr) = initializer {
+            return match expr {
+                Expression::AllocDynamicArray(..)
+                | Expression::Constructor { .. }
+                | Expression::StructLiteral(..) => true,
+
+                _ => false,
+            };
+        }
+    }
+
+    false
+}

--- a/src/codegen/unused_variable.rs
+++ b/src/codegen/unused_variable.rs
@@ -3,6 +3,8 @@ use crate::parser::pt;
 use crate::sema::ast::{Expression, Function, Namespace};
 use crate::sema::symtable::VariableUsage;
 
+/// This struct saves the parameters to call 'check_side_effects_expressions'
+/// using 'expression.recurse'
 pub struct SideEffectsCheckParameters<'a> {
     pub cfg: &'a mut ControlFlowGraph,
     pub contract_no: usize,
@@ -11,16 +13,12 @@ pub struct SideEffectsCheckParameters<'a> {
     pub vartab: &'a mut Vartable,
 }
 
+/// Check if we should remove an assignment. The expression in the argument is the left-hand side
+/// of the assignment
 pub fn should_remove_assignment(ns: &Namespace, exp: &Expression, func: &Function) -> bool {
     match &exp {
         Expression::StorageVariable(_, _, contract_no, offset) => {
             let var = &ns.contracts[*contract_no].variables[*offset];
-            if matches!(
-                var.visibility,
-                pt::Visibility::Public(_) | pt::Visibility::External(_)
-            ) {
-                return false;
-            }
 
             !var.read
         }
@@ -45,20 +43,25 @@ pub fn should_remove_assignment(ns: &Namespace, exp: &Expression, func: &Functio
         | Expression::Cast(_, _, expr)
         | Expression::BytesCast(_, _, _, expr) => should_remove_assignment(ns, expr, func),
 
-        _ => true,
+        _ => false,
     }
 }
 
+/// Checks if we should remove a variable
 pub fn should_remove_variable(
     pos: &usize,
     func: &Function,
     initializer: Option<&Expression>,
 ) -> bool {
-    let var = func.symtable.vars.get(pos).unwrap();
+    let var = &func.symtable.vars[pos];
+
+    //If the variable has never been read nor assigned, we can remove it right away.
     if !var.read && !var.assigned {
         return true;
     }
 
+    // If the variable has been assigned, we must detect special cases
+    // Parameters and return variable cannot be removed
     if !var.read
         && var.assigned
         && matches!(
@@ -66,19 +69,23 @@ pub fn should_remove_variable(
             VariableUsage::DestructureVariable | VariableUsage::LocalVariable
         )
     {
+        // If the variable has the memory or storage keyword, it can be a reference to another variable.
+        // In this case, an assigment may change the value of the variable it is referencing.
         if !matches!(
             var.storage_location,
             Some(pt::StorageLocation::Memory(_)) | Some(pt::StorageLocation::Storage(_))
         ) {
             return true;
         } else if let Some(expr) = initializer {
-            return match expr {
+            // We can only remove variable with memory and storage keywords if the initializer is
+            // an array allocation, a constructor and a struct literal (only available in the local scope),
+            return matches!(
+                expr,
                 Expression::AllocDynamicArray(..)
-                | Expression::Constructor { .. }
-                | Expression::StructLiteral(..) => true,
-
-                _ => false,
-            };
+                    | Expression::ArrayLiteral(..)
+                    | Expression::Constructor { .. }
+                    | Expression::StructLiteral(..)
+            );
         }
     }
 

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -4753,7 +4753,7 @@ fn member_access(
                         return Err(());
                     }
                 }
-
+                used_variable(ns, &expr, symtable);
                 return Ok(Expression::Builtin(
                     *loc,
                     vec![Type::Value],

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -4814,6 +4814,7 @@ fn member_access(
         }
         Type::ExternalFunction { .. } => {
             if id.name == "address" {
+                used_variable(ns, &expr, symtable);
                 return Ok(Expression::Builtin(
                     e.loc(),
                     vec![Type::Address(false)],
@@ -4822,6 +4823,7 @@ fn member_access(
                 ));
             }
             if id.name == "selector" {
+                used_variable(ns, &expr, symtable);
                 return Ok(Expression::Builtin(
                     e.loc(),
                     vec![Type::Bytes(4)],

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -29,8 +29,9 @@ pub fn resolve_function_body(
                 name,
                 ns.functions[function_no].params[i].ty.clone(),
                 ns,
-                true,
+                None,
                 VariableUsage::Parameter,
+                p.storage.clone(),
             ) {
                 ns.check_shadowing(file_no, contract_no, name);
 
@@ -191,8 +192,9 @@ pub fn resolve_function_body(
                 name,
                 ret.ty.clone(),
                 ns,
-                false,
+                None,
                 VariableUsage::ReturnVariable,
+                None,
             ) {
                 ns.check_shadowing(file_no, contract_no, name);
                 symtable.returns.push(pos);
@@ -209,8 +211,9 @@ pub fn resolve_function_body(
                     &id,
                     ret.ty.clone(),
                     ns,
-                    true,
+                    None,
                     VariableUsage::AnonymousReturnVariable,
+                    None,
                 )
                 .unwrap();
 
@@ -345,8 +348,9 @@ fn statement(
                 &decl.name,
                 var_ty.clone(),
                 ns,
-                initializer.is_some(),
+                initializer.clone(),
                 VariableUsage::LocalVariable,
+                decl.storage.clone(),
             ) {
                 ns.check_shadowing(file_no, contract_no, &decl.name);
 
@@ -1235,8 +1239,9 @@ fn destructure(
                     &name,
                     ty.clone(),
                     ns,
-                    true,
+                    None,
                     VariableUsage::DestructureVariable,
+                    storage.clone(),
                 ) {
                     ns.check_shadowing(file_no, contract_no, &name);
 
@@ -1867,8 +1872,9 @@ fn try_catch(
                         &name,
                         ret_ty.clone(),
                         ns,
-                        false,
+                        None,
                         VariableUsage::TryCatchReturns,
+                        storage.clone(),
                     ) {
                         ns.check_shadowing(file_no, contract_no, &name);
                         params.push((
@@ -1976,8 +1982,9 @@ fn try_catch(
                 &name,
                 Type::String,
                 ns,
-                true,
+                None,
                 VariableUsage::TryCatchErrorString,
+                error_stmt.1.storage.clone(),
             ) {
                 ns.check_shadowing(file_no, contract_no, &name);
 
@@ -2042,9 +2049,14 @@ fn try_catch(
     let mut catch_stmt_resolved = Vec::new();
 
     if let Some(name) = &catch_stmt.0.name {
-        if let Some(pos) =
-            symtable.add(&name, catch_ty, ns, true, VariableUsage::TryCatchErrorBytes)
-        {
+        if let Some(pos) = symtable.add(
+            &name,
+            catch_ty,
+            ns,
+            None,
+            VariableUsage::TryCatchErrorBytes,
+            catch_stmt.0.storage.clone(),
+        ) {
             ns.check_shadowing(file_no, contract_no, &name);
             catch_param_pos = Some(pos);
             catch_param.name = name.name.to_string();

--- a/src/sema/symtable.rs
+++ b/src/sema/symtable.rs
@@ -5,6 +5,7 @@ use std::str;
 
 use super::ast::{Diagnostic, Namespace, Type};
 use crate::parser::pt;
+use crate::sema::ast::Expression;
 
 #[derive(Clone)]
 pub struct Variable {
@@ -15,6 +16,8 @@ pub struct Variable {
     pub assigned: bool,
     pub read: bool,
     pub usage_type: VariableUsage,
+    pub initializer: Option<Expression>,
+    pub storage_location: Option<pt::StorageLocation>,
 }
 
 #[derive(Clone)]
@@ -56,8 +59,9 @@ impl Symtable {
         id: &pt::Identifier,
         ty: Type,
         ns: &mut Namespace,
-        assigned: bool,
+        initializer: Option<Expression>,
         usage_type: VariableUsage,
+        storage_location: Option<pt::StorageLocation>,
     ) -> Option<usize> {
         let pos = ns.next_id;
         ns.next_id += 1;
@@ -69,9 +73,11 @@ impl Symtable {
                 ty,
                 pos,
                 slice: false,
-                assigned,
+                initializer,
+                assigned: false,
                 usage_type,
                 read: false,
+                storage_location,
             },
         );
 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -34,7 +34,8 @@ fn testcase(path: PathBuf) {
     let mut checks = Vec::new();
     let mut fails = Vec::new();
     for line in reader.lines() {
-        let line = line.unwrap();
+        let mut line = line.unwrap();
+        line = line.trim().parse().unwrap();
         if let Some(args) = line.strip_prefix("// RUN: ") {
             assert_eq!(command_line, None);
 

--- a/tests/codegen_testcases/dead_storage.sol
+++ b/tests/codegen_testcases/dead_storage.sol
@@ -36,9 +36,10 @@ contract deadstorage {
    // two successive stores are redundant
 // BEGIN-CHECK: deadstorage::function::test4
     int b;
-	function test4() public {
+	function test4() public returns (int) {
 		b = 511;
 	    b = 512;
+        return b;
 	}
 // CHECK: store storage slot(uint256 1)
 // NOT-CHECK: store storage slot(uint256 1)
@@ -46,13 +47,15 @@ contract deadstorage {
    // stores in a previous block are always redundant
 // BEGIN-CHECK: deadstorage::function::test5
     int test5var;
-	function test5(bool c) public {
+	function test5(bool c) public returns (int) {
         if (c) {
             test5var = 1;
         } else {
             test5var = 2;
         }
         test5var = 3;
+
+        return test5var;
 	}
 // CHECK: store storage slot(uint256 2)
 // NOT-CHECK: store storage slot(uint256 2)
@@ -60,10 +63,11 @@ contract deadstorage {
 // BEGIN-CHECK: deadstorage::function::test6
     // store/load are not merged yet. Make sure that we have a store before a load
     int test6var;
-    function test6() public {
+    function test6() public returns (int) {
         test6var = 1;
         int f = test6var;
         test6var = 2;
+        return test6var + f;
     }
 // CHECK: store storage slot(uint256 3)
 // CHECK: store storage slot(uint256 3)
@@ -71,10 +75,11 @@ contract deadstorage {
 // BEGIN-CHECK: deadstorage::function::test7
     // storage should be flushed before function call
     int test7var;
-    function test7() public {
+    function test7() public returns (int) {
         test7var = 1;
         test6();
         test7var = 2;
+        return test7var;
     }
 // CHECK: store storage slot(uint256 4)
 // CHECK: store storage slot(uint256 4)
@@ -92,12 +97,14 @@ contract deadstorage {
 // BEGIN-CHECK: deadstorage::function::test9
     // push should make both load/stores not redundant
     bytes test9var;
-    function test9() public {
+    function test9() public returns (bytes){
         test9var = "a";
         bytes f = test9var;
         test9var.push(hex"01");
         f = test9var;
         test9var = "c";
+
+        return f;
     }
 // CHECK: store storage slot(uint256 6)
 // CHECK: load storage slot(uint256 6)
@@ -108,12 +115,14 @@ contract deadstorage {
 // BEGIN-CHECK: deadstorage::function::test10
     // pop should make both load/stores not redundant
     bytes test10var;
-    function test10() public {
+    function test10() public returns (bytes) {
         test10var = "a";
         bytes f = test10var;
         test10var.pop();
         f = test10var;
         test10var = "c";
+
+        return f;
     }
 // CHECK: store storage slot(uint256 7)
 // CHECK: load storage slot(uint256 7)

--- a/tests/codegen_testcases/slice1.sol
+++ b/tests/codegen_testcases/slice1.sol
@@ -1,10 +1,11 @@
 // RUN: --emit cfg
 contract c {
 // BEGIN-CHECK: c::function::test1
-	function test1() public pure {
+	function test1() public pure{
 		bytes x = "foo1";
 		// x is not being used, so it can be a slice
-// CHECK:
+// CHECK: alloc slice uint32 4 "foo1"
+	bytes y = x;
 	}
 
 // BEGIN-CHECK: c::function::test2

--- a/tests/codegen_testcases/slice1.sol
+++ b/tests/codegen_testcases/slice1.sol
@@ -4,14 +4,15 @@ contract c {
 	function test1() public pure {
 		bytes x = "foo1";
 		// x is not being used, so it can be a slice
-// CHECK: alloc slice uint32 4 "foo1"
+// CHECK:
 	}
 
 // BEGIN-CHECK: c::function::test2
-	function test2() public pure {
+	function test2() public pure returns (bytes) {
 		bytes x = "foo2";
 
 		x[1] = 0;
+		return x;
 		// x is being modified, so it must be a vector
 // CHECK: alloc bytes uint32 4 "foo2"
 	}
@@ -46,10 +47,11 @@ contract c {
 	}
 
 // BEGIN-CHECK: c::function::test5
-	function test5() public pure {
+	function test5() public pure returns (bytes) {
 		bytes x = "foo5";
 
 		x.push(0);
+		return x;
 		// push modifies vectotr
 // CHECK: alloc bytes uint32 4 "foo5"
 	}
@@ -65,23 +67,24 @@ contract c {
 
 
 // BEGIN-CHECK: c::function::test7
-	function test7() public pure {
+	function test7() public pure returns (bytes) {
 		bytes x = "foo7";
 
 		bytes y = x;
 		y[1] = 0;
-
+		return y;
 		// x modified via y
 // CHECK: alloc bytes uint32 4 "foo7"
 	}
 
 // BEGIN-CHECK: c::function::test8
-	function test8() public pure {
+	function test8() public pure returns (bytes) {
 		string x = "foo8";
 
 		bytes y = bytes(x);
 		y[1] = 0;
 
+		return y;
 		// x modified via y
 // CHECK: alloc string uint32 4 "foo8"
 	}

--- a/tests/codegen_testcases/unused_variable_elimination.sol
+++ b/tests/codegen_testcases/unused_variable_elimination.sol
@@ -1,0 +1,236 @@
+// RUN: --emit cfg
+
+contract c2 {
+    int public cd;
+    function sum(int32 a, int32 b) public pure returns (int32) {
+        return a+b;
+    }
+// BEGIN-CHECK: function::doSomething
+    function doSomething() public returns (int, int) {
+        cd=2;
+// CHECK: store storage slot(uint256 0) ty:int256 =
+        return (1, 2);
+    } 
+}
+
+contract c {
+    int32 g;
+// BEGIN-CHECK: c::function::test
+	function test() public returns (int32) {
+		int32 x = 102;
+        g = 3;
+		return 5;
+// NOT-CHECK: ty:int32 %x = int32 102
+
+	}
+
+// BEGIN-CHECK: c::function::test2
+	function test2() public view returns (int32) {
+		int32 x = 102;
+        int32 y = 93;
+        int32 t = 9;
+        x = 102 + t*y/(t+5*y) + g;
+		return 2;
+// NOT-CHECK: ty:int32 %x = int32 102
+// NOT-CHECK: ty:int32 %x = (int32 103 + %temp.6)
+	}
+
+// BEGIN-CHECK: c::function::test3
+	function test3() public view returns (int32) {
+		int32 x;
+        int32 y = 93;
+        int32 t = 9;
+        x = 102 + t*y/(t+5*y) + g;
+		return 2;
+// NOT-CHECK: ty:int32 %x = (int32 103 + %temp.6)
+	}
+
+// BEGIN-CHECK: c::function::test4
+	function test4() public view returns (int32) {
+		int32 x;
+        int32 y = 93;
+        int32 t = 9;
+        x = 102 + t*y/(t+5*y) + g + test3();
+		return 2;
+// NOT-CHECK: ty:int32 %x = (int32 103 + %temp.6)
+// CHECK: call c::c::function::test3
+	}
+
+// BEGIN-CHECK: c::function::test5
+    function test5() public returns (int32) {
+		int32 x;
+        int32[] vec;
+        int32 y = 93;
+        int32 t = 9;
+        c2 ct = new c2();
+        x = 102 + t*y/(t+5*y) + g + test3() - vec.push(2) + ct.sum(1, 2);
+		return 2;
+// CHECK: push array ty:int32[] value:int32 2
+// CHECK: _ = external call::regular address:%ct payload:(abiencode packed:bytes4 2438430579 non-packed:int32 1, int32 2) value:uint128 0 gas:uint64 0
+	}
+}
+
+contract c3 {
+// BEGIN-CHECK: c3::function::test6
+    function test6() public returns (int32) {
+        c2 ct = new c2();
+
+        return 3;
+// CHECK: constructor salt: value: gas:uint64 0 space: c2 #None ()
+    }
+
+// BEGIN-CHECK: c3::function::test7
+    function test7() public returns (int32) {
+        c2 ct = new c2();
+// CHECK: constructor salt: value: gas:uint64 0 space: c2 #None ()
+        address ad = address(ct);
+        (bool p, ) = ad.call(hex'ba');
+// CHECK: external call::regular address:%ad payload:(alloc bytes uint32 1 hex"ba") value:uint128 0 gas:uint64 0
+// NOT-CHECk: ty:bool %p = %success.temp.30
+return 3;
+    }
+
+
+    struct testStruct {
+        int a;
+        int b;
+    }
+
+    testStruct t1;
+    int public it1;
+    int private it2;
+
+
+// BEGIN-CHECK: c3::function::test8
+    function test8() public returns (int){
+        testStruct storage t2 = t1;
+        t2.a = 5;
+
+        it1 = 2;
+        testStruct memory t3 = testStruct(1, 2);
+
+        int[] memory vec = new int[](5);
+        vec[0] = 3;
+        it2 = 1;
+
+        return 2;
+// CHECK: store storage slot((%t2 + uint256 0)) ty:int256 = 
+// CHECK: store storage slot(uint256 2) ty:int256 = 
+// NOT-CHECK: ty:struct c1.testStruct %t3 = struct { int256 1, int256 2 }
+// NOT-CHECK: alloc int256[] len uint32 5
+// NOT-CHECK: store storage slot(uint256 3) ty:int256
+    }
+
+// BEGIN-CHECK: c3::function::test9
+    function test9() public view returns (int) {
+        int f = 4;
+
+        int c = 32 +4 *(f = it1+it2);
+//CHECK: ty:int256 %f =
+        return f;
+    }
+
+// BEGIN-CHECK: c3::function::test10
+    function test10() public view returns (int) {
+        int f = 4;
+
+        int c = 32 +4 *(f = it1+it2);
+// CHECK: ty:int256 %c = (int256 32 + (sext int256 (int64 4 * (trunc int64 (%temp.67 + %temp.68)))))
+// NOT-CHECK: ty:int256 %f = (%temp.10 + %temp.11)
+        return c;
+    }
+
+// BEGIN-CHECK: c3::function::test11
+    function test11() public returns (int) {
+        c2 ct = new c2();
+        (int a, int b) = ct.doSomething();
+// CHECK: ty:int256 %b =
+// NOT-CHECK: ty:int256 %a = 
+        return b;
+    }
+
+// BEGIN-CHECK: c3::function::test12
+    function test12() public returns (int) {
+        c2 ct = new c2();
+        int a = 1;
+        int b = 2;
+        (a, b) = ct.doSomething();
+        // CHECK: ty:int256 %a =
+        // NOT-CHECK: ty:int256 %b = 
+        return a;
+    }
+
+// BEGIN-CHECK: c3::function::test13
+    function test13() public returns (int){
+
+        int[] memory vec = new int[](5);
+        // CHECK: alloc int256[] len uint32 5
+        vec[0] = 3;
+
+        return vec[1];
+    }
+
+    int[] testArr;
+
+// BEGIN-CHECK: c3::function::test14
+    function test14() public returns (int) {
+        int[] storage ptrArr = testArr;
+        
+// CHECK: store storage slot(%temp.69) ty:int256 storage = int256 3
+        ptrArr.push(3);
+
+        return ptrArr[0];
+    }
+
+// BEGIN-CHECK: c3::function::test15
+    function test15() public returns (int) {
+        int[4] memory arr = [1, 2, 3, 4];
+// CHECK: ty:int256[4] %arr = [4] [ int256 1, int256 2, int256 3, int256 4 ]
+        return arr[2];
+    }
+
+// BEGIN-CHECK: c3::function::test16
+    function test16() public returns (int) {
+        int[4] memory arr = [1, 2, 3, 4];
+// NOT-CHECK: ty:int256[4] %arr = [4] [ int256 1, int256 2, int256 3, int256 4 ]
+        return 2;
+    }
+
+// BEGIN-CHECK: c3::function::test17
+    function test17() public pure returns (int) {
+        int x;
+// NOT-CHECK: ty:int256 %x
+        int[] vec = new int[](2);
+        x = 5*vec.pop();
+        return 0;
+// CHECK: pop array ty:int256[]
+    }  
+// BEGIN-CHECK: c3::function::test18
+    function test18(address payable addr) public returns (bool) {
+        bool p;
+        p = false || addr.send(msg.value);
+        // CHECK: value transfer address
+        return true;
+    }
+
+    int[] arrt;
+// BEGIN-CHECK: c3::function::test19
+    function test19() public returns (int) {
+        int x;
+    // NOT-CHECK: ty:int256 %x
+        int y;
+        x = y + arrt.pop();
+        // NOT-CHECK: clear storage slot
+        return 0;
+    }
+
+bytes bar;
+// BEGIN-CHECK: c3::function::test20
+    function test20() public {
+        bytes1 x = bar.push();
+// NOT-CHECK: ty:bytes1 %x
+// CHECK: push storage slot
+    }
+
+}
+

--- a/tests/solana_tests/mod.rs
+++ b/tests/solana_tests/mod.rs
@@ -11,3 +11,4 @@ mod primitives;
 mod signature_verify;
 mod simple;
 mod storage;
+mod unused_variable_elimination;

--- a/tests/solana_tests/unused_variable_elimination.rs
+++ b/tests/solana_tests/unused_variable_elimination.rs
@@ -1,0 +1,48 @@
+use crate::build_solidity;
+use ethabi::Token;
+
+/// This tests check that a public storage variable is not eliminated
+/// and that an assignment inside an expression works
+#[test]
+fn test_returns() {
+    let file = r#"
+    contract c1 {
+        int public pb1;
+
+        function assign() public {
+            pb1 = 5;
+        }
+
+        int t1;
+        int t2;
+        function test1() public returns (int) {
+            t1 = 2;
+            t2 = 3;
+            int f = 6;
+            int c = 32 +4 *(f = t1+t2);
+            return c;
+        }
+
+        function test2() public returns (int) {
+            t1 = 2;
+            t2 = 3;
+            int f = 6;
+            int c = 32 + 4*(f= t1+t2);
+            return f;
+        }
+
+    }
+    "#;
+
+    let mut vm = build_solidity(file);
+    vm.constructor("c1", &[]);
+    let _ = vm.function("assign", &[], &[]);
+    let returns = vm.function("pb1", &[], &[]);
+
+    assert_eq!(returns, vec![Token::Int(ethereum_types::U256::from(5))]);
+
+    let returns = vm.function("test1", &[], &[]);
+    assert_eq!(returns, vec![Token::Int(ethereum_types::U256::from(52))]);
+    let returns = vm.function("test2", &[], &[]);
+    assert_eq!(returns, vec![Token::Int(ethereum_types::U256::from(5))]);
+}

--- a/tests/substrate_tests/arrays.rs
+++ b/tests/substrate_tests/arrays.rs
@@ -959,10 +959,11 @@ fn array_bounds_dynamic_array() {
     let mut runtime = build_solidity(
         r#"
         contract foo {
-            function test() public {
+            function test() public returns (int32) {
                 int32[] memory a = new int32[](5);
 
                 a[5] = 102;
+                return a[3];
             }
         }"#,
     );
@@ -976,10 +977,11 @@ fn empty_array_bounds_dynamic_array() {
     let mut runtime = build_solidity(
         r#"
         contract foo {
-            function test() public {
+            function test() public returns (bytes32) {
                 bytes32[] memory a = new bytes32[](0);
 
                 a[0] = "yo";
+                return a[0];
             }
         }"#,
     );

--- a/tests/substrate_tests/expressions.rs
+++ b/tests/substrate_tests/expressions.rs
@@ -1519,8 +1519,9 @@ fn addition_overflow() {
     let mut runtime = build_solidity_with_overflow_check(
         r#"
         contract overflow {
-            function foo(uint8 x) internal {
+            function foo(uint8 x) internal returns (uint8) {
                 uint8 y = x + 1;
+                return y;
             }
 
             function bar() public {
@@ -1539,8 +1540,9 @@ fn subtraction_underflow() {
     let mut runtime = build_solidity_with_overflow_check(
         r#"
         contract underflow {
-            function foo(uint64 x) internal {
+            function foo(uint64 x) internal return (uint64) {
                 uint64 y = x - 1;
+                return y;
             }
 
             function bar() public {
@@ -1559,8 +1561,9 @@ fn multiplication_overflow() {
     let mut runtime = build_solidity_with_overflow_check(
         r#"
         contract overflow {
-            function foo(int8 x) internal {
+            function foo(int8 x) internal returns (int8) {
                 int8 y = x * int8(64);
+                return y;
             }
 
             function bar() public {

--- a/tests/substrate_tests/primitives.rs
+++ b/tests/substrate_tests/primitives.rs
@@ -815,10 +815,11 @@ fn implicit_bytes_cast_incompatible_size() {
     let mut runtime = build_solidity(
         r#"
         contract c {
-            function test() public {
+            function test() public returns (bytes3) {
                 bytes b1 = hex"01020304";
 
                 bytes3 b2 = b1;
+                return b2;
             }
         }
         "#,

--- a/tests/substrate_tests/strings.rs
+++ b/tests/substrate_tests/strings.rs
@@ -555,6 +555,10 @@ fn bytes_storage_subscript() {
             function and(uint32 index, bytes1 val) public {
                 bar[index] &= val;
             }
+
+            function get() public returns (bytes) {
+                return bar;
+            }
         }"##,
     );
 

--- a/tests/substrate_tests/structs.rs
+++ b/tests/substrate_tests/structs.rs
@@ -511,7 +511,7 @@ fn struct_in_struct() {
                 foo c;
             }
 
-            function test() public pure {
+            function test() public pure returns (bytes7) {
                 bar memory f = bar({ a: address(0), b: hex"fe", c: foo({ x: true, y: 102 }) });
 
                 foo memory m = foo(false, 50);
@@ -521,6 +521,8 @@ fn struct_in_struct() {
                 f.c.y = 300;
 
                 assert(m.y == 300);
+
+                return f.b;
             }
         }"##,
     );


### PR DESCRIPTION
This PR implements unused variable elimination for the Solang compiler and improves the unused variable detection.

For unused variable detection, this PR improves the following cases:

- Variables inside `format()`
- Functions assigned to local variables
- Storage load
- Usage of methods `address` and `selector`

For the unused variable elimination, the PR allows Solang to remove from the intermediate representation the following cases:

- Variables that have never been read nor assigned.
- Variables that have been assigned but never read.
- Assignments of unused variables, including destructures.
- Assignments of unused variables inside expressions (`a = b + (c = 1)`)

This PR is part of the Linux Foundation mentorship for the Solang compiler. For more information, please refer to the [project plan](https://wiki.hyperledger.org/display/INTERN/Project+plan+-+Solang+compiler+passes+2021).