### PR TITLE
Move to ubuntu 20.04 for CI

### DIFF
--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -20,7 +20,7 @@ jobs:
 
   linux-x86-64:
     name: Linux x86-64
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: create
     steps:
     - run: git clone --depth 1 --branch solana-rustc/12.0-2021-04-15 git://github.com/solana-labs/llvm-project.git

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -2,7 +2,7 @@ name: Build and push ci image
 on: [workflow_dispatch]
 jobs:
   build-push-ci-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: Build Release Binaries
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: hyperledgerlabs/solang:ci
     steps:
     - name: Checkout sources
@@ -102,7 +102,7 @@ jobs:
 
   docker:
     name: Docker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
   lints:
     name: Lints
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: hyperledgerlabs/solang:ci
     steps:
       - name: Checkout sources
@@ -26,7 +26,7 @@ jobs:
 
   linux:
     name: Linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: hyperledgerlabs/solang:ci
     steps:
     - name: Checkout sources
@@ -118,7 +118,7 @@ jobs:
 
   docker:
     name: Docker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -137,8 +137,8 @@ jobs:
 
   solana:
     name: Solana Integration test
-    runs-on: ubuntu-18.04
-    container: ubuntu:18.04
+    runs-on: ubuntu-20.04
+    container: ubuntu:20.04
     needs: linux
     services:
       solana:
@@ -171,7 +171,7 @@ jobs:
 
   substrate:
     name: Substrate Integration test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: linux
     steps:
     - name: Checkout sources
@@ -200,8 +200,8 @@ jobs:
 
   burrow:
     name: Burrow Integration test
-    runs-on: ubuntu-18.04
-    container: ubuntu:18.04
+    runs-on: ubuntu-20.04
+    container: ubuntu:20.04
     needs: linux
     services:
       burrow:
@@ -233,7 +233,7 @@ jobs:
 
   vscode:
     name: Visual Code Extension
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: linux
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN make
 WORKDIR /src
 RUN cargo build --release
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 COPY --from=builder /src/target/release/solang /usr/bin/solang
 
 ENTRYPOINT ["/usr/bin/solang"]

--- a/build/build-llvm-linux.dockerfile
+++ b/build/build-llvm-linux.dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python
+RUN apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python3
 
 RUN git clone --single-branch --branch solana-rustc/12.0-2021-04-15 \
     git://github.com/solana-labs/llvm-project.git

--- a/build/ci.dockerfile
+++ b/build/ci.dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04 as builder
+FROM ubuntu:20.04 as builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python
+RUN apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python3
 
 RUN git clone --single-branch --branch solana-rustc/12.0-2021-04-15 \
     git://github.com/solana-labs/llvm-project.git
@@ -17,11 +17,11 @@ RUN cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off \
 
 RUN cmake --build . --target install
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y zlib1g-dev pkg-config libssl-dev git libffi-dev curl gcc
+RUN apt-get install -y zlib1g-dev pkg-config libssl-dev git libffi-dev curl gcc g++
 RUN apt-get clean
 RUN apt-get autoclean
 


### PR DESCRIPTION
llvm 12 requires a newer version of cmake, so just move to
ubuntu 20.04.

Signed-off-by: Sean Young <sean@mess.org>