### PR TITLE
Fix resolving relative paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ will be documented here.
 - Added supported for solc import mapppings using `--importmap`
 - Added supported for Events on Solana
 
-## Changed
+### Changed
 - On Solana, the return data is now provided in the program log. As a result,
   RPCs are now are now supported.
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+*.wasm
+*.so
+*.contract

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -71,8 +71,12 @@ fn import_map() {
 fn import() {
     let mut cmd = Command::cargo_bin("solang").unwrap();
     let assert = cmd
-        .args(&["--importpath", "imports", "import.sol"])
-        .current_dir("tests/imports_testcases")
+        .args(&[
+            "--importpath",
+            "./imports_testcases/imports",
+            "imports_testcases/import.sol",
+        ])
+        .current_dir("tests")
         .assert();
 
     let output = assert.get_output();


### PR DESCRIPTION
solang ./foo/bar.sol would always fail on Windows

Signed-off-by: Sean Young <sean@mess.org>