### PR TITLE
feat(parser): DocComments grouping & type annotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ funty = "=1.1.0"
 itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.7"
-solang-parser = { path = "solang-parser", version = "0.1" }
+solang-parser = { path = "solang-parser", version = "0.1.1" }
 
 [dev-dependencies]
 parity-scale-codec-derive = "2.0.0"

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/solang-parser/src/doc.rs
+++ b/solang-parser/src/doc.rs
@@ -68,7 +68,7 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
                     tag: line[tag_start + 1..tag_end + 1].to_owned(),
                     value: line[tag_end + 1..].trim().to_owned(),
                 });
-            } else if single_tags.len() > 0 || tags.len() > 0 {
+            } else if !single_tags.is_empty() || !tags.is_empty() {
                 let line = line.trim();
                 if !line.is_empty() {
                     let single_doc_comment = if let Some(single_tag) = single_tags.last_mut() {
@@ -83,7 +83,7 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
                     };
 
                     if let Some(comment) = single_doc_comment {
-                        comment.value.push(' ');
+                        comment.value.push('\n');
                         comment.value.push_str(line);
                     }
                 }
@@ -97,7 +97,7 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
         }
 
         match ty {
-            CommentType::Line if single_tags.len() > 0 => tags.push(DocComment::Line {
+            CommentType::Line if !single_tags.is_empty() => tags.push(DocComment::Line {
                 comment: single_tags[0].to_owned(),
             }),
             CommentType::Block => tags.push(DocComment::Block {

--- a/solang-parser/src/doc.rs
+++ b/solang-parser/src/doc.rs
@@ -9,26 +9,27 @@ fn to_lines<'a>(
     let mut res = Vec::new();
 
     for (start, ty, comment) in comments.iter() {
+        let mut grouped_comments = Vec::new();
+
         match ty {
-            CommentType::Line => res.push((*ty, vec![(*start, comment.trim())])),
+            CommentType::Line => grouped_comments.push((*start, comment.trim())),
             CommentType::Block => {
                 let mut start = *start;
-                let mut block_comments = Vec::new();
 
                 for s in comment.lines() {
                     if let Some((i, _)) = s
                         .char_indices()
                         .find(|(_, ch)| !ch.is_whitespace() && *ch != '*')
                     {
-                        block_comments.push((start + i, s[i..].trim_end()));
+                        grouped_comments.push((start + i, s[i..].trim_end()));
                     }
 
                     start += s.len();
                 }
-
-                res.push((*ty, block_comments));
             }
         }
+
+        res.push((*ty, grouped_comments));
     }
 
     res
@@ -41,7 +42,7 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
 
     let lines = to_lines(lines);
     for (ty, comment_lines) in lines {
-        let mut tags_buffer = Vec::new();
+        let mut single_tags = Vec::new();
 
         for (start_offset, line) in comment_lines {
             let mut chars = line.char_indices().peekable();
@@ -62,16 +63,16 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
                 }
 
                 // tag value
-                tags_buffer.push(SingleDocComment {
+                single_tags.push(SingleDocComment {
                     offset: tag_start,
                     tag: line[tag_start + 1..tag_end + 1].to_owned(),
                     value: line[tag_end + 1..].trim().to_owned(),
                 });
-            } else if tags_buffer.len() > 0 || tags.len() > 0 {
+            } else if single_tags.len() > 0 || tags.len() > 0 {
                 let line = line.trim();
                 if !line.is_empty() {
-                    let single_doc_comment = if let Some(tag_buffered) = tags_buffer.last_mut() {
-                        Some(tag_buffered)
+                    let single_doc_comment = if let Some(single_tag) = single_tags.last_mut() {
+                        Some(single_tag)
                     } else if let Some(tag) = tags.last_mut() {
                         match tag {
                             DocComment::Line { comment } => Some(comment),
@@ -87,7 +88,7 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
                     }
                 }
             } else {
-                tags_buffer.push(SingleDocComment {
+                single_tags.push(SingleDocComment {
                     offset: start_offset,
                     tag: String::from("notice"),
                     value: line.trim().to_owned(),
@@ -96,11 +97,11 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
         }
 
         match ty {
-            CommentType::Line if tags_buffer.len() > 0 => tags.push(DocComment::Line {
-                comment: tags_buffer[0].to_owned(),
+            CommentType::Line if single_tags.len() > 0 => tags.push(DocComment::Line {
+                comment: single_tags[0].to_owned(),
             }),
             CommentType::Block => tags.push(DocComment::Block {
-                comments: tags_buffer,
+                comments: single_tags,
             }),
             _ => {}
         }

--- a/solang-parser/src/doc.rs
+++ b/solang-parser/src/doc.rs
@@ -1,27 +1,32 @@
 // Parse the fields f
 use crate::lexer::CommentType;
-use crate::pt::DocComment;
+use crate::pt::{DocComment, SingleDocComment};
 
 /// Convert the comment to lines, stripping
-fn to_lines<'a>(comments: &[(usize, CommentType, &'a str)]) -> Vec<(usize, &'a str)> {
+fn to_lines<'a>(
+    comments: &[(usize, CommentType, &'a str)],
+) -> Vec<(CommentType, Vec<(usize, &'a str)>)> {
     let mut res = Vec::new();
 
     for (start, ty, comment) in comments.iter() {
         match ty {
-            CommentType::Line => res.push((*start, comment.trim())),
+            CommentType::Line => res.push((*ty, vec![(*start, comment.trim())])),
             CommentType::Block => {
                 let mut start = *start;
+                let mut block_comments = Vec::new();
 
                 for s in comment.lines() {
                     if let Some((i, _)) = s
                         .char_indices()
                         .find(|(_, ch)| !ch.is_whitespace() && *ch != '*')
                     {
-                        res.push((start + i, s[i..].trim_end()))
+                        block_comments.push((start + i, s[i..].trim_end()));
                     }
 
                     start += s.len();
                 }
+
+                res.push((*ty, block_comments));
             }
         }
     }
@@ -34,42 +39,71 @@ pub fn tags(lines: &[(usize, CommentType, &str)]) -> Vec<DocComment> {
     // first extract the tags
     let mut tags = Vec::new();
 
-    for (start_offset, line) in to_lines(lines).into_iter() {
-        let mut chars = line.char_indices().peekable();
+    let lines = to_lines(lines);
+    for (ty, comment_lines) in lines {
+        let mut tags_buffer = Vec::new();
 
-        if let Some((_, '@')) = chars.peek() {
-            // step over @
-            let (tag_start, _) = chars.next().unwrap();
-            let mut tag_end = tag_start;
+        for (start_offset, line) in comment_lines {
+            let mut chars = line.char_indices().peekable();
 
-            while let Some((offset, c)) = chars.peek() {
-                if c.is_whitespace() {
-                    break;
+            if let Some((_, '@')) = chars.peek() {
+                // step over @
+                let (tag_start, _) = chars.next().unwrap();
+                let mut tag_end = tag_start;
+
+                while let Some((offset, c)) = chars.peek() {
+                    if c.is_whitespace() {
+                        break;
+                    }
+
+                    tag_end = *offset;
+
+                    chars.next();
                 }
 
-                tag_end = *offset;
-
-                chars.next();
+                // tag value
+                tags_buffer.push(SingleDocComment {
+                    offset: tag_start,
+                    tag: line[tag_start + 1..tag_end + 1].to_owned(),
+                    value: line[tag_end + 1..].trim().to_owned(),
+                });
+            } else if let Some(tag) = tags_buffer.last_mut() {
+                let line = line.trim();
+                if !line.is_empty() {
+                    tag.value.push(' ');
+                    tag.value.push_str(line.trim());
+                }
+            } else if let Some(tag) = tags.last_mut() {
+                let line = line.trim();
+                if !line.is_empty() {
+                    match tag {
+                        DocComment::Line { comment } => {
+                            comment.value.push(' ');
+                            comment.value.push_str(line.trim());
+                        }
+                        DocComment::Block { comments } => {
+                            comments[0].value.push(' ');
+                            comments[0].value.push_str(line.trim());
+                        }
+                    }
+                }
+            } else {
+                tags_buffer.push(SingleDocComment {
+                    offset: start_offset,
+                    tag: String::from("notice"),
+                    value: line.trim().to_owned(),
+                });
             }
+        }
 
-            // tag value
-            tags.push(DocComment {
-                offset: tag_start,
-                tag: line[tag_start + 1..tag_end + 1].to_owned(),
-                value: line[tag_end + 1..].trim().to_owned(),
-            });
-        } else if let Some(tag) = tags.last_mut() {
-            let line = line.trim();
-            if !line.is_empty() {
-                tag.value.push(' ');
-                tag.value.push_str(line.trim());
-            }
-        } else {
-            tags.push(DocComment {
-                offset: start_offset,
-                tag: String::from("notice"),
-                value: line.trim().to_owned(),
-            });
+        match ty {
+            CommentType::Line if !tags_buffer.is_empty() => tags.push(DocComment::Line {
+                comment: tags_buffer[0].to_owned(),
+            }),
+            CommentType::Block => tags.push(DocComment::Block {
+                comments: tags_buffer,
+            }),
+            _ => {}
         }
     }
 

--- a/solang-parser/src/lib.rs
+++ b/solang-parser/src/lib.rs
@@ -112,7 +112,7 @@ mod test {
                         comment: SingleDocComment {
                             offset: 0,
                             tag: "description".to_string(),
-                            value: "Foo Bar".to_string(),
+                            value: "Foo\nBar".to_string(),
                         },
                     },
                 ],
@@ -145,7 +145,7 @@ mod test {
                                     SingleDocComment {
                                         offset: 0,
                                         tag: "description".to_string(),
-                                        value: "Data for jurisdiction".to_string(),
+                                        value: "Data for\njurisdiction".to_string(),
                                     },
                                     SingleDocComment {
                                         offset: 0,

--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -31,6 +31,15 @@ pub enum DocComment {
     Block { comments: Vec<SingleDocComment> },
 }
 
+impl DocComment {
+    pub fn comments(&self) -> Vec<&SingleDocComment> {
+        match self {
+            DocComment::Line { comment } => vec![comment],
+            DocComment::Block { comments } => comments.iter().collect(),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct SingleDocComment {
     pub offset: usize,

--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -1,7 +1,9 @@
-use crate::lexer::CommentType;
+use std::fmt;
+
 use num_bigint::BigInt;
 use num_rational::BigRational;
-use std::fmt;
+
+use crate::lexer::CommentType;
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Hash, Clone, Copy)]
 /// file no, start offset, end offset (in bytes)
@@ -24,7 +26,13 @@ pub struct Identifier {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct DocComment {
+pub enum DocComment {
+    Line { comment: SingleDocComment },
+    Block { comments: Vec<SingleDocComment> },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct SingleDocComment {
     pub offset: usize,
     pub tag: String,
     pub value: String,

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -99,7 +99,7 @@ impl Dot {
         if !tags.is_empty() {
             let labels = tags
                 .iter()
-                .map(|tag| format!("{}: {}", tag.tag, tag.value))
+                .map(|tag| format!("{}: {}", tag.tag, tag.value.replace('\n', " ")))
                 .collect();
 
             self.add_node(

--- a/src/sema/tags.rs
+++ b/src/sema/tags.rs
@@ -13,180 +13,131 @@ pub fn resolve_tags(
 ) -> Vec<Tag> {
     let mut res: Vec<Tag> = Vec::new();
 
-    for c in doc.iter() {
-        for single_c in c.comments() {
-            match single_c.tag.as_str() {
-                "notice" | "author" | "title" | "dev" => {
-                    // fold fields with the same name
-                    if let Some(prev) = res.iter_mut().find(|e| e.tag == single_c.tag) {
-                        prev.value.push(' ');
-                        prev.value.push_str(&single_c.value);
+    for c in doc.iter().flat_map(pt::DocComment::comments) {
+        match c.tag.as_str() {
+            "notice" | "author" | "title" | "dev" => {
+                // fold fields with the same name
+                if let Some(prev) = res.iter_mut().find(|e| e.tag == c.tag) {
+                    prev.value.push(' ');
+                    prev.value.push_str(&c.value);
+                } else {
+                    res.push(Tag {
+                        tag: c.tag.to_owned(),
+                        value: c.value.to_owned(),
+                        no: 0,
+                    })
+                }
+            }
+            "param" if params.is_some() => {
+                let v: Vec<&str> = c.value.splitn(2, char::is_whitespace).collect();
+                if v.is_empty() || v[0].is_empty() {
+                    ns.diagnostics.push(Diagnostic::error(
+                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                        "tag ‘@param’ missing parameter name".to_string(),
+                    ));
+                    continue;
+                }
+                let name = v[0];
+                let value = v.get(1).unwrap_or(&"").to_string();
+
+                if let Some(no) = params.unwrap().iter().position(|p| p.name == name) {
+                    if res.iter().any(|e| e.tag == "param" && e.no == no) {
+                        ns.diagnostics.push(Diagnostic::error(
+                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                            format!("duplicate tag ‘@param’ for ‘{}’", name),
+                        ));
                     } else {
                         res.push(Tag {
-                            tag: single_c.tag.to_owned(),
-                            value: single_c.value.to_owned(),
-                            no: 0,
-                        })
+                            tag: String::from("param"),
+                            no,
+                            value,
+                        });
                     }
+                } else {
+                    ns.diagnostics.push(Diagnostic::error(
+                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                        format!("tag ‘@param’ no field ‘{}’", name),
+                    ));
                 }
-                "param" if params.is_some() => {
-                    let v: Vec<&str> = single_c.value.splitn(2, char::is_whitespace).collect();
+            }
+            "return" if returns.is_some() => {
+                let returns = returns.unwrap();
+
+                if returns.is_empty() {
+                    ns.diagnostics.push(Diagnostic::error(
+                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                        "tag ‘@return’ for function with no return values".to_string(),
+                    ));
+                } else if returns.len() == 1 {
+                    if res.iter().any(|e| e.tag == "return") {
+                        ns.diagnostics.push(Diagnostic::error(
+                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                            "duplicate tag ‘@return’".to_string(),
+                        ));
+                    } else {
+                        res.push(Tag {
+                            tag: String::from("return"),
+                            no: 0,
+                            value: c.value.to_owned(),
+                        });
+                    }
+                } else {
+                    let v: Vec<&str> = c.value.splitn(2, char::is_whitespace).collect();
                     if v.is_empty() || v[0].is_empty() {
                         ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(
-                                file_no,
-                                single_c.offset,
-                                single_c.offset + single_c.tag.len(),
-                            ),
-                            "tag ‘@param’ missing parameter name".to_string(),
+                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                            "tag ‘@return’ missing parameter name".to_string(),
                         ));
                         continue;
                     }
                     let name = v[0];
                     let value = v.get(1).unwrap_or(&"").to_string();
 
-                    if let Some(no) = params.unwrap().iter().position(|p| p.name == name) {
-                        if res.iter().any(|e| e.tag == "param" && e.no == no) {
+                    if let Some(no) = returns.iter().position(|p| p.name == name) {
+                        if res.iter().any(|e| e.tag == "return" && e.no == no) {
                             ns.diagnostics.push(Diagnostic::error(
-                                pt::Loc(
-                                    file_no,
-                                    single_c.offset,
-                                    single_c.offset + single_c.tag.len(),
-                                ),
-                                format!("duplicate tag ‘@param’ for ‘{}’", name),
+                                pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                                format!("duplicate tag ‘@return’ for ‘{}’", name),
                             ));
                         } else {
                             res.push(Tag {
-                                tag: String::from("param"),
+                                tag: String::from("return"),
                                 no,
                                 value,
                             });
                         }
                     } else {
                         ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(
-                                file_no,
-                                single_c.offset,
-                                single_c.offset + single_c.tag.len(),
-                            ),
-                            format!("tag ‘@param’ no field ‘{}’", name),
+                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                            format!("tag ‘@return’ no field ‘{}’", name),
                         ));
                     }
                 }
-                "return" if returns.is_some() => {
-                    let returns = returns.unwrap();
-
-                    if returns.is_empty() {
-                        ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(
-                                file_no,
-                                single_c.offset,
-                                single_c.offset + single_c.tag.len(),
-                            ),
-                            "tag ‘@return’ for function with no return values".to_string(),
-                        ));
-                    } else if returns.len() == 1 {
-                        if res.iter().any(|e| e.tag == "return") {
-                            ns.diagnostics.push(Diagnostic::error(
-                                pt::Loc(
-                                    file_no,
-                                    single_c.offset,
-                                    single_c.offset + single_c.tag.len(),
-                                ),
-                                "duplicate tag ‘@return’".to_string(),
-                            ));
-                        } else {
-                            res.push(Tag {
-                                tag: String::from("return"),
-                                no: 0,
-                                value: single_c.value.to_owned(),
-                            });
-                        }
-                    } else {
-                        let v: Vec<&str> = single_c.value.splitn(2, char::is_whitespace).collect();
-                        if v.is_empty() || v[0].is_empty() {
-                            ns.diagnostics.push(Diagnostic::error(
-                                pt::Loc(
-                                    file_no,
-                                    single_c.offset,
-                                    single_c.offset + single_c.tag.len(),
-                                ),
-                                "tag ‘@return’ missing parameter name".to_string(),
-                            ));
-                            continue;
-                        }
-                        let name = v[0];
-                        let value = v.get(1).unwrap_or(&"").to_string();
-
-                        if let Some(no) = returns.iter().position(|p| p.name == name) {
-                            if res.iter().any(|e| e.tag == "return" && e.no == no) {
-                                ns.diagnostics.push(Diagnostic::error(
-                                    pt::Loc(
-                                        file_no,
-                                        single_c.offset,
-                                        single_c.offset + single_c.tag.len(),
-                                    ),
-                                    format!("duplicate tag ‘@return’ for ‘{}’", name),
-                                ));
-                            } else {
-                                res.push(Tag {
-                                    tag: String::from("return"),
-                                    no,
-                                    value,
-                                });
-                            }
-                        } else {
-                            ns.diagnostics.push(Diagnostic::error(
-                                pt::Loc(
-                                    file_no,
-                                    single_c.offset,
-                                    single_c.offset + single_c.tag.len(),
-                                ),
-                                format!("tag ‘@return’ no field ‘{}’", name),
-                            ));
-                        }
-                    }
-                }
-                "inheritdoc" if bases.is_some() => {
-                    if single_c.value.is_empty() {
-                        ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(
-                                file_no,
-                                single_c.offset,
-                                single_c.offset + single_c.tag.len(),
-                            ),
-                            "missing contract for tag ‘@inheritdoc’".to_string(),
-                        ));
-                    } else if bases.unwrap().iter().any(|s| &single_c.value == s) {
-                        res.push(Tag {
-                            tag: String::from("inheritdoc"),
-                            no: 0,
-                            value: single_c.value.to_owned(),
-                        });
-                    } else {
-                        ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(
-                                file_no,
-                                single_c.offset,
-                                single_c.offset + single_c.tag.len(),
-                            ),
-                            format!(
-                                "base contract ‘{}’ not found in tag ‘@inheritdoc’",
-                                single_c.value
-                            ),
-                        ));
-                    }
-                }
-                _ => {
+            }
+            "inheritdoc" if bases.is_some() => {
+                if c.value.is_empty() {
                     ns.diagnostics.push(Diagnostic::error(
-                        pt::Loc(
-                            file_no,
-                            single_c.offset,
-                            single_c.offset + single_c.tag.len(),
-                        ),
-                        format!("tag ‘@{}’ is not valid for {}", single_c.tag, ty),
+                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                        "missing contract for tag ‘@inheritdoc’".to_string(),
+                    ));
+                } else if bases.unwrap().iter().any(|s| &c.value == s) {
+                    res.push(Tag {
+                        tag: String::from("inheritdoc"),
+                        no: 0,
+                        value: c.value.to_owned(),
+                    });
+                } else {
+                    ns.diagnostics.push(Diagnostic::error(
+                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                        format!("base contract ‘{}’ not found in tag ‘@inheritdoc’", c.value),
                     ));
                 }
+            }
+            _ => {
+                ns.diagnostics.push(Diagnostic::error(
+                    pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
+                    format!("tag ‘@{}’ is not valid for {}", c.tag, ty),
+                ));
             }
         }
     }

--- a/src/sema/tags.rs
+++ b/src/sema/tags.rs
@@ -14,130 +14,179 @@ pub fn resolve_tags(
     let mut res: Vec<Tag> = Vec::new();
 
     for c in doc.iter() {
-        match c.tag.as_str() {
-            "notice" | "author" | "title" | "dev" => {
-                // fold fields with the same name
-                if let Some(prev) = res.iter_mut().find(|e| e.tag == c.tag) {
-                    prev.value.push(' ');
-                    prev.value.push_str(&c.value);
-                } else {
-                    res.push(Tag {
-                        tag: c.tag.to_owned(),
-                        value: c.value.to_owned(),
-                        no: 0,
-                    })
-                }
-            }
-            "param" if params.is_some() => {
-                let v: Vec<&str> = c.value.splitn(2, char::is_whitespace).collect();
-                if v.is_empty() || v[0].is_empty() {
-                    ns.diagnostics.push(Diagnostic::error(
-                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                        "tag ‘@param’ missing parameter name".to_string(),
-                    ));
-                    continue;
-                }
-                let name = v[0];
-                let value = v.get(1).unwrap_or(&"").to_string();
-
-                if let Some(no) = params.unwrap().iter().position(|p| p.name == name) {
-                    if res.iter().any(|e| e.tag == "param" && e.no == no) {
-                        ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                            format!("duplicate tag ‘@param’ for ‘{}’", name),
-                        ));
+        for single_c in c.comments() {
+            match single_c.tag.as_str() {
+                "notice" | "author" | "title" | "dev" => {
+                    // fold fields with the same name
+                    if let Some(prev) = res.iter_mut().find(|e| e.tag == single_c.tag) {
+                        prev.value.push(' ');
+                        prev.value.push_str(&single_c.value);
                     } else {
                         res.push(Tag {
-                            tag: String::from("param"),
-                            no,
-                            value,
-                        });
-                    }
-                } else {
-                    ns.diagnostics.push(Diagnostic::error(
-                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                        format!("tag ‘@param’ no field ‘{}’", name),
-                    ));
-                }
-            }
-            "return" if returns.is_some() => {
-                let returns = returns.unwrap();
-
-                if returns.is_empty() {
-                    ns.diagnostics.push(Diagnostic::error(
-                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                        "tag ‘@return’ for function with no return values".to_string(),
-                    ));
-                } else if returns.len() == 1 {
-                    if res.iter().any(|e| e.tag == "return") {
-                        ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                            "duplicate tag ‘@return’".to_string(),
-                        ));
-                    } else {
-                        res.push(Tag {
-                            tag: String::from("return"),
+                            tag: single_c.tag.to_owned(),
+                            value: single_c.value.to_owned(),
                             no: 0,
-                            value: c.value.to_owned(),
-                        });
+                        })
                     }
-                } else {
-                    let v: Vec<&str> = c.value.splitn(2, char::is_whitespace).collect();
+                }
+                "param" if params.is_some() => {
+                    let v: Vec<&str> = single_c.value.splitn(2, char::is_whitespace).collect();
                     if v.is_empty() || v[0].is_empty() {
                         ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                            "tag ‘@return’ missing parameter name".to_string(),
+                            pt::Loc(
+                                file_no,
+                                single_c.offset,
+                                single_c.offset + single_c.tag.len(),
+                            ),
+                            "tag ‘@param’ missing parameter name".to_string(),
                         ));
                         continue;
                     }
                     let name = v[0];
                     let value = v.get(1).unwrap_or(&"").to_string();
 
-                    if let Some(no) = returns.iter().position(|p| p.name == name) {
-                        if res.iter().any(|e| e.tag == "return" && e.no == no) {
+                    if let Some(no) = params.unwrap().iter().position(|p| p.name == name) {
+                        if res.iter().any(|e| e.tag == "param" && e.no == no) {
                             ns.diagnostics.push(Diagnostic::error(
-                                pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                                format!("duplicate tag ‘@return’ for ‘{}’", name),
+                                pt::Loc(
+                                    file_no,
+                                    single_c.offset,
+                                    single_c.offset + single_c.tag.len(),
+                                ),
+                                format!("duplicate tag ‘@param’ for ‘{}’", name),
                             ));
                         } else {
                             res.push(Tag {
-                                tag: String::from("return"),
+                                tag: String::from("param"),
                                 no,
                                 value,
                             });
                         }
                     } else {
                         ns.diagnostics.push(Diagnostic::error(
-                            pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                            format!("tag ‘@return’ no field ‘{}’", name),
+                            pt::Loc(
+                                file_no,
+                                single_c.offset,
+                                single_c.offset + single_c.tag.len(),
+                            ),
+                            format!("tag ‘@param’ no field ‘{}’", name),
                         ));
                     }
                 }
-            }
-            "inheritdoc" if bases.is_some() => {
-                if c.value.is_empty() {
+                "return" if returns.is_some() => {
+                    let returns = returns.unwrap();
+
+                    if returns.is_empty() {
+                        ns.diagnostics.push(Diagnostic::error(
+                            pt::Loc(
+                                file_no,
+                                single_c.offset,
+                                single_c.offset + single_c.tag.len(),
+                            ),
+                            "tag ‘@return’ for function with no return values".to_string(),
+                        ));
+                    } else if returns.len() == 1 {
+                        if res.iter().any(|e| e.tag == "return") {
+                            ns.diagnostics.push(Diagnostic::error(
+                                pt::Loc(
+                                    file_no,
+                                    single_c.offset,
+                                    single_c.offset + single_c.tag.len(),
+                                ),
+                                "duplicate tag ‘@return’".to_string(),
+                            ));
+                        } else {
+                            res.push(Tag {
+                                tag: String::from("return"),
+                                no: 0,
+                                value: single_c.value.to_owned(),
+                            });
+                        }
+                    } else {
+                        let v: Vec<&str> = single_c.value.splitn(2, char::is_whitespace).collect();
+                        if v.is_empty() || v[0].is_empty() {
+                            ns.diagnostics.push(Diagnostic::error(
+                                pt::Loc(
+                                    file_no,
+                                    single_c.offset,
+                                    single_c.offset + single_c.tag.len(),
+                                ),
+                                "tag ‘@return’ missing parameter name".to_string(),
+                            ));
+                            continue;
+                        }
+                        let name = v[0];
+                        let value = v.get(1).unwrap_or(&"").to_string();
+
+                        if let Some(no) = returns.iter().position(|p| p.name == name) {
+                            if res.iter().any(|e| e.tag == "return" && e.no == no) {
+                                ns.diagnostics.push(Diagnostic::error(
+                                    pt::Loc(
+                                        file_no,
+                                        single_c.offset,
+                                        single_c.offset + single_c.tag.len(),
+                                    ),
+                                    format!("duplicate tag ‘@return’ for ‘{}’", name),
+                                ));
+                            } else {
+                                res.push(Tag {
+                                    tag: String::from("return"),
+                                    no,
+                                    value,
+                                });
+                            }
+                        } else {
+                            ns.diagnostics.push(Diagnostic::error(
+                                pt::Loc(
+                                    file_no,
+                                    single_c.offset,
+                                    single_c.offset + single_c.tag.len(),
+                                ),
+                                format!("tag ‘@return’ no field ‘{}’", name),
+                            ));
+                        }
+                    }
+                }
+                "inheritdoc" if bases.is_some() => {
+                    if single_c.value.is_empty() {
+                        ns.diagnostics.push(Diagnostic::error(
+                            pt::Loc(
+                                file_no,
+                                single_c.offset,
+                                single_c.offset + single_c.tag.len(),
+                            ),
+                            "missing contract for tag ‘@inheritdoc’".to_string(),
+                        ));
+                    } else if bases.unwrap().iter().any(|s| &single_c.value == s) {
+                        res.push(Tag {
+                            tag: String::from("inheritdoc"),
+                            no: 0,
+                            value: single_c.value.to_owned(),
+                        });
+                    } else {
+                        ns.diagnostics.push(Diagnostic::error(
+                            pt::Loc(
+                                file_no,
+                                single_c.offset,
+                                single_c.offset + single_c.tag.len(),
+                            ),
+                            format!(
+                                "base contract ‘{}’ not found in tag ‘@inheritdoc’",
+                                single_c.value
+                            ),
+                        ));
+                    }
+                }
+                _ => {
                     ns.diagnostics.push(Diagnostic::error(
-                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                        "missing contract for tag ‘@inheritdoc’".to_string(),
-                    ));
-                } else if bases.unwrap().iter().any(|s| &c.value == s) {
-                    res.push(Tag {
-                        tag: String::from("inheritdoc"),
-                        no: 0,
-                        value: c.value.to_owned(),
-                    });
-                } else {
-                    ns.diagnostics.push(Diagnostic::error(
-                        pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                        format!("base contract ‘{}’ not found in tag ‘@inheritdoc’", c.value),
+                        pt::Loc(
+                            file_no,
+                            single_c.offset,
+                            single_c.offset + single_c.tag.len(),
+                        ),
+                        format!("tag ‘@{}’ is not valid for {}", single_c.tag, ty),
                     ));
                 }
-            }
-            _ => {
-                ns.diagnostics.push(Diagnostic::error(
-                    pt::Loc(file_no, c.offset, c.offset + c.tag.len()),
-                    format!("tag ‘@{}’ is not valid for {}", c.tag, ty),
-                ));
             }
         }
     }


### PR DESCRIPTION
Resolves https://github.com/hyperledger-labs/solang/issues/620

---

- [x] Differentiate different doc comment styles: line (`/// @author Alexey`) and block (`/** @author Alexey */`)
- [x] Group multiple block doc comments into one introducing `SingleDocComment` that's contained in `DocComment::Block` enum variant
- [x] Preserve newlines in both line and block doc comments, so it would be possible to restore the original formatting of comments