### PR TITLE
Ensure output from compiler is deterministic

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1,6 +1,5 @@
 use num_bigint::BigInt;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::str;
 
@@ -289,7 +288,7 @@ impl fmt::Display for HashTy {
 
 #[derive(Clone)]
 pub struct BasicBlock {
-    pub phis: Option<HashSet<usize>>,
+    pub phis: Option<BTreeSet<usize>>,
     pub name: String,
     pub instr: Vec<Instr>,
     pub defs: reaching_definitions::VarDefs,
@@ -374,7 +373,7 @@ impl ControlFlowGraph {
         pos
     }
 
-    pub fn set_phis(&mut self, block: usize, phis: HashSet<usize>) {
+    pub fn set_phis(&mut self, block: usize, phis: BTreeSet<usize>) {
         if !phis.is_empty() {
             self.blocks[block].phis = Some(phis);
         }
@@ -1604,7 +1603,7 @@ pub struct Vartable {
 
 pub struct DirtyTracker {
     lim: usize,
-    set: HashSet<usize>,
+    set: BTreeSet<usize>,
 }
 
 impl Vartable {
@@ -1747,11 +1746,11 @@ impl Vartable {
     pub fn new_dirty_tracker(&mut self, lim: usize) {
         self.dirty.push(DirtyTracker {
             lim,
-            set: HashSet::new(),
+            set: BTreeSet::new(),
         });
     }
 
-    pub fn pop_dirty_tracker(&mut self) -> HashSet<usize> {
+    pub fn pop_dirty_tracker(&mut self) -> BTreeSet<usize> {
         self.dirty.pop().unwrap().set
     }
 }

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -12,7 +12,7 @@ use crate::sema::expression::{bigint_to_expression, cast, cast_shift_arg};
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::ops::Mul;
 
 pub fn expression(
@@ -640,7 +640,7 @@ pub fn expression(
                 },
             );
 
-            let mut phis = HashSet::new();
+            let mut phis = BTreeSet::new();
             phis.insert(pos);
 
             cfg.set_phis(end_or, phis);
@@ -695,7 +695,7 @@ pub fn expression(
                 },
             );
 
-            let mut phis = HashSet::new();
+            let mut phis = BTreeSet::new();
             phis.insert(pos);
 
             cfg.set_phis(end_and, phis);

--- a/src/emit/solana.rs
+++ b/src/emit/solana.rs
@@ -77,7 +77,7 @@ impl SolanaTarget {
             .cfg
             .iter()
             .enumerate()
-            .find(|(_, cfg)| cfg.ty == pt::FunctionTy::Constructor)
+            .find(|(_, cfg)| cfg.ty == pt::FunctionTy::Constructor && cfg.public)
             .map(|(cfg_no, cfg)| (binary.functions[&cfg_no], &cfg.params));
 
         let mut functions = HashMap::new();
@@ -165,7 +165,7 @@ impl SolanaTarget {
                     .cfg
                     .iter()
                     .enumerate()
-                    .find(|(_, cfg)| cfg.ty == pt::FunctionTy::Constructor)
+                    .find(|(_, cfg)| cfg.ty == pt::FunctionTy::Constructor && cfg.public)
                     .map(|(cfg_no, cfg)| (binary.functions[&cfg_no], &cfg.params));
 
                 let mut functions = HashMap::new();

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -3,9 +3,11 @@ use crate::codegen::cfg::ControlFlowGraph;
 use crate::parser::pt;
 use crate::Target;
 use num_bigint::BigInt;
-use std::collections::HashMap;
-use std::fmt;
-use std::path::PathBuf;
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    path::PathBuf,
+};
 use tiny_keccak::{Hasher, Keccak};
 
 #[derive(PartialEq, Clone, Eq, Hash, Debug)]
@@ -425,7 +427,7 @@ pub struct Contract {
     pub layout: Vec<Layout>,
     pub fixed_layout_size: BigInt,
     pub functions: Vec<usize>,
-    pub all_functions: HashMap<usize, usize>,
+    pub all_functions: BTreeMap<usize, usize>,
     pub virtual_functions: HashMap<String, usize>,
     pub variables: Vec<Variable>,
     // List of contracts this contract instantiates

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -2,8 +2,7 @@ use crate::parser::pt;
 use inkwell::OptimizationLevel;
 use num_bigint::BigInt;
 use num_traits::Zero;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 use tiny_keccak::{Hasher, Keccak};
 
@@ -30,7 +29,7 @@ impl ast::Contract {
             fixed_layout_size: BigInt::zero(),
             tags,
             functions: Vec::new(),
-            all_functions: HashMap::new(),
+            all_functions: BTreeMap::new(),
             virtual_functions: HashMap::new(),
             variables: Vec::new(),
             creates: Vec::new(),

--- a/tests/solana_tests/simple.rs
+++ b/tests/solana_tests/simple.rs
@@ -189,3 +189,60 @@ fn flipper() {
 
     assert_eq!(returns, vec![ethabi::Token::Bool(false)]);
 }
+
+#[test]
+fn incrementer() {
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            // make sure incrementer has a base contract with an empty constructor
+            // is to check that the correct constructor is selected at emit time
+            // https://github.com/hyperledger-labs/solang/issues/487
+            constructor() {}
+        }
+
+        contract incrementer is foo {
+            uint32 private value;
+
+            /// Constructor that initializes the `int32` value to the given `init_value`.
+            constructor(uint32 initvalue) {
+                value = initvalue;
+            }
+
+            /// This increments the value by `by`.
+            function inc(uint32 by) public {
+                value += by;
+            }
+
+            /// Simply returns the current value of our `uint32`.
+            function get() public view returns (uint32) {
+                return value;
+            }
+        }"#,
+    );
+
+    vm.constructor(
+        "incrementer",
+        &[ethabi::Token::Uint(ethereum_types::U256::from(5))],
+    );
+
+    let returns = vm.function("get", &[], &[]);
+
+    assert_eq!(
+        returns,
+        vec![ethabi::Token::Uint(ethereum_types::U256::from(5))]
+    );
+
+    vm.function(
+        "inc",
+        &[ethabi::Token::Uint(ethereum_types::U256::from(7))],
+        &[],
+    );
+
+    let returns = vm.function("get", &[], &[]);
+
+    assert_eq!(
+        returns,
+        vec![ethabi::Token::Uint(ethereum_types::U256::from(12))]
+    );
+}


### PR DESCRIPTION
The codegen for solana dispatch looked for the constructor for a
contract, without checking it was the non-base constructor. So,
the constructor for one of the base contracts may be selected instead.

Since functions are stored in HashMaps at various points, this
as not determinstic.

Signed-off-by: Sean Young <sean@mess.org>