### PR TITLE
Fix line comments that end in non-ascii character

### DIFF
--- a/solang-parser/src/lexer.rs
+++ b/solang-parser/src/lexer.rs
@@ -903,10 +903,10 @@ impl<'input> Lexer<'input> {
 
                             if !newline {
                                 for (i, ch) in &mut self.chars {
+                                    last = i;
                                     if ch == '\n' || ch == '\r' {
                                         break;
                                     }
-                                    last = i;
                                 }
                             }
 
@@ -916,15 +916,15 @@ impl<'input> Lexer<'input> {
                                         start + 3,
                                         Token::DocComment(
                                             CommentType::Line,
-                                            &self.input[doc_start..=last],
+                                            &self.input[doc_start..last],
                                         ),
-                                        last + 1,
+                                        last,
                                     )));
                                 }
                             } else {
                                 self.comments.push(Comment::Line(
-                                    Loc(self.file_no, start, last + 1),
-                                    self.input[start..=last].to_owned(),
+                                    Loc(self.file_no, start, last),
+                                    self.input[start..last].to_owned(),
                                 ));
                             }
                         }

--- a/tests/contract_testcases/solana/comment.dot
+++ b/tests/contract_testcases/solana/comment.dot
@@ -1,0 +1,8 @@
+strict digraph "tests/contract_testcases/solana/comment.sol" {
+	contract [label="contract Hello\ntests/contract_testcases/solana/comment.sol:1:24-2:16"]
+	diagnostic [label="pragma ‘solidity’ is ignored\nlevel Debug\ntests/contract_testcases/solana/comment.sol:1:8-23"]
+	diagnostic_6 [label="found contract ‘Hello’\nlevel Debug\ntests/contract_testcases/solana/comment.sol:1:24-2:16"]
+	contracts -> contract
+	diagnostics -> diagnostic [label="Debug"]
+	diagnostics -> diagnostic_6 [label="Debug"]
+}

--- a/tests/contract_testcases/solana/comment.sol
+++ b/tests/contract_testcases/solana/comment.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.8.0;
+contract Hello {
+    // xxx 。
+}
+


### PR DESCRIPTION
The lexer assumed the last character was 1 byte.

Fixes #660 