### PR TITLE
Fix invalid llvm IR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ serde = "1.0"
 serde_derive = { version = "1.0" }
 inkwell = { version = "^0.1.0-beta.3", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm13-0"], optional = true }
 blake2-rfc = "0.2.18"
-handlebars = "4.1"
+handlebars = "4.2"
 contract-metadata = "0.3.0"
 semver = { version = "^1.0.3", features = ["serde"] }
-tempfile = "3.1"
+tempfile = "3.3"
 libc = { version = "0.2", optional = true }
 tower-lsp = "0.14"
-tokio = { version = "1.6", features = ["rt", "io-std", "macros"] }
+tokio = { version = "1.16", features = ["rt", "io-std", "macros"] }
 base58 = "0.2.0"
 sha2 = "0.10"
 ripemd = "0.1"
@@ -40,7 +40,7 @@ bitvec = "0.20"
 funty = "=1.1.0"
 itertools = "0.10"
 num-rational = "0.4"
-indexmap = "1.7"
+indexmap = "1.8"
 once_cell = "1.9"
 solang-parser = { path = "solang-parser", version = "0.1.1" }
 

--- a/src/emit/ewasm.rs
+++ b/src/emit/ewasm.rs
@@ -1670,6 +1670,8 @@ impl<'a> TargetRuntime<'a> for EwasmTarget {
                 .into()],
             "terminated",
         );
+
+        binary.builder.build_unreachable();
     }
 
     /// Crypto Hash

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -4328,7 +4328,7 @@ pub trait TargetRuntime<'a> {
                         }
                     }
                     Instr::Unreachable => {
-                        bin.builder.build_unreachable();
+                        // Nothing to do; unreachable instruction should have already been inserteds
                     }
                     Instr::SelfDestruct { recipient } => {
                         let recipient = self

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -3901,6 +3901,8 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
             ],
             "terminated",
         );
+
+        binary.builder.build_unreachable();
     }
 
     /// Crypto Hash


### PR DESCRIPTION
LLVM permits invalid IR in many cases, which llc or llvm-dis does not permit.

Fixes #641 