### PR TITLE
Reduce the stack frame on the Solana bundle and modifier fix

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1040,7 +1040,7 @@ pub fn generate_cfg(
 
         cfg.public = false;
 
-        for call in func.modifiers.iter().rev() {
+        for (chain_no, call) in func.modifiers.iter().enumerate().rev() {
             let modifier_cfg_no = all_cfgs.len();
 
             all_cfgs.push(cfg);
@@ -1049,8 +1049,15 @@ pub fn generate_cfg(
 
             let modifier = &ns.functions[modifier_no];
 
-            cfg =
-                generate_modifier_dispatch(contract_no, func, modifier, modifier_cfg_no, args, ns);
+            cfg = generate_modifier_dispatch(
+                contract_no,
+                func,
+                modifier,
+                modifier_cfg_no,
+                chain_no,
+                args,
+                ns,
+            );
         }
 
         cfg.public = public;
@@ -1352,13 +1359,16 @@ pub fn generate_modifier_dispatch(
     func: &Function,
     modifier: &Function,
     cfg_no: usize,
+    chain_no: usize,
     args: &[Expression],
     ns: &Namespace,
 ) -> ControlFlowGraph {
     let name = format!(
-        "sol::{}::modifier::{}::{}",
+        "{}::{}::{}::modifier{}::{}",
         &ns.contracts[contract_no].name,
+        &ns.contracts[func.contract_no.unwrap()].name,
         func.llvm_symbol(ns),
+        chain_no,
         modifier.llvm_symbol(ns)
     );
     let mut cfg = ControlFlowGraph::new(name, None);

--- a/tests/substrate_tests/modifier.rs
+++ b/tests/substrate_tests/modifier.rs
@@ -520,3 +520,27 @@ fn mutability() {
         "function ‘foo’ overrides modifier"
     );
 }
+
+#[test]
+fn repeated_modifier() {
+    let mut runtime = build_solidity(
+        r##"
+        contract Test {
+            modifier notZero(uint64 num) {
+                require(num != 0, "invalid number");
+                _;
+            }
+
+            function contfunc(uint64 num1, uint64 num2) public notZero(num1) notZero(num2) {
+                // any code
+            }
+        }"##,
+    );
+
+    runtime.constructor(0, Vec::new());
+
+    runtime.function_expect_failure("contfunc", (1u64, 0u64).encode());
+    runtime.function_expect_failure("contfunc", (0u64, 0u64).encode());
+    runtime.function_expect_failure("contfunc", (0u64, 1u64).encode());
+    runtime.function("contfunc", (1u64, 1u64).encode());
+}


### PR DESCRIPTION
Turns out, the llvm does not take lifetime into consideration when
creating stack frames. All the stack space created with alloca is just
bundled into a single mega stack frame. Unfortunately, this is limited
to 4096 bytes and if the stack frame is larger, then you will get access
violation errors.

The solang_dispatch() function contained the dispatch for every function
in every contract. The dispatch includes the abi decoding; so, split
this into per-contract dispatch.

Signed-off-by: Sean Young <sean@mess.org>