### PR TITLE
Support skiping implicit type cast checking by using flag --no-implicit-type-cast-check

### DIFF
--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -57,10 +57,12 @@ impl SolangServer {
 
             let os_str = path.file_name().unwrap();
 
-            let mut ns = parse_and_resolve(os_str, &mut resolver, self.target);
+            let opt = &Default::default();
+
+            let mut ns = parse_and_resolve(os_str, &mut resolver, self.target, opt);
 
             // codegen all the contracts; some additional errors/warnings will be detected here
-            codegen(&mut ns, &Default::default());
+            codegen(&mut ns, opt);
 
             let diags = ns
                 .diagnostics

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1286,7 +1286,7 @@ pub fn optimize_and_check_cfg(
         vector_to_slice::vector_to_slice(cfg, ns);
     }
     if opt.strength_reduce {
-        strength_reduce::strength_reduce(cfg, ns);
+        strength_reduce::strength_reduce(cfg, ns, opt);
     }
     if opt.dead_storage {
         dead_storage::dead_storage(cfg, ns);

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -1310,7 +1310,7 @@ fn abi_encode_with_signature(
         vec![args_iter.next().unwrap().clone()],
     );
     let hash = expression(&hash, cfg, contract_no, func, ns, vartab, opt);
-    let selector = cast(loc, hash, &Type::Bytes(4), false, ns, &mut Vec::new()).unwrap();
+    let selector = cast(loc, hash, &Type::Bytes(4), false, ns, &mut Vec::new(), opt).unwrap();
     let args = args_iter
         .map(|v| expression(v, cfg, contract_no, func, ns, vartab, opt))
         .collect();
@@ -2285,7 +2285,16 @@ fn array_subscript(
         Instr::Set {
             loc: pt::Loc(0, 0, 0),
             res: pos,
-            expr: cast(&index.loc(), index, &coerced_ty, false, ns, &mut Vec::new()).unwrap(),
+            expr: cast(
+                &index.loc(),
+                index,
+                &coerced_ty,
+                false,
+                ns,
+                &mut Vec::new(),
+                opt,
+            )
+            .unwrap(),
         },
     );
 
@@ -2308,6 +2317,7 @@ fn array_subscript(
                         false,
                         ns,
                         &mut Vec::new(),
+                        opt,
                     )
                     .unwrap(),
                 ),
@@ -2335,6 +2345,7 @@ fn array_subscript(
                     false,
                     ns,
                     &mut Vec::new(),
+                    opt,
                 )
                 .unwrap();
 
@@ -2353,6 +2364,7 @@ fn array_subscript(
                     false,
                     ns,
                     &mut Vec::new(),
+                    opt,
                 )
                 .unwrap();
 
@@ -2410,6 +2422,7 @@ fn array_subscript(
                                         false,
                                         ns,
                                         &mut Vec::new(),
+                                        opt,
                                     )
                                     .unwrap(),
                                 ),
@@ -2434,6 +2447,7 @@ fn array_subscript(
                     false,
                     ns,
                     &mut Vec::new(),
+                    opt,
                 )
                 .unwrap(),
                 elem_ty,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -23,6 +23,8 @@ use crate::emit::Generate;
 use crate::sema::ast::{Layout, Namespace};
 use crate::sema::contracts::visit_bases;
 use crate::sema::diagnostics::any_errors;
+use crate::OptimizationLevel;
+use crate::Options;
 use crate::Target;
 
 use num_bigint::BigInt;
@@ -30,62 +32,6 @@ use num_traits::Zero;
 
 // The sizeof(struct account_data_header)
 pub const SOLANA_FIRST_OFFSET: u64 = 16;
-
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum OptimizationLevel {
-    None = 0,
-    Less = 1,
-    Default = 2,
-    Aggressive = 3,
-}
-
-#[cfg(feature = "llvm")]
-impl From<OptimizationLevel> for inkwell::OptimizationLevel {
-    fn from(level: OptimizationLevel) -> Self {
-        match level {
-            OptimizationLevel::None => inkwell::OptimizationLevel::None,
-            OptimizationLevel::Less => inkwell::OptimizationLevel::Less,
-            OptimizationLevel::Default => inkwell::OptimizationLevel::Default,
-            OptimizationLevel::Aggressive => inkwell::OptimizationLevel::Aggressive,
-        }
-    }
-}
-
-#[cfg(feature = "llvm")]
-impl From<inkwell::OptimizationLevel> for OptimizationLevel {
-    fn from(level: inkwell::OptimizationLevel) -> Self {
-        match level {
-            inkwell::OptimizationLevel::None => OptimizationLevel::None,
-            inkwell::OptimizationLevel::Less => OptimizationLevel::Less,
-            inkwell::OptimizationLevel::Default => OptimizationLevel::Default,
-            inkwell::OptimizationLevel::Aggressive => OptimizationLevel::Aggressive,
-        }
-    }
-}
-
-pub struct Options {
-    pub dead_storage: bool,
-    pub constant_folding: bool,
-    pub strength_reduce: bool,
-    pub vector_to_slice: bool,
-    pub math_overflow_check: bool,
-    pub common_subexpression_elimination: bool,
-    pub opt_level: OptimizationLevel,
-}
-
-impl Default for Options {
-    fn default() -> Self {
-        Options {
-            dead_storage: true,
-            constant_folding: true,
-            strength_reduce: true,
-            vector_to_slice: true,
-            math_overflow_check: false,
-            common_subexpression_elimination: true,
-            opt_level: OptimizationLevel::Default,
-        }
-    }
-}
 
 /// The contracts are fully resolved but they do not have any a CFG which is needed for
 /// the llvm code emitter. This will also do addition code checks.

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -833,7 +833,7 @@ fn returns(
         .iter()
         .zip(uncast_values.into_iter())
         .map(|(left, right)| {
-            let right = cast(&left.loc, right, &left.ty, true, ns, &mut Vec::new())
+            let right = cast(&left.loc, right, &left.ty, true, ns, &mut Vec::new(), opt)
                 .expect("sema should have checked cast");
             // casts to StorageLoad generate LoadStorage instructions
             expression(&right, cfg, contract_no, Some(func), ns, vartab, opt)
@@ -934,7 +934,7 @@ fn destructure(
             }
             DestructureField::VariableDecl(res, param) => {
                 // the resolver did not cast the expression
-                let expr = cast(&param.loc, right, &param.ty, true, ns, &mut Vec::new())
+                let expr = cast(&param.loc, right, &param.ty, true, ns, &mut Vec::new(), opt)
                     .expect("sema should have checked cast");
                 // casts to StorageLoad generate LoadStorage instructions
                 let expr = expression(&expr, cfg, contract_no, Some(func), ns, vartab, opt);
@@ -963,6 +963,7 @@ fn destructure(
                     true,
                     ns,
                     &mut Vec::new(),
+                    opt,
                 )
                 .expect("sema should have checked cast");
                 // casts to StorageLoad generate LoadStorage instructions

--- a/src/sema/format.rs
+++ b/src/sema/format.rs
@@ -2,6 +2,7 @@ use super::ast::{Diagnostic, Expression, FormatArg, Namespace, Type};
 use super::expression::{cast, expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
 use crate::parser::pt;
+use crate::Options;
 
 use std::iter::Peekable;
 use std::slice::Iter;
@@ -19,16 +20,26 @@ pub fn string_format(
     ns: &mut Namespace,
     symtable: &mut Symtable,
     diagnostics: &mut Vec<Diagnostic>,
+    opt: &Options,
 ) -> Result<Expression, ()> {
     // first resolve the arguments. We can't say anything about the format string if the args are broken
     let mut resolved_args = Vec::new();
 
     for arg in args {
-        let expr = expression(arg, context, ns, symtable, diagnostics, ResolveTo::Unknown)?;
+        let expr = expression(
+            arg,
+            context,
+            ns,
+            symtable,
+            diagnostics,
+            ResolveTo::Unknown,
+            opt,
+        )?;
 
         let ty = expr.ty();
 
-        resolved_args.push(cast(&arg.loc(), expr, ty.deref_any(), true, ns, diagnostics).unwrap());
+        resolved_args
+            .push(cast(&arg.loc(), expr, ty.deref_any(), true, ns, diagnostics, opt).unwrap());
     }
 
     let mut format_iterator = FormatIterator::new(literals).peekable();

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -1,4 +1,4 @@
-use solang::{file_resolver::FileResolver, parse_and_resolve, Target};
+use solang::{file_resolver::FileResolver, parse_and_resolve, Options, Target};
 use std::{
     ffi::OsStr,
     fs::{read_dir, File},
@@ -56,7 +56,12 @@ fn parse_file(path: PathBuf, target: Target) -> io::Result<()> {
     // The files may have had their end of lines mangled on Windows
     cache.set_file_contents(&filename, source.replace("\r\n", "\n"));
 
-    let ns = parse_and_resolve(OsStr::new(&filename), &mut cache, target);
+    let ns = parse_and_resolve(
+        OsStr::new(&filename),
+        &mut cache,
+        target,
+        &Options::default(),
+    );
 
     let mut path = path;
 

--- a/tests/ewasm.rs
+++ b/tests/ewasm.rs
@@ -11,7 +11,7 @@ use tiny_keccak::{Hasher, Keccak};
 use wasmi::memory_units::Pages;
 use wasmi::*;
 
-use solang::{compile, file_resolver::FileResolver, sema::diagnostics, Target};
+use solang::{compile, file_resolver::FileResolver, sema::diagnostics, Options, Target};
 
 mod ewasm_tests;
 
@@ -821,6 +821,7 @@ fn build_solidity(src: &str) -> TestRuntime {
         inkwell::OptimizationLevel::Default,
         Target::Ewasm,
         false,
+        &Options::default(),
     );
 
     diagnostics::print_messages(&cache, &ns, false);

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -18,13 +18,8 @@ use solana_rbpf::{
     vm::{Config, EbpfVm, SyscallObject, SyscallRegistry, TestInstructionMeter},
 };
 use solang::{
-    abi::generate_abi,
-    codegen::{codegen, Options},
-    compile_many,
-    emit::Generate,
-    file_resolver::FileResolver,
-    sema::diagnostics,
-    Target,
+    abi::generate_abi, codegen::codegen, compile_many, emit::Generate, file_resolver::FileResolver,
+    sema::diagnostics, Options, Target,
 };
 use std::{
     alloc::Layout,
@@ -119,7 +114,12 @@ fn build_solidity(src: &str) -> VirtualMachine {
 
     cache.set_file_contents("test.sol", src.to_string());
 
-    let mut ns = solang::parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
+    let mut ns = solang::parse_and_resolve(
+        OsStr::new("test.sol"),
+        &mut cache,
+        Target::Solana,
+        &Options::default(),
+    );
 
     // codegen all the contracts; some additional errors/warnings will be detected here
     codegen(&mut ns, &Options::default());

--- a/tests/solana_tests/simple.rs
+++ b/tests/solana_tests/simple.rs
@@ -1,5 +1,5 @@
 use crate::build_solidity;
-use solang::{file_resolver::FileResolver, Target};
+use solang::{file_resolver::FileResolver, Options, Target};
 use std::ffi::OsStr;
 
 #[test]
@@ -275,7 +275,12 @@ contract line {
 
     cache.set_file_contents("test.sol", src);
 
-    let ns = solang::parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
+    let ns = solang::parse_and_resolve(
+        OsStr::new("test.sol"),
+        &mut cache,
+        Target::Solana,
+        &Options::default(),
+    );
 
     solang::sema::diagnostics::print_messages(&cache, &ns, false);
 

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -12,7 +12,7 @@ use solang::abi;
 use solang::file_resolver::FileResolver;
 use solang::sema::ast;
 use solang::sema::diagnostics;
-use solang::{compile, Target};
+use solang::{compile, Options, Target};
 
 mod substrate_tests;
 
@@ -1188,6 +1188,7 @@ pub fn build_solidity(src: &'static str) -> TestRuntime {
         inkwell::OptimizationLevel::Default,
         Target::default_substrate(),
         false,
+        &Options::default(),
     );
 
     diagnostics::print_messages(&cache, &ns, false);
@@ -1225,6 +1226,7 @@ pub fn build_solidity_with_overflow_check(src: &'static str) -> TestRuntime {
         inkwell::OptimizationLevel::Default,
         Target::default_substrate(),
         true,
+        &Options::default(),
     );
 
     diagnostics::print_messages(&cache, &ns, false);

--- a/tests/substrate_tests/events.rs
+++ b/tests/substrate_tests/events.rs
@@ -1,7 +1,7 @@
 use crate::{build_solidity, no_errors};
 use parity_scale_codec::Encode;
 use parity_scale_codec_derive::Decode;
-use solang::{file_resolver::FileResolver, Target};
+use solang::{file_resolver::FileResolver, Options, Target};
 use std::ffi::OsStr;
 
 #[test]
@@ -86,8 +86,12 @@ fn event_imported() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -117,8 +121,12 @@ fn event_imported() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -148,8 +156,12 @@ fn event_imported() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -177,8 +189,12 @@ fn event_imported() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 }

--- a/tests/substrate_tests/imports.rs
+++ b/tests/substrate_tests/imports.rs
@@ -1,6 +1,6 @@
 use crate::{first_error, no_errors};
 use solang::file_resolver::FileResolver;
-use solang::Target;
+use solang::{Options, Target};
 use std::ffi::OsStr;
 
 #[test]
@@ -27,8 +27,12 @@ fn enum_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -54,8 +58,12 @@ fn enum_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -81,8 +89,12 @@ fn enum_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -104,8 +116,12 @@ fn enum_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     assert_eq!(
         first_error(ns.diagnostics),
@@ -123,8 +139,12 @@ fn enum_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     assert_eq!(
         first_error(ns.diagnostics),
@@ -141,8 +161,12 @@ fn enum_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     assert_eq!(
         first_error(ns.diagnostics),
@@ -174,8 +198,12 @@ fn struct_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -201,8 +229,12 @@ fn struct_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     assert_eq!(first_error(ns.diagnostics), "type ‘struct_a’ not found");
 }
@@ -239,8 +271,12 @@ fn contract_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -283,8 +319,12 @@ fn contract_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -327,8 +367,12 @@ fn contract_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 }
@@ -355,6 +399,7 @@ fn circular_import() {
         OsStr::new("self.sol"),
         &mut cache,
         Target::default_substrate(),
+        &Options::default(),
     );
 
     no_errors(ns.diagnostics);
@@ -396,8 +441,12 @@ fn circular_import() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 }
@@ -431,8 +480,12 @@ fn import_symbol() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -467,8 +520,12 @@ fn import_symbol() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -503,8 +560,12 @@ fn import_symbol() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -549,8 +610,12 @@ fn import_symbol() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 }
@@ -600,8 +665,12 @@ fn enum_import_chain() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 
@@ -648,8 +717,12 @@ fn enum_import_chain() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     assert_eq!(
         first_error(ns.diagnostics),
@@ -698,8 +771,12 @@ fn import_base_dir() {
         .to_string(),
     );
 
-    let ns =
-        solang::parse_and_resolve(OsStr::new("a.sol"), &mut cache, Target::default_substrate());
+    let ns = solang::parse_and_resolve(
+        OsStr::new("a.sol"),
+        &mut cache,
+        Target::default_substrate(),
+        &Options::default(),
+    );
 
     no_errors(ns.diagnostics);
 }

--- a/tests/substrate_tests/inheritance.rs
+++ b/tests/substrate_tests/inheritance.rs
@@ -2,7 +2,7 @@ use crate::{build_solidity, no_errors};
 use parity_scale_codec::Encode;
 use parity_scale_codec_derive::Decode;
 use solang::file_resolver::FileResolver;
-use solang::Target;
+use solang::{Options, Target};
 use std::ffi::OsStr;
 
 #[test]
@@ -35,6 +35,7 @@ fn test_abstract() {
         inkwell::OptimizationLevel::Default,
         Target::default_substrate(),
         false,
+        &Options::default(),
     );
 
     no_errors(ns.diagnostics);
@@ -73,6 +74,7 @@ fn test_abstract() {
         inkwell::OptimizationLevel::Default,
         Target::default_substrate(),
         false,
+        &Options::default(),
     );
 
     no_errors(ns.diagnostics);

--- a/tests/undefined_variable_detection.rs
+++ b/tests/undefined_variable_detection.rs
@@ -1,14 +1,19 @@
-use solang::codegen::{codegen, OptimizationLevel, Options};
+use solang::codegen::codegen;
 use solang::file_resolver::FileResolver;
 use solang::sema::ast::Diagnostic;
 use solang::sema::ast::{Level, Namespace};
-use solang::{parse_and_resolve, Target};
+use solang::{parse_and_resolve, OptimizationLevel, Options, Target};
 use std::ffi::OsStr;
 
 fn parse_and_codegen(src: &'static str) -> Namespace {
     let mut cache = FileResolver::new();
     cache.set_file_contents("test.sol", src.to_string());
-    let mut ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Ewasm);
+    let mut ns = parse_and_resolve(
+        OsStr::new("test.sol"),
+        &mut cache,
+        Target::Ewasm,
+        &Options::default(),
+    );
 
     let opt = Options {
         dead_storage: false,
@@ -16,6 +21,7 @@ fn parse_and_codegen(src: &'static str) -> Namespace {
         strength_reduce: false,
         vector_to_slice: false,
         common_subexpression_elimination: false,
+        implicit_type_cast_check: false,
         opt_level: OptimizationLevel::Default,
         math_overflow_check: false,
     };

--- a/tests/unused_variable_detection.rs
+++ b/tests/unused_variable_detection.rs
@@ -2,14 +2,19 @@ use itertools::Itertools;
 use solang::file_resolver::FileResolver;
 use solang::sema::ast;
 use solang::sema::ast::{Diagnostic, Level};
-use solang::{parse_and_resolve, Target};
+use solang::{parse_and_resolve, Options, Target};
 use std::ffi::OsStr;
 
 fn parse(src: &'static str) -> ast::Namespace {
     let mut cache = FileResolver::new();
     cache.set_file_contents("test.sol", src.to_string());
 
-    parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Ewasm)
+    parse_and_resolve(
+        OsStr::new("test.sol"),
+        &mut cache,
+        Target::Ewasm,
+        &Options::default(),
+    )
 }
 
 fn parse_two_files(src1: &'static str, src2: &'static str) -> ast::Namespace {
@@ -17,7 +22,12 @@ fn parse_two_files(src1: &'static str, src2: &'static str) -> ast::Namespace {
     cache.set_file_contents("test.sol", src1.to_string());
     cache.set_file_contents("test2.sol", src2.to_string());
 
-    parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Ewasm)
+    parse_and_resolve(
+        OsStr::new("test.sol"),
+        &mut cache,
+        Target::Ewasm,
+        &Options::default(),
+    )
 }
 
 fn count_warnings(diagnostics: &[Diagnostic]) -> usize {


### PR DESCRIPTION
Hi,

I created this PR to resolve the issue reported in https://github.com/hyperledger-labs/solang/issues/632 where Solang reports errors on implicit type truncation of integers (which Solc can compile well).

In particular, I added a field `pub implicit_type_cast_check: bool` into the structure `Options` to capture this flag.

I also move the structure `Options` from `codegen/mod.rs` into `lib.rs` so that the compiler options can be accessed by both `sema` and `codegen` modules.

Can you review this PR and advise if my implementation can be merged?

Thank you!

