### PR TITLE
Improve error message when accessing contract variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
       - name: Run cargo clippy
-        run: cargo clippy --tests --bins -- -D warnings
+        run: cargo clippy --tests --bins -- -D warnings -D clippy::inconsistent-struct-constructor
       - name: Ensure cargo publish is happy
         run: cargo publish --dry-run
 
@@ -63,7 +63,7 @@ jobs:
       run: echo "c:\llvm12.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
     # We run clippy on Linux in the lint job above, but this does not check #[cfg(windows)] items
     - name: Run cargo clippy
-      run: cargo clippy --tests --bins -- -D warnings
+      run: cargo clippy --tests --bins -- -D warnings -D clippy::inconsistent-struct-constructor
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -153,9 +153,9 @@ impl FileResolver {
 
                             return Ok(ResolvedFile {
                                 full_path,
-                                base,
-                                import_no,
                                 file_no,
+                                import_no,
+                                base,
                             });
                         }
                     }

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -25,8 +25,6 @@ pub struct FileResolver {
 pub struct ResolvedFile {
     /// Full path on the filesystem
     pub full_path: PathBuf,
-    /// Index into the file resolver
-    file_no: usize,
     /// Which import path was used, if any
     import_no: usize,
     // Base part relative to import
@@ -90,9 +88,9 @@ impl FileResolver {
     }
 
     /// Populate the cache with absolute file path
-    fn load_file(&mut self, path: &Path) -> Result<usize, String> {
-        if let Some(file_no) = self.cached_paths.get(path) {
-            return Ok(*file_no);
+    fn load_file(&mut self, path: &Path) -> Result<(), String> {
+        if self.cached_paths.get(path).is_some() {
+            return Ok(());
         }
 
         // read the file
@@ -122,7 +120,7 @@ impl FileResolver {
 
         self.cached_paths.insert(path.to_path_buf(), pos);
 
-        Ok(pos)
+        Ok(())
     }
 
     /// Walk the import path to search for a file. If no import path is set up,
@@ -145,7 +143,7 @@ impl FileResolver {
                     if first_part == mapping {
                         // match!
                         if let Ok(full_path) = join_fold(import_path, &relpath).canonicalize() {
-                            let file_no = self.load_file(&full_path)?;
+                            self.load_file(&full_path)?;
                             let base = full_path
                                 .parent()
                                 .expect("path should include filename")
@@ -153,7 +151,6 @@ impl FileResolver {
 
                             return Ok(ResolvedFile {
                                 full_path,
-                                file_no,
                                 import_no,
                                 base,
                             });
@@ -177,13 +174,10 @@ impl FileResolver {
                     .expect("path should include filename")
                     .to_path_buf();
 
-                let file_no = self.cached_paths[&full_path];
-
                 return Ok(ResolvedFile {
                     full_path,
                     base,
                     import_no: 0,
-                    file_no,
                 });
             }
 
@@ -191,7 +185,7 @@ impl FileResolver {
                 let import_path = join_fold(import_path, base);
 
                 if let Ok(full_path) = join_fold(&import_path, &path).canonicalize() {
-                    let file_no = self.load_file(&full_path)?;
+                    self.load_file(&full_path)?;
                     let base = full_path
                         .parent()
                         .expect("path should include filename")
@@ -201,7 +195,6 @@ impl FileResolver {
                         full_path,
                         base,
                         import_no: *import_no,
-                        file_no,
                     });
                 }
             }
@@ -216,13 +209,11 @@ impl FileResolver {
             let base = (&full_path.parent())
                 .expect("path should include filename")
                 .to_path_buf();
-            let file_no = self.cached_paths[&full_path];
 
             return Ok(ResolvedFile {
                 full_path,
                 base,
                 import_no: 0,
-                file_no,
             });
         }
 
@@ -236,11 +227,10 @@ impl FileResolver {
                         .parent()
                         .expect("path should include filename")
                         .to_path_buf();
-                    let file_no = self.load_file(&full_path)?;
+                    self.load_file(&full_path)?;
 
                     return Ok(ResolvedFile {
                         full_path,
-                        file_no,
                         import_no,
                         base,
                     });

--- a/src/linker/bpf.rs
+++ b/src/linker/bpf.rs
@@ -79,9 +79,7 @@ SECTIONS
         CString::new(res_filename.to_str().expect("temp path should be unicode")).unwrap(),
     ];
 
-    if super::elf_linker(&command_line) {
-        panic!("linker failed");
-    }
+    assert!(!super::elf_linker(&command_line), "linker failed");
 
     let mut output = Vec::new();
     // read the whole file

--- a/src/linker/wasm.rs
+++ b/src/linker/wasm.rs
@@ -58,9 +58,7 @@ pub fn link(input: &[u8], name: &str, target: Target) -> Vec<u8> {
     command_line
         .push(CString::new(res_filename.to_str().expect("temp path should be unicode")).unwrap());
 
-    if super::wasm_linker(&command_line) {
-        panic!("linker failed");
-    }
+    assert!(!super::wasm_linker(&command_line), "linker failed");
 
     let mut output = Vec::new();
     // read the whole file

--- a/tests/ewasm.rs
+++ b/tests/ewasm.rs
@@ -316,9 +316,10 @@ impl Externals for TestRuntime {
                 match module.invoke_export("main", &[], self) {
                     Err(wasmi::Error::Trap(trap)) => match trap.kind() {
                         TrapKind::Host(host_error) => {
-                            if host_error.downcast_ref::<HostCodeRevert>().is_some() {
-                                panic!("revert executed");
-                            }
+                            assert!(
+                                host_error.downcast_ref::<HostCodeRevert>().is_none(),
+                                "revert executed"
+                            );
                         }
                         _ => panic!("fail to invoke main via create: {}", trap),
                     },
@@ -522,9 +523,7 @@ impl Externals for TestRuntime {
                     topics: Vec::new(),
                 };
 
-                if topic_count > 4 {
-                    panic!("log: wrong topic count {}", topic_count);
-                }
+                assert!(topic_count <= 4, "log: wrong topic count {}", topic_count);
 
                 for topic in 0..topic_count {
                     let topic_ptr: u32 = args.nth_checked(3 + topic as usize)?;
@@ -627,9 +626,11 @@ impl TestRuntime {
         match module.invoke_export("main", &[], self) {
             Err(wasmi::Error::Trap(trap)) => match trap.kind() {
                 TrapKind::Host(host_error) => {
-                    if host_error.downcast_ref::<HostCodeFinish>().is_none() {
-                        panic!("fail to invoke main: {}", host_error);
-                    }
+                    assert!(
+                        host_error.downcast_ref::<HostCodeFinish>().is_some(),
+                        "fail to invoke main: {}",
+                        host_error
+                    );
                 }
                 _ => panic!("fail to invoke main: {}", trap),
             },
@@ -668,9 +669,11 @@ impl TestRuntime {
         match module.invoke_export("main", &[], self) {
             Err(wasmi::Error::Trap(trap)) => match trap.kind() {
                 TrapKind::Host(host_error) => {
-                    if host_error.downcast_ref::<HostCodeFinish>().is_none() {
-                        panic!("fail to invoke main: {}", host_error);
-                    }
+                    assert!(
+                        host_error.downcast_ref::<HostCodeFinish>().is_some(),
+                        "fail to invoke main: {}",
+                        host_error
+                    );
                 }
                 _ => panic!("fail to invoke main: {}", trap),
             },

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -507,9 +507,8 @@ impl<'a> SyscallObject<UserError> for SyscallSetReturnData<'a> {
         memory_mapping: &MemoryMapping,
         result: &mut Result<u64, EbpfError<UserError>>,
     ) {
-        if len > 1024 {
-            panic!("sol_set_return_data: length is {}", len);
-        }
+        assert!(len <= 1024, "sol_set_return_data: length is {}", len);
+
         let buf = question_mark!(translate_slice::<u8>(memory_mapping, addr, len), result);
 
         if let Ok(mut context) = self.context.try_borrow_mut() {

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -1449,7 +1449,7 @@ impl VirtualMachine {
                     .collect();
                 let data = fields[1].clone();
 
-                RawLog { data, topics }
+                RawLog { topics, data }
             })
             .collect()
     }

--- a/tests/solana_tests/constant.rs
+++ b/tests/solana_tests/constant.rs
@@ -80,6 +80,6 @@ fn not_constant() {
     );
     assert_eq!(
         first_error(ns.diagnostics),
-        "conversion from function() internal view returns (uint256) to uint256 not possible",
+        "need instance of contract ‘C’ to get variable value ‘NOT_CONSTANT’",
     );
 }

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -137,9 +137,13 @@ impl Externals for TestRuntime {
                     .get_value::<u32>($len_ptr)
                     .expect(&format!("{} len_ptr should be valid", $name));
 
-                if (len as usize) < $buf.len() {
-                    panic!("{} input is {} buffer is {}", $name, $buf.len(), len);
-                }
+                assert!(
+                    (len as usize) >= $buf.len(),
+                    "{} input is {} buffer is {}",
+                    $name,
+                    $buf.len(),
+                    len
+                );
 
                 if let Err(e) = self.vm.memory.set($dest_ptr, $buf) {
                     panic!("{}: {}", $name, e);
@@ -163,9 +167,12 @@ impl Externals for TestRuntime {
                     .get_value::<u32>(len_ptr)
                     .expect("seal_input len_ptr should be valid");
 
-                if (len as usize) < self.vm.input.len() {
-                    panic!("input is {} seal_input buffer {}", self.vm.input.len(), len);
-                }
+                assert!(
+                    (len as usize) >= self.vm.input.len(),
+                    "input is {} seal_input buffer {}",
+                    self.vm.input.len(),
+                    len
+                );
 
                 if let Err(e) = self.vm.memory.set(dest_ptr, &self.vm.input) {
                     panic!("seal_input: {}", e);
@@ -200,9 +207,10 @@ impl Externals for TestRuntime {
                         .get_value::<u32>(len_ptr)
                         .expect("seal_get_storage len_ptr should be valid");
 
-                    if (len as usize) < value.len() {
-                        panic!("seal_get_storage buffer is too small");
-                    }
+                    assert!(
+                        (len as usize) >= value.len(),
+                        "seal_get_storage buffer is too small"
+                    );
 
                     if let Err(e) = self.vm.memory.set(dest_ptr, value) {
                         panic!("seal_get_storage: {}", e);
@@ -431,9 +439,10 @@ impl Externals for TestRuntime {
                     .get_value::<u32>(len_ptr)
                     .expect("seal_random len_ptr should be valid");
 
-                if (len as usize) < hash.len() {
-                    panic!("seal_random dest buffer is too small");
-                }
+                assert!(
+                    (len as usize) >= hash.len(),
+                    "seal_random dest buffer is too small"
+                );
 
                 if let Err(e) = self.vm.memory.set(dest_ptr, &hash) {
                     panic!("seal_random: {}", e);
@@ -459,9 +468,7 @@ impl Externals for TestRuntime {
 
                 let mut address = [0u8; 32];
 
-                if address_len != 32 {
-                    panic!("seal_call: len = {}", address_len);
-                }
+                assert!(address_len == 32, "seal_call: len = {}", address_len);
 
                 if let Err(e) = self.vm.memory.get_into(address_ptr, &mut address) {
                     panic!("seal_call: {}", e);
@@ -469,9 +476,7 @@ impl Externals for TestRuntime {
 
                 let mut value = [0u8; 16];
 
-                if value_len != 16 {
-                    panic!("seal_call: len = {}", value_len);
-                }
+                assert!(value_len == 16, "seal_call: len = {}", value_len);
 
                 if let Err(e) = self.vm.memory.get_into(value_ptr, &mut value) {
                     panic!("seal_call: {}", e);
@@ -548,9 +553,7 @@ impl Externals for TestRuntime {
 
                 let mut address = [0u8; 32];
 
-                if address_len != 32 {
-                    panic!("seal_transfer: len = {}", address_len);
-                }
+                assert!(address_len == 32, "seal_transfer: len = {}", address_len);
 
                 if let Err(e) = self.vm.memory.get_into(address_ptr, &mut address) {
                     panic!("seal_transfer: {}", e);
@@ -558,9 +561,7 @@ impl Externals for TestRuntime {
 
                 let mut value = [0u8; 16];
 
-                if value_len != 16 {
-                    panic!("seal_transfer: len = {}", value_len);
-                }
+                assert!(value_len == 16, "seal_transfer: len = {}", value_len);
 
                 if let Err(e) = self.vm.memory.get_into(value_ptr, &mut value) {
                     panic!("seal_transfer: {}", e);
@@ -596,9 +597,11 @@ impl Externals for TestRuntime {
 
                 let mut codehash = [0u8; 32];
 
-                if codehash_len != 32 {
-                    panic!("seal_instantiate: len = {}", codehash_len);
-                }
+                assert!(
+                    codehash_len == 32,
+                    "seal_instantiate: len = {}",
+                    codehash_len
+                );
 
                 if let Err(e) = self.vm.memory.get_into(codehash_ptr, &mut codehash) {
                     panic!("seal_instantiate: {}", e);
@@ -606,9 +609,7 @@ impl Externals for TestRuntime {
 
                 let mut value = [0u8; 16];
 
-                if value_len != 16 {
-                    panic!("seal_instantiate: len = {}", value_len);
-                }
+                assert!(value_len == 16, "seal_instantiate: len = {}", value_len);
 
                 if let Err(e) = self.vm.memory.get_into(value_ptr, &mut value) {
                     panic!("seal_instantiate: {}", e);
@@ -825,9 +826,7 @@ impl Externals for TestRuntime {
 
                 let mut address = [0u8; 32];
 
-                if address_len != 32 {
-                    panic!("seal_terminate: len = {}", address_len);
-                }
+                assert!(address_len == 32, "seal_terminate: len = {}", address_len);
 
                 if let Err(e) = self.vm.memory.get_into(address_ptr, &mut address) {
                     panic!("seal_terminate: {}", e);
@@ -1046,9 +1045,7 @@ impl TestRuntime {
         println!("input:{}", hex::encode(&self.vm.input));
 
         if let Some(RuntimeValue::I32(ret)) = self.invoke_call(module) {
-            if ret != 0 {
-                panic!("non zero return: {}", ret);
-            }
+            assert!(ret == 0, "non zero return: {}", ret);
         }
     }
 

--- a/tests/substrate_tests/inheritance.rs
+++ b/tests/substrate_tests/inheritance.rs
@@ -2158,3 +2158,33 @@ fn visibility() {
         "visibility ‘private’ of function ‘foo’ is not compatible with visibility ‘internal’"
     );
 }
+
+#[test]
+fn var_or_function() {
+    let mut runtime = build_solidity(
+        r##"
+        contract x is c {
+            function f1() public returns (int64) {
+                return c.selector();
+            }
+
+            function f2() public returns (int64)  {
+                function() internal returns (int64) a = c.selector;
+                return a();
+            }
+        }
+
+        contract c {
+            int64 public selector = 102;
+        }"##,
+    );
+
+    runtime.constructor(0, Vec::new());
+    runtime.function("f1", Vec::new());
+
+    assert_eq!(runtime.vm.output, 102u64.encode());
+
+    runtime.function("f2", Vec::new());
+
+    assert_eq!(runtime.vm.output, 102u64.encode());
+}


### PR DESCRIPTION
 If a contract variable is not constant and it is accessed via the contract type, rather than a contract instance, give a nicer error message.
    
