### PR TITLE
Do not link against libffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = { version = "1.0" }
-inkwell = { version = "^0.1.0-beta.3", features = ["target-webassembly", "target-bpf", "llvm12-0"] }
+inkwell = { version = "^0.1.0-beta.3", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm12-0"] }
 blake2-rfc = "0.2.18"
 phf = { version = "0.10", features = ["macros"] }
 unicode-xid = "0.2.0"


### PR DESCRIPTION
libffi is not needed and we shouldn't depend on it.

Signed-off-by: Sean Young <sean@mess.org>