### PR TITLE
Lisbon Release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to [Solang](https://github.com/hyperledger-labs/solang/)
 will be documented here.
 
-## [Unreleased]
+## [0.1.9]
 
 ### Added
 - Added support for solc import mapppings using `--importmap`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019 - 2021 Sean Young <sean@mess.org>'
 author = 'Sean Young <sean@mess.org>'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.8'
+release = '0.1.9'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,25 +8,25 @@ Download release binaries
 
 For Linux x86-64, there is a binary available in the github releases:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/solang-linux>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang-linux>`_
 
 For Windows x64, there is a binary available:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/solang.exe>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang.exe>`_
 
 For MacOS, there is an arm and intel binary available.
 Remember to remove the quarantine attribute using ``xattr -d com.apple.quarantine solang-mac-arm`` in the terminal.
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/solang-mac-arm>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang-mac-arm>`_
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/solang-mac-intel>`_
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang-mac-intel>`_
 
 Using ghcr.io/hyperledger-labs/solang containers
 ------------------------------------------------
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger-labs/solang/pkgs/container/solang>`_.
-There is a release `v0.1.8` tag and a `latest` tag:
+There is a release `v0.1.9` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -68,7 +68,7 @@ These patches make it possible to generate code for Solana, and fixes some
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger-labs/solang/releases/tag/v0.1.8>`_
+`github <https://github.com/hyperledger-labs/solang/releases/tag/v0.1.9>`_
 or build your own from source. After that, you need to add the `bin` directory to your
 path, so that the build system of Solang can find the correct version of llvm to use.
 
@@ -76,7 +76,7 @@ Installing LLVM on Linux
 ________________________
 
 A pre-built version of llvm, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/llvm12.0-linux-x86-64.tar.xz>`_.
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/llvm12.0-linux-x86-64.tar.xz>`_.
 After downloading, untar the file in a terminal and add it to your path.
 
 .. code-block:: bash
@@ -88,7 +88,7 @@ Installing LLVM on Windows
 __________________________
 
 A pre-built version of llvm, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/llvm12.0-win.zip>`_.
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/llvm12.0-win.zip>`_.
 
 After unzipping the file, add the bin directory to your path.
 
@@ -100,8 +100,8 @@ Installing LLVM on Mac
 ______________________
 
 A pre-built version of llvm for intel macs, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/llvm12.0-mac-intel.tar.xz>`_ and for arm macs there is
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.8/llvm12.0-mac-arm.tar.xz>`_. After downloading,
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/llvm12.0-mac-intel.tar.xz>`_ and for arm macs there is
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/llvm12.0-mac-arm.tar.xz>`_. After downloading,
 untar the file in a terminal and add it to your path like so:
 
 .. code-block:: bash


### PR DESCRIPTION
Added
- Added support for solc import mapppings using `--importmap`
- Added support for Events on Solana
- `msg.data`, `msg.sig`, `msg.value`, `block.number`, and `block.slot` are
  implemented for Solana
- Implemented balance transfers using `.send()` and `.transfer()` on Solana
- Implemented retrieving account balances on Solana
- Verify ed25519 signatures with `signatureVerify()` on Solana
- Added support for Rational numbers
- The address type and value type can changed using `--address-length` and
  `--value-length` command line arguments (for Substrate only)

Changed
- Solana now requires v1.8.1 or later
- On Solana, the return data is now provided in the program log. As a result,
  RPCs are now are now supported.
- On the solang command line, the target must be specified.
- The Solana instruction now includes a 64 bit value field
- Many fixes to the parser and resolver, so solidity compatibility is much
  improved, thanks to [sushi-shi](https://github.com/hyperledger-labs/solang/pulls?q=is%3Apr+author%3Asushi-shi+is%3Aclosed).

Removed
- The Sawtooth Sabre target has been removed.
- The generic target has been removed.

Signed-off-by: Sean Young <sean@mess.org>