### PR TITLE
Increase stack size on Windows to 8MB

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -46,11 +46,15 @@ fn main() {
         println!("cargo:rustc-link-lib=static={}", lib);
     }
 
-    // note: add error checking yourself.
     let output = Command::new("git")
         .args(&["describe", "--tags"])
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
+    // Make sure we have an 8MiB stack on Windows. Windows defaults to a 1MB
+    // stack, which is not big enough for debug builds
+    #[cfg(windows)]
+    println!("cargo:rustc-link-arg=/STACK:8388608");
 }

--- a/tests/codegen_testcases/common_subexpression_elimination.sol
+++ b/tests/codegen_testcases/common_subexpression_elimination.sol
@@ -1,4 +1,4 @@
-// RUN: --target substrate --emit cfg --no-strength-reduce
+// RUN: --target substrate --emit cfg
 
 // Tests control commands
 contract c1 {


### PR DESCRIPTION
Both Mac and Linux already use a 8MB stack by default.

Signed-off-by: Sean Young <sean@mess.org>