### PR TITLE
fix: solana mechanism for return has changed yet again

### DIFF
--- a/integration/solana/index.ts
+++ b/integration/solana/index.ts
@@ -18,7 +18,7 @@ import { encode } from 'querystring';
 const Web3EthAbi = require('web3-eth-abi');
 
 const default_url: string = "http://localhost:8899";
-const return_data_prefix = 'Program return data: ';
+const return_data_prefix = 'Program return: ';
 
 export async function establishConnection(): Promise<TestConnection> {
     let url = process.env.RPC_URL || default_url;


### PR DESCRIPTION
unless am wrong:

```
[
  'Program 3vtWFA1tozq1mfZAMJfAVtQVvRkTjeio8rkyRFzRuTP5 invoke [1]',
  'Program 3vtWFA1tozq1mfZAMJfAVtQVvRkTjeio8rkyRFzRuTP5 consumed 1020 of 200000 compute units',
  'Program return: 3vtWFA1tozq1mfZAMJfAVtQVvRkTjeio8rkyRFzRuTP5 CMN5oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABNEbyB0aGUgcmV2ZXJ0IHRoaW5nAAAAAAAAAAAAAAAAAA==',
  'Program 3vtWFA1tozq1mfZAMJfAVtQVvRkTjeio8rkyRFzRuTP5 failed: custom program error: 0x0'
]
```

tested on latest `solanalabs/solana:edge` image.