### PR TITLE
Keep next_id up to date in namespace

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -199,7 +199,9 @@ fn storage_initializer(contract_no: usize, ns: &mut Namespace, opt: &Options) ->
 
     cfg.add(&mut vartab, Instr::Return { value: Vec::new() });
 
-    cfg.vars = vartab.drain();
+    let (vars, next_id) = vartab.drain();
+    cfg.vars = vars;
+    ns.next_id = next_id;
 
     optimize_and_check_cfg(&mut cfg, ns, None, opt);
 

--- a/tests/codegen_testcases/unused_variable_elimination.sol
+++ b/tests/codegen_testcases/unused_variable_elimination.sol
@@ -135,7 +135,7 @@ return 3;
         int f = 4;
 
         int c = 32 +4 *(f = it1+it2);
-// CHECK: ty:int256 %c = (int256 32 + (sext int256 (int64 4 * (trunc int64 (%temp.67 + %temp.68)))))
+// CHECK: ty:int256 %c = (int256 32 + (sext int256 (int64 4 * (trunc int64 (%temp.84 + %temp.85)))))
 // NOT-CHECK: ty:int256 %f = (%temp.10 + %temp.11)
         return c;
     }
@@ -176,7 +176,7 @@ return 3;
     function test14() public returns (int) {
         int[] storage ptrArr = testArr;
 
-// CHECK: store storage slot(%temp.69) ty:int256 storage = int256 3
+// CHECK: store storage slot(%temp.97) ty:int256 storage = int256 3
         ptrArr.push(3);
 
         return ptrArr[0];


### PR DESCRIPTION
This PR keeps the `next_id` attribute of `struct Namespace` always updated after the insertion of temporaries. This is modification is necessary to make the common subexpressions elimination work.