### PR TITLE
Build container images for amd64 and arm64

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -2,12 +2,10 @@ name: Build and push ci image
 on: [workflow_dispatch]
 jobs:
   build-push-ci-image:
-    runs-on: ubuntu-20.04
+    runs-on: macos-arm
     steps:
     - name: Checkout sources
       uses: actions/checkout@v1
-    - run: docker build -t ghcr.io/${GITHUB_REPOSITORY}:ci .github/
-    - name: Push to github container registry
-      run: |
+    - run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/${GITHUB_REPOSITORY}:ci
+          docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/${GITHUB_REPOSITORY}:ci --push .github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-  
+
 jobs:
   repolinter:
     name: Repolinter
@@ -134,9 +134,31 @@ jobs:
         name: solang-mac-intel
         path: ./target/debug/solang
 
+  image-multiarch:
+    name: Multiarch Container Image
+    runs-on: macos-arm
+    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+      with:
+        # Make sure "git describe --tags" works for solang --version
+        fetch-depth: 0
+    - run: echo "::set-output name=push::--push"
+      id: push
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    - run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+        docker buildx build . \
+          ${{steps.push.outputs.push}} \
+          -t ghcr.io/${GITHUB_REPOSITORY}:latest \
+          --platform linux/arm64,linux/amd64 \
+          --label org.opencontainers.image.description="Solidity Compiler for Solana, Substrate, and ewasm version $(git describe --tags)"
+
   image:
     name: Container Image
     runs-on: ubuntu-20.04
+    if: ${{ github.repository_owner != 'hyperledger-labs' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -144,13 +166,9 @@ jobs:
         # Make sure "git describe --tags" works for solang --version
         fetch-depth: 0
     - run:
-          docker build . -t ghcr.io/${GITHUB_REPOSITORY}:latest
-            --label org.opencontainers.image.description="Solidity Compiler for Solana, Substrate, and ewasm version $(git describe --tags)"
-    - name: Push to github container registry
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/${GITHUB_REPOSITORY}:latest
+        docker build .
+          -t ghcr.io/${GITHUB_REPOSITORY}:latest
+          --label org.opencontainers.image.description="Solidity Compiler for Solana, Substrate, and ewasm version $(git describe --tags)"
 
   solana:
     name: Solana Integration test


### PR DESCRIPTION
This is done using Hyperledger mac CI servers, which has docker buildx
configured so that the arm64 build happens on the arm mac, and the amd64
on the intel mac.

Signed-off-by: Sean Young <sean@mess.org>