### PR TITLE
Add tests for msg.sender system call

### DIFF
--- a/integration/substrate/mgs_sender.sol
+++ b/integration/substrate/mgs_sender.sol
@@ -1,0 +1,8 @@
+contract mytoken {
+    function test(address account, bool sender) public view returns (address) {
+        if (sender) {
+            return msg.sender;
+        }
+        return msg.sender;
+    }
+}

--- a/integration/substrate/msg_sender.spec.ts
+++ b/integration/substrate/msg_sender.spec.ts
@@ -1,0 +1,50 @@
+import expect from "expect";
+import {aliceKeypair, createConnection, deploy, gasLimit, transaction} from "./index";
+import {ContractPromise} from "@polkadot/api-contract";
+import {DecodedEvent} from "@polkadot/api-contract/types";
+import {ApiPromise} from "@polkadot/api";
+
+describe('Deploy mytoken contract and test', () => {
+    let conn: ApiPromise
+
+    beforeEach(async function() {
+       conn = await createConnection();
+    });
+
+    afterEach(async function () {
+        await conn.disconnect();
+    });
+
+    it('mytoken', async function() {
+        this.timeout(100000);
+
+        const alice = aliceKeypair();
+
+        let deployed_contract = await deploy(conn, alice, 'mytoken.contract');
+        let contract = new ContractPromise(conn, deployed_contract.abi, deployed_contract.address);
+
+        let res = await contract.query.test(alice.address, {}, alice.address, true);
+        expect(res.output?.toJSON()).toEqual(alice.address);
+
+        res = await contract.query.test(alice.address, {}, alice.address, false);
+        expect(res.output?.toJSON()).toEqual(alice.address);
+    });
+
+    it('mytokenEvent', async function() {
+        this.timeout(100000);
+
+        const alice = aliceKeypair();
+
+        let deployed_contract = await deploy(conn, alice, 'mytokenEvent.contract');
+        let contract = new ContractPromise(conn, deployed_contract.abi, deployed_contract.address);
+        let tx = contract.tx.test({ gasLimit });
+        let res0: any = await transaction(tx, alice);
+
+        let events : DecodedEvent[] = res0.contractEvents;
+
+        expect(events.length).toEqual(1);
+
+        expect(events[0].event.identifier).toBe("Debugging");
+        expect(events[0].args.map(a => a.toJSON())).toEqual([alice.address]);
+    });
+});

--- a/integration/substrate/msg_sender_event.sol
+++ b/integration/substrate/msg_sender_event.sol
@@ -1,0 +1,7 @@
+contract mytokenEvent {
+    event Debugging(address b);
+
+    function test() public {
+        emit Debugging(msg.sender);
+    }
+}

--- a/tests/substrate_tests/builtins.rs
+++ b/tests/substrate_tests/builtins.rs
@@ -677,3 +677,32 @@ fn mulmod() {
 
     runtime.function("test", Vec::new());
 }
+
+#[test]
+fn my_token() {
+    #[derive(Debug, PartialEq, Encode, Decode)]
+    struct TokenTest([u8; 32], bool);
+    let mut runtime = build_solidity(
+        "
+        contract mytoken {
+            function test(address account, bool sender) public view returns (address) {
+                if (sender) {
+                    return msg.sender;
+                }
+                return account;
+            }
+        }
+        ",
+    );
+
+    let addr: [u8; 32] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+        0x16, 0x17, 0x18, 0x19, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x30,
+        0x31, 0x32,
+    ];
+    runtime.function("test", TokenTest(addr, true).encode());
+    assert_eq!(&runtime.vm.caller[..], &runtime.vm.output[..]);
+
+    runtime.function("test", TokenTest(addr, false).encode());
+    assert_eq!(&runtime.vm.output[..], &addr[..]);
+}


### PR DESCRIPTION
This PR includes tests for the `msg.sender` system call.