### PR TITLE
Get the function selector via contract.function.selector

### DIFF
--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -884,7 +884,7 @@ fn try_catch(
                 let selector = Expression::Builtin(
                     *loc,
                     vec![Type::Bytes(4)],
-                    Builtin::ExternalFunctionSelector,
+                    Builtin::FunctionSelector,
                     vec![function.clone()],
                 );
 

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -2876,7 +2876,7 @@ pub trait TargetRuntime<'a> {
 
                 ef.into()
             }
-            Expression::Builtin(_, _, Builtin::ExternalFunctionSelector, args) => {
+            Expression::Builtin(_, _, Builtin::FunctionSelector, args) => {
                 let ef = self
                     .expression(bin, &args[0], vartab, function, ns)
                     .into_pointer_value();

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1332,7 +1332,7 @@ pub enum Builtin {
     MulMod,
     AddMod,
     ExternalFunctionAddress,
-    ExternalFunctionSelector,
+    FunctionSelector,
     SignatureVerify,
 }
 

--- a/tests/solana_tests/expressions.rs
+++ b/tests/solana_tests/expressions.rs
@@ -135,3 +135,56 @@ fn contract_no_init() {
 
     no_errors(ns.diagnostics);
 }
+
+#[test]
+fn selector_in_free_function() {
+    let ns = parse_and_resolve(
+        r#"
+        interface I {
+            function X(bytes) external;
+        }
+
+        function x() returns (bytes4) {
+            return I.X.selector;
+        }
+
+        contract foo {}
+        "#,
+        Target::Solana,
+    );
+
+    no_errors(ns.diagnostics);
+
+    let ns = parse_and_resolve(
+        r#"
+        interface I {
+            function X(bytes) external;
+        }
+
+        contract X {
+            function x() public returns (bytes4) {
+                return I.X.selector;
+            }
+        }"#,
+        Target::Solana,
+    );
+
+    no_errors(ns.diagnostics);
+
+    let ns = parse_and_resolve(
+        r#"
+        contract I {
+            function X() external {}
+        }
+
+        contract foo {
+            function f(I t) public returns (bytes4) {
+                return t.X.selector;
+            }
+        }
+        "#,
+        Target::Solana,
+    );
+
+    no_errors(ns.diagnostics);
+}


### PR DESCRIPTION
contract does not have to be a base class, it can be an interface as
well.

Signed-off-by: Sean Young <sean@mess.org>