### PR TITLE
feat(parser): add support for custom error types

### DIFF
--- a/solang-parser/src/lexer.rs
+++ b/solang-parser/src/lexer.rs
@@ -39,6 +39,7 @@ pub enum Token<'input> {
 
     Struct,
     Event,
+    Error,
     Enum,
 
     Memory,
@@ -260,6 +261,7 @@ impl<'input> fmt::Display for Token<'input> {
             Token::Import => write!(f, "import"),
             Token::Struct => write!(f, "struct"),
             Token::Event => write!(f, "event"),
+            Token::Error => write!(f, "error"),
             Token::Enum => write!(f, "enum"),
             Token::Memory => write!(f, "memory"),
             Token::Storage => write!(f, "storage"),
@@ -441,6 +443,7 @@ static KEYWORDS: phf::Map<&'static str, Token> = phf_map! {
     "emit" => Token::Emit,
     "enum" => Token::Enum,
     "event" => Token::Event,
+    "error" => Token::Error,
     "external" => Token::External,
     "false" => Token::False,
     "for" => Token::For,

--- a/solang-parser/src/lib.rs
+++ b/solang-parser/src/lib.rs
@@ -617,4 +617,245 @@ mod test {
             ]
         )
     }
+
+    #[test]
+    fn parse_error_test() {
+        let src = r#"
+
+        error Outer(uint256 available, uint256 required);
+
+        contract TestToken {
+            error NotPending();
+            /// Insufficient balance for transfer. Needed `required` but only
+            /// `available` available.
+            /// @param available balance available.
+            /// @param required requested amount to transfer.
+            error InsufficientBalance(uint256 available, uint256 required);
+        }
+        "#;
+
+        let (actual_parse_tree, _) = crate::parse(src, 0).unwrap();
+        assert_eq!(actual_parse_tree.0.len(), 2);
+
+        let expected_parse_tree = SourceUnit
+            (vec![
+                SourceUnitPart::ErrorDefinition(Box::new(ErrorDefinition {
+                    doc: vec![],
+                    loc: Loc(
+                        0,
+                        10,
+                        58,
+                    ),
+                    name: Identifier {
+                        loc: Loc(
+                            0,
+                            16,
+                            21,
+                        ),
+                        name: "Outer".to_string(),
+                    },
+                    fields: vec![
+                        ErrorParameter {
+                            ty: Expression::Type(
+                                Loc(
+                                    0,
+                                    22,
+                                    29,
+                                ),
+                                Type::Uint(
+                                    256,
+                                ),
+                            ),
+                            loc: Loc(
+                                0,
+                                22,
+                                39,
+                            ),
+                            name: Some(
+                                Identifier {
+                                    loc: Loc(
+                                        0,
+                                        30,
+                                        39,
+                                    ),
+                                    name: "available".to_string(),
+                                },
+                            ),
+                        },
+                        ErrorParameter {
+                            ty: Expression::Type(
+                                Loc(
+                                    0,
+                                    41,
+                                    48,
+                                ),
+                                Type::Uint(
+                                    256,
+                                ),
+                            ),
+                            loc: Loc(
+                                0,
+                                41,
+                                57,
+                            ),
+                            name: Some(
+                                Identifier {
+                                    loc: Loc(
+                                        0,
+                                        49,
+                                        57,
+                                    ),
+                                    name: "required".to_string(),
+                                },
+                            ),
+                        },
+                    ],
+                })),
+                SourceUnitPart::ContractDefinition(Box::new(
+                    ContractDefinition {
+                        doc: vec![],
+                        loc: Loc(
+                            0,
+                            69,
+                            88,
+                        ),
+                        ty: ContractTy::Contract(
+                            Loc(
+                                0,
+                                69,
+                                77,
+                            ),
+                        ),
+                        name: Identifier {
+                            loc: Loc(
+                                0,
+                                78,
+                                87,
+                            ),
+                            name: "TestToken".to_string(),
+                        },
+                        base: vec![],
+                        parts: vec![
+                            ContractPart::ErrorDefinition(Box::new(
+                                ErrorDefinition {
+                                    doc: vec![],
+                                    loc: Loc(
+                                        0,
+                                        102,
+                                        120,
+                                    ),
+                                    name: Identifier {
+                                        loc: Loc(
+                                            0,
+                                            108,
+                                            118,
+                                        ),
+                                        name: "NotPending".to_string(),
+                                    },
+                                    fields: vec![],
+                                },
+                            )),
+                            ContractPart::ErrorDefinition(Box::new(
+                                ErrorDefinition {
+                                    doc: vec![
+                                        DocComment::Line {
+                                            comment: SingleDocComment {
+                                                offset: 137,
+                                                tag: "notice".to_string(),
+                                                value: "Insufficient balance for transfer. Needed `required` but only\n`available` available.".to_string(),
+                                            },
+                                        },
+                                        DocComment::Line {
+                                            comment: SingleDocComment {
+                                                offset: 0,
+                                                tag: "param".to_string(),
+                                                value: "available balance available.".to_string(),
+                                            },
+                                        },
+                                        DocComment::Line {
+                                            comment: SingleDocComment {
+                                                offset: 0,
+                                                tag: "param".to_string(),
+                                                value: "required requested amount to transfer.".to_string(),
+                                            },
+                                        },
+                                    ],
+                                    loc: Loc(
+                                        0,
+                                        365,
+                                        427,
+                                    ),
+                                    name: Identifier {
+                                        loc: Loc(
+                                            0,
+                                            371,
+                                            390,
+                                        ),
+                                        name: "InsufficientBalance".to_string(),
+                                    },
+                                    fields: vec![
+                                        ErrorParameter {
+                                            ty: Expression::Type(
+                                                Loc(
+                                                    0,
+                                                    391,
+                                                    398,
+                                                ),
+                                                Type::Uint(
+                                                    256,
+                                                ),
+                                            ),
+                                            loc: Loc(
+                                                0,
+                                                391,
+                                                408,
+                                            ),
+                                            name: Some(
+                                                Identifier {
+                                                    loc: Loc(
+                                                        0,
+                                                        399,
+                                                        408,
+                                                    ),
+                                                    name: "available".to_string(),
+                                                },
+                                            ),
+                                        },
+                                        ErrorParameter {
+                                            ty: Expression::Type(
+                                                Loc(
+                                                    0,
+                                                    410,
+                                                    417,
+                                                ),
+                                                Type::Uint(
+                                                    256,
+                                                ),
+                                            ),
+                                            loc: Loc(
+                                                0,
+                                                410,
+                                                426,
+                                            ),
+                                            name: Some(
+                                                Identifier {
+                                                    loc: Loc(
+                                                        0,
+                                                        418,
+                                                        426,
+                                                    ),
+                                                    name: "required".to_string(),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            )),
+                        ],
+                    },
+                ))
+            ]);
+
+        assert_eq!(actual_parse_tree, expected_parse_tree);
+    }
 }

--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -66,6 +66,7 @@ pub enum SourceUnitPart {
     EnumDefinition(Box<EnumDefinition>),
     StructDefinition(Box<StructDefinition>),
     EventDefinition(Box<EventDefinition>),
+    ErrorDefinition(Box<ErrorDefinition>),
     FunctionDefinition(Box<FunctionDefinition>),
     VariableDefinition(Box<VariableDefinition>),
     StraySemicolon(Loc),
@@ -148,6 +149,7 @@ pub enum ContractPart {
     StructDefinition(Box<StructDefinition>),
     EventDefinition(Box<EventDefinition>),
     EnumDefinition(Box<EnumDefinition>),
+    ErrorDefinition(Box<ErrorDefinition>),
     VariableDefinition(Box<VariableDefinition>),
     FunctionDefinition(Box<FunctionDefinition>),
     StraySemicolon(Loc),
@@ -212,6 +214,21 @@ pub struct EventDefinition {
     pub name: Identifier,
     pub fields: Vec<EventParameter>,
     pub anonymous: bool,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ErrorParameter {
+    pub ty: Expression,
+    pub loc: Loc,
+    pub name: Option<Identifier>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ErrorDefinition {
+    pub doc: Vec<DocComment>,
+    pub loc: Loc,
+    pub name: Identifier,
+    pub fields: Vec<ErrorParameter>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -23,6 +23,7 @@ SourceUnitPart: SourceUnitPart = {
     EnumDefinition => SourceUnitPart::EnumDefinition(<>),
     StructDefinition => SourceUnitPart::StructDefinition(<>),
     EventDefinition => SourceUnitPart::EventDefinition(<>),
+    ErrorDefinition => SourceUnitPart::ErrorDefinition(<>),
     FunctionDefinition => SourceUnitPart::FunctionDefinition(<>),
     VariableDefinition => SourceUnitPart::VariableDefinition(<>),
     <l:@L> ";" <r:@R> => SourceUnitPart::StraySemicolon(Loc(file_no, l, r)),
@@ -154,6 +155,7 @@ ContractTy: ContractTy = {
 ContractPart: ContractPart = {
     StructDefinition => ContractPart::StructDefinition(<>),
     EventDefinition => ContractPart::EventDefinition(<>),
+    ErrorDefinition => ContractPart::ErrorDefinition(<>),
     EnumDefinition => ContractPart::EnumDefinition(<>),
     VariableDefinition => ContractPart::VariableDefinition(<>),
     FunctionDefinition => ContractPart::FunctionDefinition(<>),
@@ -189,10 +191,24 @@ EventParameter: EventParameter = {
     }
 }
 
+ErrorParameter: ErrorParameter = {
+    <l:@L> <ty:Precedence0> <name:SolIdentifier?> <r:@R> => ErrorParameter{
+        loc: Loc(file_no, l, r), ty, name
+    }
+}
+
 EventDefinition: Box<EventDefinition> = {
     <doc:DocComments> <l:@L> "event" <name:SolIdentifier> "(" <v:Comma<EventParameter>> ")" <a:"anonymous"?> <r:@R> ";" => {
         Box::new(EventDefinition{
             loc: Loc(file_no, l, r), doc, name, fields: v, anonymous: a.is_some()
+        })
+    },
+}
+
+ErrorDefinition: Box<ErrorDefinition> = {
+    <doc:DocComments> <l:@L> "error" <name:SolIdentifier> "(" <v:Comma<ErrorParameter>> ")" <r:@R> ";" => {
+        Box::new(ErrorDefinition{
+            loc: Loc(file_no, l, r), doc, name, fields: v
         })
     },
 }
@@ -957,6 +973,7 @@ extern {
         "interface" => Token::Interface,
         "library" => Token::Library,
         "event" => Token::Event,
+        "error" => Token::Error,
         "enum" => Token::Enum,
         "public" => Token::Public,
         "private" => Token::Private,


### PR DESCRIPTION
Add
* ErrorDefinition
* ErrorParameter

support in lalrpop and ast types (based on existing EventDef/EventParam), following https://docs.soliditylang.org/en/v0.8.11/grammar.html#a4.SolidityParser.errorDefinition

