### PR TITLE
Allow comparisons between bytes32 and 0

### DIFF
--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -361,6 +361,12 @@ fn coerce_number(
         (Type::Bytes(left_length), Type::Bytes(right_length)) if allow_bytes => {
             return Ok(Type::Bytes(std::cmp::max(*left_length, *right_length)));
         }
+        (Type::Bytes(_), _) if allow_bytes => {
+            return Ok(l.clone());
+        }
+        (_, Type::Bytes(_)) if allow_bytes => {
+            return Ok(r.clone());
+        }
         (Type::Rational, Type::Int(_)) => {
             return Ok(Type::Rational);
         }

--- a/tests/solana_tests/expressions.rs
+++ b/tests/solana_tests/expressions.rs
@@ -142,3 +142,41 @@ fn read_buffer() {
     let res = vm.function_must_fail("test2", &[Token::Bytes(buf)], &[], 0, None);
     assert_eq!(res, Ok(4294967296));
 }
+
+#[test]
+fn bytes_compare() {
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            function test1(bytes4 bs) public returns (bool) {
+                return bs != 0;
+            }
+
+            function test2(bytes4 bs) public returns (bool) {
+                return bs == 0;
+            }
+        }"#,
+    );
+
+    vm.constructor("foo", &[], 0);
+
+    let returns = vm.function(
+        "test1",
+        &[Token::FixedBytes([0xbc, 0xbc, 0xbd, 0xbe].to_vec())],
+        &[],
+        0,
+        None,
+    );
+
+    assert_eq!(returns, vec![Token::Bool(true)]);
+
+    let returns = vm.function(
+        "test2",
+        &[Token::FixedBytes([0xbc, 0xbc, 0xbd, 0xbe].to_vec())],
+        &[],
+        0,
+        None,
+    );
+
+    assert_eq!(returns, vec![Token::Bool(false)]);
+}


### PR DESCRIPTION
The constant 0 can be implicitly converted to a fixed-bytes value, so
the following statement should be allowed:

function foo(bytes4 bs) public returns (bool) {
	return bs > 0;
}

Found in the example code of #643
