### PR TITLE
Barcelona Release v0.1.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
       - name: Run cargo clippy
-        run: cargo clippy --tests --bins -- -D warnings -D clippy::inconsistent-struct-constructor
+        run: cargo clippy --workspace --tests --bins -- -D warnings -D clippy::inconsistent-struct-constructor
 
   linux-x86-64:
     name: Linux x86-64
@@ -94,7 +94,7 @@ jobs:
         components: clippy
     # We run clippy on Linux in the lint job above, but this does not check #[cfg(windows)] items
     - name: Run cargo clippy
-      run: cargo clippy --tests --bins -- -D warnings -D clippy::inconsistent-struct-constructor
+      run: cargo clippy --workspace --tests --bins -- -D warnings -D clippy::inconsistent-struct-constructor
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to [Solang](https://github.com/hyperledger-labs/solang/)
 will be documented here.
 
-## [Unreleased]
+## [0.1.10]
 
 ### Added
 - On Solana, the accounts that were passed into the transactions are listed in
@@ -10,10 +10,13 @@ will be documented here.
 - A new common subexpression elimination pass was added, thanks to
   [LucasSte](https://github.com/hyperledger-labs/solang/pull/550)
 - A graphviz dot file can be generated from the ast, using `--emit ast-dot`
+- Many improvements to the solidity parser, and the parser has been spun out
+  in it's own create `solang-parser`.
 
 ### Changed
 - Solang now uses LLVM 13.0, based on the [Solana LLVM tree](https://github.com/solana-labs/llvm-project/)
 - The ast datastructure has been simplified.
+- Many bugfixes across the entire tree.
 
 ## [0.1.9]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ regex = "1"
 num-bigint = "0.4"
 num-traits = "0.2"
 parity-wasm = "0.42"
-clap = "3.0"
+clap = "3.1"
 hex = "0.4"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = { version = "1.0" }
-inkwell = { version = "^0.1.0-beta.3", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm13-0"], optional = true }
+inkwell = { version = "^0.1.0-beta.4", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm13-0"], optional = true }
 blake2-rfc = "0.2.18"
 handlebars = "4.2"
 contract-metadata = "0.3.0"
@@ -54,7 +54,7 @@ wasmi = "0.11"
 rand = "0.7"
 sha2 = "0.10"
 # solana_rbpf makes api changes in patch versions
-solana_rbpf = "=0.2.23"
+solana_rbpf = "=0.2.24"
 byteorder = "1.3"
 assert_cmd = "2.0"
 bincode = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,6 +1,7 @@
 # Release Checklist
 
-- Update the version in `Cargo.toml`, the binary links in `docs/installing.rst`, and `CHANGELOG.md`
+- Update the version in `Cargo.toml`, `solang-parser/Cargo.toml`, the binary
+  links in `docs/installing.rst`, and `CHANGELOG.md`
 - Copy the contents of the CHANGELOG for this release into commit message
 - Ensure the cargo publish is happy `cargo publish --dry-run`
 - Try the release github actions by pushing a tag to your solang fork

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -6,27 +6,23 @@ The Solang compiler is a single binary. It can be installed in different ways.
 Download release binaries
 -------------------------
 
-For Linux x86-64, there is a binary available in the github releases:
+There are binaries available on github releases:
 
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang-linux>`_
+- `Linux x86-64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/solang-mac-arm>`_
 
-For Windows x64, there is a binary available:
-
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang.exe>`_
-
-For MacOS, there is an arm and intel binary available.
-Remember to remove the quarantine attribute using ``xattr -d com.apple.quarantine solang-mac-arm`` in the terminal.
-
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang-mac-arm>`_
-
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.9/solang-mac-intel>`_
+On MacOS, remember to remove the quarantine attribute using ``xattr -d com.apple.quarantine solang-mac-arm``
+in the terminal.
 
 Using ghcr.io/hyperledger-labs/solang containers
 ------------------------------------------------
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger-labs/solang/pkgs/container/solang>`_.
-There is a release `v0.1.9` tag and a `latest` tag:
+There is a release `v0.1.10` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -68,7 +64,7 @@ These patches make it possible to generate code for Solana, and fixes some
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger-labs/solang/releases/tag/v0.1.9>`_
+`github <https://github.com/hyperledger-labs/solang/releases/tag/v0.1.10>`_
 or build your own from source. After that, you need to add the `bin` directory to your
 path, so that the build system of Solang can find the correct version of llvm to use.
 
@@ -76,7 +72,7 @@ Installing LLVM on Linux
 ________________________
 
 A pre-built version of llvm, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/llvm13.0-1/llvm13.0-linux-x86-64.tar.xz>`_.
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/llvm13.0-linux-x86-64.tar.xz>`_.
 After downloading, untar the file in a terminal and add it to your path.
 
 .. code-block:: bash
@@ -88,7 +84,7 @@ Installing LLVM on Windows
 __________________________
 
 A pre-built version of llvm, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/llvm13.0-1/llvm13.0-win.zip>`_.
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/llvm13.0-win.zip>`_.
 
 After unzipping the file, add the bin directory to your path.
 
@@ -100,8 +96,8 @@ Installing LLVM on Mac
 ______________________
 
 A pre-built version of llvm for intel macs, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/llvm13.0-1/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
-`<https://github.com/hyperledger-labs/solang/releases/download/llvm13.0-1/llvm13.0-mac-arm.tar.xz>`_. After downloading,
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.10/llvm13.0-mac-arm.tar.xz>`_. After downloading,
 untar the file in a terminal and add it to your path like so:
 
 .. code-block:: bash

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.1.2"
+version = "0.1.10"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/solang-parser/src/lib.rs
+++ b/solang-parser/src/lib.rs
@@ -8,6 +8,7 @@ pub mod diagnostics;
 mod doc;
 pub mod lexer;
 pub mod pt;
+#[cfg(test)]
 mod test;
 
 #[allow(clippy::all)]

--- a/solang-parser/src/test.rs
+++ b/solang-parser/src/test.rs
@@ -1,13 +1,11 @@
-#[cfg(test)]
-mod test {
-    use crate::lexer;
-    use crate::pt::*;
-    use crate::solidity;
-    use num_bigint::BigInt;
+use crate::lexer;
+use crate::pt::*;
+use crate::solidity;
+use num_bigint::BigInt;
 
-    #[test]
-    fn parse_test() {
-        let src = r#"/// @title Foo
+#[test]
+fn parse_test() {
+    let src = r#"/// @title Foo
                 /// @description Foo
                 /// Bar
                 contract foo {
@@ -42,320 +40,317 @@ mod test {
                     }
                 }"#;
 
-        let mut comments = Vec::new();
-        let lex = lexer::Lexer::new(src, 0, &mut comments);
+    let mut comments = Vec::new();
+    let lex = lexer::Lexer::new(src, 0, &mut comments);
 
-        let actual_parse_tree = solidity::SourceUnitParser::new()
-            .parse(src, 0, lex)
-            .unwrap();
+    let actual_parse_tree = solidity::SourceUnitParser::new()
+        .parse(src, 0, lex)
+        .unwrap();
 
-        let expected_parse_tree = SourceUnit(vec![
-            SourceUnitPart::ContractDefinition(Box::new(ContractDefinition {
-                doc: vec![
-                    DocComment::Line {
-                        comment: SingleDocComment {
-                            offset: 0,
-                            tag: "title".to_string(),
-                            value: "Foo".to_string(),
-                        },
+    let expected_parse_tree = SourceUnit(vec![
+        SourceUnitPart::ContractDefinition(Box::new(ContractDefinition {
+            doc: vec![
+                DocComment::Line {
+                    comment: SingleDocComment {
+                        offset: 0,
+                        tag: "title".to_string(),
+                        value: "Foo".to_string(),
                     },
-                    DocComment::Line {
-                        comment: SingleDocComment {
-                            offset: 0,
-                            tag: "description".to_string(),
-                            value: "Foo\nBar".to_string(),
-                        },
-                    },
-                ],
-                loc: Loc::File(0, 92, 105),
-                ty: ContractTy::Contract(Loc::File(0, 92, 100)),
-                name: Identifier {
-                    loc: Loc::File(0, 101, 104),
-                    name: "foo".to_string(),
                 },
-                base: Vec::new(),
-                parts: vec![
-                    ContractPart::StructDefinition(Box::new(StructDefinition {
-                        doc: vec![
-                            DocComment::Block {
-                                comments: vec![SingleDocComment {
+                DocComment::Line {
+                    comment: SingleDocComment {
+                        offset: 0,
+                        tag: "description".to_string(),
+                        value: "Foo\nBar".to_string(),
+                    },
+                },
+            ],
+            loc: Loc::File(0, 92, 105),
+            ty: ContractTy::Contract(Loc::File(0, 92, 100)),
+            name: Identifier {
+                loc: Loc::File(0, 101, 104),
+                name: "foo".to_string(),
+            },
+            base: Vec::new(),
+            parts: vec![
+                ContractPart::StructDefinition(Box::new(StructDefinition {
+                    doc: vec![
+                        DocComment::Block {
+                            comments: vec![SingleDocComment {
+                                offset: 0,
+                                tag: "title".to_string(),
+                                value: "Jurisdiction".to_string(),
+                            }],
+                        },
+                        DocComment::Line {
+                            comment: SingleDocComment {
+                                offset: 0,
+                                tag: "author".to_string(),
+                                value: "Anon".to_string(),
+                            },
+                        },
+                        DocComment::Block {
+                            comments: vec![
+                                SingleDocComment {
                                     offset: 0,
-                                    tag: "title".to_string(),
-                                    value: "Jurisdiction".to_string(),
-                                }],
-                            },
-                            DocComment::Line {
-                                comment: SingleDocComment {
+                                    tag: "description".to_string(),
+                                    value: "Data for\njurisdiction".to_string(),
+                                },
+                                SingleDocComment {
                                     offset: 0,
-                                    tag: "author".to_string(),
-                                    value: "Anon".to_string(),
+                                    tag: "dev".to_string(),
+                                    value: "It's a struct".to_string(),
                                 },
-                            },
-                            DocComment::Block {
-                                comments: vec![
-                                    SingleDocComment {
-                                        offset: 0,
-                                        tag: "description".to_string(),
-                                        value: "Data for\njurisdiction".to_string(),
-                                    },
-                                    SingleDocComment {
-                                        offset: 0,
-                                        tag: "dev".to_string(),
-                                        value: "It's a struct".to_string(),
-                                    },
-                                ],
-                            },
-                        ],
-                        name: Identifier {
-                            loc: Loc::File(0, 419, 431),
-                            name: "Jurisdiction".to_string(),
-                        },
-                        loc: Loc::File(0, 412, 609),
-                        fields: vec![
-                            VariableDeclaration {
-                                loc: Loc::File(0, 458, 469),
-                                ty: Expression::Type(Loc::File(0, 458, 462), Type::Bool),
-                                storage: None,
-                                name: Identifier {
-                                    loc: Loc::File(0, 463, 469),
-                                    name: "exists".to_string(),
-                                },
-                            },
-                            VariableDeclaration {
-                                loc: Loc::File(0, 495, 506),
-                                ty: Expression::Type(Loc::File(0, 495, 499), Type::Uint(256)),
-                                storage: None,
-                                name: Identifier {
-                                    loc: Loc::File(0, 500, 506),
-                                    name: "keyIdx".to_string(),
-                                },
-                            },
-                            VariableDeclaration {
-                                loc: Loc::File(0, 532, 546),
-                                ty: Expression::Type(Loc::File(0, 532, 538), Type::Bytes(2)),
-                                storage: None,
-                                name: Identifier {
-                                    loc: Loc::File(0, 539, 546),
-                                    name: "country".to_string(),
-                                },
-                            },
-                            VariableDeclaration {
-                                loc: Loc::File(0, 572, 586),
-                                ty: Expression::Type(Loc::File(0, 572, 579), Type::Bytes(32)),
-                                storage: None,
-                                name: Identifier {
-                                    loc: Loc::File(0, 580, 586),
-                                    name: "region".to_string(),
-                                },
-                            },
-                        ],
-                    })),
-                    ContractPart::VariableDefinition(Box::new(VariableDefinition {
-                        doc: vec![],
-                        ty: Expression::Type(Loc::File(0, 630, 636), Type::String),
-                        attrs: vec![],
-                        name: Identifier {
-                            loc: Loc::File(0, 637, 645),
-                            name: "__abba_$".to_string(),
-                        },
-                        loc: Loc::File(0, 630, 645),
-                        initializer: None,
-                    })),
-                    ContractPart::VariableDefinition(Box::new(VariableDefinition {
-                        doc: vec![],
-                        ty: Expression::Type(Loc::File(0, 667, 672), Type::Int(64)),
-                        attrs: vec![],
-                        name: Identifier {
-                            loc: Loc::File(0, 673, 683),
-                            name: "$thing_102".to_string(),
-                        },
-                        loc: Loc::File(0, 667, 683),
-                        initializer: None,
-                    })),
-                ],
-            })),
-            SourceUnitPart::FunctionDefinition(Box::new(FunctionDefinition {
-                doc: vec![],
-                loc: Loc::File(0, 720, 735),
-                ty: FunctionTy::Function,
-                name: Some(Identifier {
-                    loc: Loc::File(0, 729, 732),
-                    name: "bar".to_string(),
-                }),
-                name_loc: Loc::File(0, 729, 732),
-                params: vec![],
-                attributes: vec![],
-                return_not_returns: None,
-                returns: vec![],
-                body: Some(Statement::Block {
-                    loc: Loc::File(0, 735, 1138),
-                    unchecked: false,
-                    statements: vec![Statement::Try(
-                        Loc::File(0, 757, 1120),
-                        Expression::FunctionCall(
-                            Loc::File(0, 761, 770),
-                            Box::new(Expression::Variable(Identifier {
-                                loc: Loc::File(0, 761, 764),
-                                name: "sum".to_string(),
-                            })),
-                            vec![
-                                Expression::NumberLiteral(Loc::File(0, 765, 766), 1.into()),
-                                Expression::NumberLiteral(Loc::File(0, 768, 769), 1.into()),
                             ],
-                        ),
-                        Some((
-                            vec![(
-                                Loc::File(0, 780, 788),
-                                Some(Parameter {
-                                    loc: Loc::File(0, 780, 788),
-                                    ty: Expression::Type(Loc::File(0, 780, 784), Type::Uint(256)),
-                                    storage: None,
-                                    name: Some(Identifier {
-                                        loc: Loc::File(0, 785, 788),
-                                        name: "sum".to_string(),
-                                    }),
+                        },
+                    ],
+                    name: Identifier {
+                        loc: Loc::File(0, 419, 431),
+                        name: "Jurisdiction".to_string(),
+                    },
+                    loc: Loc::File(0, 412, 609),
+                    fields: vec![
+                        VariableDeclaration {
+                            loc: Loc::File(0, 458, 469),
+                            ty: Expression::Type(Loc::File(0, 458, 462), Type::Bool),
+                            storage: None,
+                            name: Identifier {
+                                loc: Loc::File(0, 463, 469),
+                                name: "exists".to_string(),
+                            },
+                        },
+                        VariableDeclaration {
+                            loc: Loc::File(0, 495, 506),
+                            ty: Expression::Type(Loc::File(0, 495, 499), Type::Uint(256)),
+                            storage: None,
+                            name: Identifier {
+                                loc: Loc::File(0, 500, 506),
+                                name: "keyIdx".to_string(),
+                            },
+                        },
+                        VariableDeclaration {
+                            loc: Loc::File(0, 532, 546),
+                            ty: Expression::Type(Loc::File(0, 532, 538), Type::Bytes(2)),
+                            storage: None,
+                            name: Identifier {
+                                loc: Loc::File(0, 539, 546),
+                                name: "country".to_string(),
+                            },
+                        },
+                        VariableDeclaration {
+                            loc: Loc::File(0, 572, 586),
+                            ty: Expression::Type(Loc::File(0, 572, 579), Type::Bytes(32)),
+                            storage: None,
+                            name: Identifier {
+                                loc: Loc::File(0, 580, 586),
+                                name: "region".to_string(),
+                            },
+                        },
+                    ],
+                })),
+                ContractPart::VariableDefinition(Box::new(VariableDefinition {
+                    doc: vec![],
+                    ty: Expression::Type(Loc::File(0, 630, 636), Type::String),
+                    attrs: vec![],
+                    name: Identifier {
+                        loc: Loc::File(0, 637, 645),
+                        name: "__abba_$".to_string(),
+                    },
+                    loc: Loc::File(0, 630, 645),
+                    initializer: None,
+                })),
+                ContractPart::VariableDefinition(Box::new(VariableDefinition {
+                    doc: vec![],
+                    ty: Expression::Type(Loc::File(0, 667, 672), Type::Int(64)),
+                    attrs: vec![],
+                    name: Identifier {
+                        loc: Loc::File(0, 673, 683),
+                        name: "$thing_102".to_string(),
+                    },
+                    loc: Loc::File(0, 667, 683),
+                    initializer: None,
+                })),
+            ],
+        })),
+        SourceUnitPart::FunctionDefinition(Box::new(FunctionDefinition {
+            doc: vec![],
+            loc: Loc::File(0, 720, 735),
+            ty: FunctionTy::Function,
+            name: Some(Identifier {
+                loc: Loc::File(0, 729, 732),
+                name: "bar".to_string(),
+            }),
+            name_loc: Loc::File(0, 729, 732),
+            params: vec![],
+            attributes: vec![],
+            return_not_returns: None,
+            returns: vec![],
+            body: Some(Statement::Block {
+                loc: Loc::File(0, 735, 1138),
+                unchecked: false,
+                statements: vec![Statement::Try(
+                    Loc::File(0, 757, 1120),
+                    Expression::FunctionCall(
+                        Loc::File(0, 761, 770),
+                        Box::new(Expression::Variable(Identifier {
+                            loc: Loc::File(0, 761, 764),
+                            name: "sum".to_string(),
+                        })),
+                        vec![
+                            Expression::NumberLiteral(Loc::File(0, 765, 766), 1.into()),
+                            Expression::NumberLiteral(Loc::File(0, 768, 769), 1.into()),
+                        ],
+                    ),
+                    Some((
+                        vec![(
+                            Loc::File(0, 780, 788),
+                            Some(Parameter {
+                                loc: Loc::File(0, 780, 788),
+                                ty: Expression::Type(Loc::File(0, 780, 784), Type::Uint(256)),
+                                storage: None,
+                                name: Some(Identifier {
+                                    loc: Loc::File(0, 785, 788),
+                                    name: "sum".to_string(),
                                 }),
+                            }),
+                        )],
+                        Box::new(Statement::Block {
+                            loc: Loc::File(0, 790, 855),
+                            unchecked: false,
+                            statements: vec![Statement::Expression(
+                                Loc::File(0, 816, 832),
+                                Expression::FunctionCall(
+                                    Loc::File(0, 816, 832),
+                                    Box::new(Expression::Variable(Identifier {
+                                        loc: Loc::File(0, 816, 822),
+                                        name: "assert".to_string(),
+                                    })),
+                                    vec![Expression::Equal(
+                                        Loc::File(0, 827, 829),
+                                        Box::new(Expression::Variable(Identifier {
+                                            loc: Loc::File(0, 823, 826),
+                                            name: "sum".to_string(),
+                                        })),
+                                        Box::new(Expression::NumberLiteral(
+                                            Loc::File(0, 830, 831),
+                                            2.into(),
+                                        )),
+                                    )],
+                                ),
                             )],
-                            Box::new(Statement::Block {
-                                loc: Loc::File(0, 790, 855),
+                        }),
+                    )),
+                    vec![
+                        CatchClause::Simple(
+                            Loc::File(0, 856, 941),
+                            Some(Parameter {
+                                loc: Loc::File(0, 863, 877),
+                                ty: Expression::Type(Loc::File(0, 863, 868), Type::DynamicBytes),
+                                storage: Some(StorageLocation::Memory(Loc::File(0, 869, 875))),
+                                name: Some(Identifier {
+                                    loc: Loc::File(0, 876, 877),
+                                    name: "b".to_string(),
+                                }),
+                            }),
+                            Statement::Block {
+                                loc: Loc::File(0, 879, 941),
                                 unchecked: false,
                                 statements: vec![Statement::Expression(
-                                    Loc::File(0, 816, 832),
+                                    Loc::File(0, 905, 918),
                                     Expression::FunctionCall(
-                                        Loc::File(0, 816, 832),
+                                        Loc::File(0, 905, 918),
                                         Box::new(Expression::Variable(Identifier {
-                                            loc: Loc::File(0, 816, 822),
-                                            name: "assert".to_string(),
+                                            loc: Loc::File(0, 905, 911),
+                                            name: "revert".to_string(),
                                         })),
-                                        vec![Expression::Equal(
-                                            Loc::File(0, 827, 829),
-                                            Box::new(Expression::Variable(Identifier {
-                                                loc: Loc::File(0, 823, 826),
-                                                name: "sum".to_string(),
-                                            })),
-                                            Box::new(Expression::NumberLiteral(
-                                                Loc::File(0, 830, 831),
-                                                2.into(),
-                                            )),
-                                        )],
+                                        vec![Expression::StringLiteral(vec![StringLiteral {
+                                            loc: Loc::File(0, 912, 917),
+                                            string: "meh".to_string(),
+                                        }])],
                                     ),
                                 )],
-                            }),
-                        )),
-                        vec![
-                            CatchClause::Simple(
-                                Loc::File(0, 856, 941),
-                                Some(Parameter {
-                                    loc: Loc::File(0, 863, 877),
-                                    ty: Expression::Type(
-                                        Loc::File(0, 863, 868),
-                                        Type::DynamicBytes,
-                                    ),
-                                    storage: Some(StorageLocation::Memory(Loc::File(0, 869, 875))),
-                                    name: Some(Identifier {
-                                        loc: Loc::File(0, 876, 877),
-                                        name: "b".to_string(),
-                                    }),
+                            },
+                        ),
+                        CatchClause::Named(
+                            Loc::File(0, 942, 1037),
+                            Identifier {
+                                loc: Loc::File(0, 948, 953),
+                                name: "Error".to_string(),
+                            },
+                            Parameter {
+                                loc: Loc::File(0, 954, 973),
+                                ty: Expression::Type(Loc::File(0, 954, 960), Type::String),
+                                storage: Some(StorageLocation::Memory(Loc::File(0, 961, 967))),
+                                name: Some(Identifier {
+                                    loc: Loc::File(0, 968, 973),
+                                    name: "error".to_string(),
                                 }),
-                                Statement::Block {
-                                    loc: Loc::File(0, 879, 941),
-                                    unchecked: false,
-                                    statements: vec![Statement::Expression(
-                                        Loc::File(0, 905, 918),
-                                        Expression::FunctionCall(
-                                            Loc::File(0, 905, 918),
-                                            Box::new(Expression::Variable(Identifier {
-                                                loc: Loc::File(0, 905, 911),
-                                                name: "revert".to_string(),
-                                            })),
-                                            vec![Expression::StringLiteral(vec![StringLiteral {
-                                                loc: Loc::File(0, 912, 917),
-                                                string: "meh".to_string(),
-                                            }])],
-                                        ),
-                                    )],
-                                },
-                            ),
-                            CatchClause::Named(
-                                Loc::File(0, 942, 1037),
-                                Identifier {
-                                    loc: Loc::File(0, 948, 953),
-                                    name: "Error".to_string(),
-                                },
-                                Parameter {
-                                    loc: Loc::File(0, 954, 973),
-                                    ty: Expression::Type(Loc::File(0, 954, 960), Type::String),
-                                    storage: Some(StorageLocation::Memory(Loc::File(0, 961, 967))),
-                                    name: Some(Identifier {
-                                        loc: Loc::File(0, 968, 973),
-                                        name: "error".to_string(),
-                                    }),
-                                },
-                                Statement::Block {
-                                    loc: Loc::File(0, 975, 1037),
-                                    unchecked: false,
-                                    statements: vec![Statement::Expression(
+                            },
+                            Statement::Block {
+                                loc: Loc::File(0, 975, 1037),
+                                unchecked: false,
+                                statements: vec![Statement::Expression(
+                                    Loc::File(0, 1001, 1014),
+                                    Expression::FunctionCall(
                                         Loc::File(0, 1001, 1014),
-                                        Expression::FunctionCall(
-                                            Loc::File(0, 1001, 1014),
-                                            Box::new(Expression::Variable(Identifier {
-                                                loc: Loc::File(0, 1001, 1007),
-                                                name: "revert".to_string(),
-                                            })),
-                                            vec![Expression::Variable(Identifier {
-                                                loc: Loc::File(0, 1008, 1013),
-                                                name: "error".to_string(),
-                                            })],
-                                        ),
-                                    )],
-                                },
-                            ),
-                            CatchClause::Named(
-                                Loc::File(0, 1038, 1120),
-                                Identifier {
-                                    loc: Loc::File(0, 1044, 1049),
-                                    name: "Panic".to_string(),
-                                },
-                                Parameter {
-                                    loc: Loc::File(0, 1050, 1056),
-                                    ty: Expression::Type(Loc::File(0, 1050, 1054), Type::Uint(256)),
-                                    storage: None,
-                                    name: Some(Identifier {
-                                        loc: Loc::File(0, 1055, 1056),
-                                        name: "x".to_string(),
-                                    }),
-                                },
-                                Statement::Block {
-                                    loc: Loc::File(0, 1058, 1120),
-                                    unchecked: false,
-                                    statements: vec![Statement::Expression(
+                                        Box::new(Expression::Variable(Identifier {
+                                            loc: Loc::File(0, 1001, 1007),
+                                            name: "revert".to_string(),
+                                        })),
+                                        vec![Expression::Variable(Identifier {
+                                            loc: Loc::File(0, 1008, 1013),
+                                            name: "error".to_string(),
+                                        })],
+                                    ),
+                                )],
+                            },
+                        ),
+                        CatchClause::Named(
+                            Loc::File(0, 1038, 1120),
+                            Identifier {
+                                loc: Loc::File(0, 1044, 1049),
+                                name: "Panic".to_string(),
+                            },
+                            Parameter {
+                                loc: Loc::File(0, 1050, 1056),
+                                ty: Expression::Type(Loc::File(0, 1050, 1054), Type::Uint(256)),
+                                storage: None,
+                                name: Some(Identifier {
+                                    loc: Loc::File(0, 1055, 1056),
+                                    name: "x".to_string(),
+                                }),
+                            },
+                            Statement::Block {
+                                loc: Loc::File(0, 1058, 1120),
+                                unchecked: false,
+                                statements: vec![Statement::Expression(
+                                    Loc::File(0, 1084, 1097),
+                                    Expression::FunctionCall(
                                         Loc::File(0, 1084, 1097),
-                                        Expression::FunctionCall(
-                                            Loc::File(0, 1084, 1097),
-                                            Box::new(Expression::Variable(Identifier {
-                                                loc: Loc::File(0, 1084, 1090),
-                                                name: "revert".to_string(),
-                                            })),
-                                            vec![Expression::StringLiteral(vec![StringLiteral {
-                                                loc: Loc::File(0, 1091, 1096),
-                                                string: "feh".to_string(),
-                                            }])],
-                                        ),
-                                    )],
-                                },
-                            ),
-                        ],
-                    )],
-                }),
-            })),
-        ]);
+                                        Box::new(Expression::Variable(Identifier {
+                                            loc: Loc::File(0, 1084, 1090),
+                                            name: "revert".to_string(),
+                                        })),
+                                        vec![Expression::StringLiteral(vec![StringLiteral {
+                                            loc: Loc::File(0, 1091, 1096),
+                                            string: "feh".to_string(),
+                                        }])],
+                                    ),
+                                )],
+                            },
+                        ),
+                    ],
+                )],
+            }),
+        })),
+    ]);
 
-        assert_eq!(actual_parse_tree, expected_parse_tree);
-    }
+    assert_eq!(actual_parse_tree, expected_parse_tree);
+}
 
-    #[test]
-    fn parse_error_test() {
-        let src = r#"
+#[test]
+fn parse_error_test() {
+    let src = r#"
 
         error Outer(uint256 available, uint256 required);
 
@@ -369,10 +364,10 @@ mod test {
         }
         "#;
 
-        let (actual_parse_tree, _) = crate::parse(src, 0).unwrap();
-        assert_eq!(actual_parse_tree.0.len(), 2);
+    let (actual_parse_tree, _) = crate::parse(src, 0).unwrap();
+    assert_eq!(actual_parse_tree.0.len(), 2);
 
-        let expected_parse_tree = SourceUnit
+    let expected_parse_tree = SourceUnit
             (vec![
                 SourceUnitPart::ErrorDefinition(Box::new(ErrorDefinition {
                     doc: vec![],
@@ -591,12 +586,12 @@ mod test {
                 ))
             ]);
 
-        assert_eq!(actual_parse_tree, expected_parse_tree);
-    }
+    assert_eq!(actual_parse_tree, expected_parse_tree);
+}
 
-    #[test]
-    fn test_assembly_parser() {
-        let src = r#"
+#[test]
+fn test_assembly_parser() {
+    let src = r#"
                 function bar() {
                     assembly "evmasm" {
                         let x := 0
@@ -630,737 +625,394 @@ mod test {
                     }
                 }"#;
 
-        let mut comments = Vec::new();
-        let lex = lexer::Lexer::new(src, 0, &mut comments);
-        let actual_parse_tree = solidity::SourceUnitParser::new()
-            .parse(src, 0, lex)
-            .unwrap();
+    let mut comments = Vec::new();
+    let lex = lexer::Lexer::new(src, 0, &mut comments);
+    let actual_parse_tree = solidity::SourceUnitParser::new()
+        .parse(src, 0, lex)
+        .unwrap();
 
-        let expected_parse_tree = SourceUnit(
-            vec![
-                SourceUnitPart::FunctionDefinition(
-                    Box::new(FunctionDefinition{
-                        doc: vec![],
-                        loc: Loc::File(0, 17, 32),
-                        ty: FunctionTy::Function,
-                        name: Some(Identifier{
-                            loc: Loc::File(0, 26, 29),
-                            name: "bar".to_string(),
-                        }),
-                        name_loc: Loc::File(0, 26, 29),
-                        params: vec![],
-                        attributes: vec![],
-                        return_not_returns: None,
-                        returns: vec![],
-                        body: Some(
-                            Statement::Block {
-                                loc: Loc::File(0, 32, 1045),
-                                unchecked: false,
-                                statements: vec![
-                                    Statement::Assembly {
-                                        loc: Loc::File(0, 54, 736),
-                                        statements: vec![
-                                            AssemblyStatement::VariableDeclaration(
-                                                Loc::File(0, 98, 108),
-                                                vec![AssemblyTypedIdentifier{
-                                                    loc: Loc::File(0, 102, 103),
-                                                    name: Identifier{
-                                                        loc: Loc::File(0, 102, 103),
-                                                        name: "x".to_string(),
-                                                    },
-                                                    ty: None,
-                                                }],
-                                                Some(AssemblyExpression::NumberLiteral(
-                                                    Loc::File(0, 107, 108),
-                                                    BigInt::from(0),
-                                                    None
-                                                ))
-                                            ),
-                                            AssemblyStatement::For(
-                                                Loc::File(0, 133, 388),
-                                                vec![
-                                                    AssemblyStatement::VariableDeclaration(
-                                                        Loc::File(0, 139, 149),
-                                                        vec![
-                                                            AssemblyTypedIdentifier{
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    143,
-                                                                    144,
-                                                                ),
-                                                                name: Identifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        143,
-                                                                        144,
-                                                                    ),
-                                                                    name: "i".to_string(),
-                                                                },
-                                                                ty: None,
-                                                            },
-                                                        ],
-                                                        Some(AssemblyExpression::NumberLiteral(
-                                                            Loc::File(
-                                                                0,
-                                                                148,
-                                                                149,
-                                                            ),
-                                                            BigInt::from(0),
-                                                            None,
-                                                        )
-                                                        )
-                                                    )
-                                                ],
-                                                AssemblyExpression::FunctionCall(Box::new(
-                                                    AssemblyFunctionCall{
-                                                        loc: Loc::File(
-                                                            0,
-                                                            152,
-                                                            164,
-                                                        ),
-                                                        function_name: Identifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                152,
-                                                                154,
-                                                            ),
-                                                            name: "lt".to_string(),
-                                                        },
-                                                        arguments: vec![
-                                                            AssemblyExpression::Variable(
-                                                                Identifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        155,
-                                                                        156,
-                                                                    ),
-                                                                    name: "i".to_string(),
-                                                                },
-                                                            ),
-                                                            AssemblyExpression::HexNumberLiteral(
-                                                                Loc::File(
-                                                                    0,
-                                                                    158,
-                                                                    163),
-                                                                "0x100".to_string(),
-                                                        None,
-                                                            )
-                                                        ]
-                                                    }
-                                                )),
-                                                vec![
-                                                    AssemblyStatement::Assign(
-                                                        Loc::File(
-                                                            0,
-                                                            167,
-                                                            184),
-                                                        vec![
-                                                            AssemblyExpression::Variable(
-                                                                Identifier{
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        167,
-                                                                        168,
-                                                                    ),
-                                                                    name: "i".to_string(),
-                                                                }
-                                                            )
-                                                        ],
-                                                        AssemblyExpression::FunctionCall(
-                                                            Box::new(AssemblyFunctionCall{
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    172,
-                                                                    184,
-                                                                ),
-                                                                function_name: Identifier{
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        172,
-                                                                        175,
-                                                                    ),
-                                                                    name: "add".to_string(),
-                                                                },
-                                                                arguments: vec![
-                                                                    AssemblyExpression::Variable(
-                                                                        Identifier {
-                                                                            loc: Loc::File(
-                                                                                0,
-                                                                                176,
-                                                                                177,
-                                                                            ),
-                                                                            name: "i".to_string(),
-                                                                        },
-                                                                    ),
-                                                                    AssemblyExpression::HexNumberLiteral(
-                                                                        Loc::File(
-                                                                            0,
-                                                                            179,
-                                                                            183,
-                                                                        ),
-                                                                        "0x20".to_string(),
-                                                                        None,
-                                                                    )
-                                                                ]
-                                                                })
-                                                            )
-                                                        )],
-                                                vec![
-                                                    AssemblyStatement::Assign(
-                                                        Loc::File(
-                                                            0,
-                                                            217,
-                                                            248,
-                                                        ),
-                                                        vec![
-                                                            AssemblyExpression::Variable(
-                                                                Identifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        217,
-                                                                        218,
-                                                                    ),
-                                                                    name: "x".to_string(),
-                                                                },
-                                                            )
-                                                        ],
-                                                        AssemblyExpression::FunctionCall(
-                                                            Box::new(AssemblyFunctionCall{
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    232,
-                                                                    248,
-                                                                ),
-                                                                function_name: Identifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        232,
-                                                                        235,
-                                                                    ),
-                                                                    name: "add".to_string(),
-                                                                },
-                                                                arguments: vec![
-                                                                    AssemblyExpression::Variable(
-                                                                        Identifier {
-                                                                            loc: Loc::File(
-                                                                                0,
-                                                                                236,
-                                                                                237,
-                                                                            ),
-                                                                            name: "x".to_string(),
-                                                                        },
-                                                                    ),
-                                                                    AssemblyExpression::FunctionCall(
-                                                                        Box::new(AssemblyFunctionCall{
-                                                                            loc: Loc::File(
-                                                                                0,
-                                                                                239,
-                                                                                247,
-                                                                            ),
-                                                                            function_name: Identifier {
-                                                                                loc: Loc::File(
-                                                                                    0,
-                                                                                    239,
-                                                                                    244,
-                                                                                ),
-                                                                                name: "mload".to_string(),
-                                                                            },
-                                                                            arguments: vec![
-                                                                                AssemblyExpression::Variable(
-                                                                                    Identifier {
-                                                                                        loc: Loc::File(
-                                                                                            0,
-                                                                                            245,
-                                                                                            246,
-                                                                                        ),
-                                                                                        name: "i".to_string(),
-                                                                                    },
-                                                                                )
-                                                                            ]
-                                                                        })
-                                                                    )
-                                                                ]
-                                                            })
-                                                        )
-                                                    ),
-                                            AssemblyStatement::If(
-                                                Loc::File(
-                                                    0,
-                                                    278,
-                                                    362,
+    let expected_parse_tree = SourceUnit(vec![SourceUnitPart::FunctionDefinition(Box::new(
+        FunctionDefinition {
+            doc: vec![],
+            loc: Loc::File(0, 17, 32),
+            ty: FunctionTy::Function,
+            name: Some(Identifier {
+                loc: Loc::File(0, 26, 29),
+                name: "bar".to_string(),
+            }),
+            name_loc: Loc::File(0, 26, 29),
+            params: vec![],
+            attributes: vec![],
+            return_not_returns: None,
+            returns: vec![],
+            body: Some(Statement::Block {
+                loc: Loc::File(0, 32, 1045),
+                unchecked: false,
+                statements: vec![
+                    Statement::Assembly {
+                        loc: Loc::File(0, 54, 736),
+                        statements: vec![
+                            AssemblyStatement::VariableDeclaration(
+                                Loc::File(0, 98, 108),
+                                vec![AssemblyTypedIdentifier {
+                                    loc: Loc::File(0, 102, 103),
+                                    name: Identifier {
+                                        loc: Loc::File(0, 102, 103),
+                                        name: "x".to_string(),
+                                    },
+                                    ty: None,
+                                }],
+                                Some(AssemblyExpression::NumberLiteral(
+                                    Loc::File(0, 107, 108),
+                                    BigInt::from(0),
+                                    None,
+                                )),
+                            ),
+                            AssemblyStatement::For(
+                                Loc::File(0, 133, 388),
+                                vec![AssemblyStatement::VariableDeclaration(
+                                    Loc::File(0, 139, 149),
+                                    vec![AssemblyTypedIdentifier {
+                                        loc: Loc::File(0, 143, 144),
+                                        name: Identifier {
+                                            loc: Loc::File(0, 143, 144),
+                                            name: "i".to_string(),
+                                        },
+                                        ty: None,
+                                    }],
+                                    Some(AssemblyExpression::NumberLiteral(
+                                        Loc::File(0, 148, 149),
+                                        BigInt::from(0),
+                                        None,
+                                    )),
+                                )],
+                                AssemblyExpression::FunctionCall(Box::new(AssemblyFunctionCall {
+                                    loc: Loc::File(0, 152, 164),
+                                    function_name: Identifier {
+                                        loc: Loc::File(0, 152, 154),
+                                        name: "lt".to_string(),
+                                    },
+                                    arguments: vec![
+                                        AssemblyExpression::Variable(Identifier {
+                                            loc: Loc::File(0, 155, 156),
+                                            name: "i".to_string(),
+                                        }),
+                                        AssemblyExpression::HexNumberLiteral(
+                                            Loc::File(0, 158, 163),
+                                            "0x100".to_string(),
+                                            None,
+                                        ),
+                                    ],
+                                })),
+                                vec![AssemblyStatement::Assign(
+                                    Loc::File(0, 167, 184),
+                                    vec![AssemblyExpression::Variable(Identifier {
+                                        loc: Loc::File(0, 167, 168),
+                                        name: "i".to_string(),
+                                    })],
+                                    AssemblyExpression::FunctionCall(Box::new(
+                                        AssemblyFunctionCall {
+                                            loc: Loc::File(0, 172, 184),
+                                            function_name: Identifier {
+                                                loc: Loc::File(0, 172, 175),
+                                                name: "add".to_string(),
+                                            },
+                                            arguments: vec![
+                                                AssemblyExpression::Variable(Identifier {
+                                                    loc: Loc::File(0, 176, 177),
+                                                    name: "i".to_string(),
+                                                }),
+                                                AssemblyExpression::HexNumberLiteral(
+                                                    Loc::File(0, 179, 183),
+                                                    "0x20".to_string(),
+                                                    None,
                                                 ),
-                                                AssemblyExpression::FunctionCall(Box::new(
-                                                    AssemblyFunctionCall{
-                                                        loc: Loc::File(
-                                                            0,
-                                                            281,
-                                                            292,
-                                                        ),
-                                                        function_name: Identifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                281,
-                                                                283,
-                                                            ),
-                                                            name: "gt".to_string(),
-                                                        },
-                                                        arguments: vec![
-                                                            AssemblyExpression::Variable(
-                                                                Identifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        284,
-                                                                        285,
-                                                                    ),
-                                                                    name: "i".to_string(),
-                                                                },
-                                                            ),
-                                                            AssemblyExpression::HexNumberLiteral(
-                                                                Loc::File(
-                                                                    0,
-                                                                    287,
-                                                                    291,
-                                                                ),
-                                                                "0x10".to_string(),
-                                                                None,
-                                                            )
-                                                        ]
-                                                    }
-                                                )),
-                                                vec![
-                                                    AssemblyStatement::Break(Loc::File(
-                                                        0,
-                                                        327,
-                                                        332,
-                                                    ))
-                                                ]
-                                            ),]),
-                                            AssemblyStatement::VariableDeclaration(
-                                                Loc::File(
-                                                    0,
-                                                    414,
-                                                    451,
-                                                ),
-                                                vec![
-                                                    AssemblyTypedIdentifier{
-                                                        loc: Loc::File(
-                                                            0,
-                                                            418,
-                                                            425,
-                                                        ),
-                                                        name: Identifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                418,
-                                                                419,
-                                                            ),
-                                                            name: "h".to_string(),
-                                                        },
-                                                        ty: Some(
-                                                            Identifier {
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    422,
-                                                                    425,
-                                                                ),
-                                                                name: "u32".to_string(),
-                                                            },
-                                                        ),
-                                                    },
-                                                    AssemblyTypedIdentifier{
-                                                        loc: Loc::File(
-                                                            0,
-                                                            427,
-                                                            428,
-                                                        ),
-                                                        name: Identifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                427,
-                                                                428,
-                                                            ),
-                                                            name: "y".to_string(),
-                                                        },
-                                                        ty: None,
-                                                    },
-                                                    AssemblyTypedIdentifier{
-                                                        loc: Loc::File(
-                                                            0,
-                                                            430,
-                                                            437,
-                                                        ),
-                                                        name: Identifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                430,
-                                                                431,
-                                                            ),
-                                                            name: "z".to_string(),
+                                            ],
+                                        },
+                                    )),
+                                )],
+                                vec![
+                                    AssemblyStatement::Assign(
+                                        Loc::File(0, 217, 248),
+                                        vec![AssemblyExpression::Variable(Identifier {
+                                            loc: Loc::File(0, 217, 218),
+                                            name: "x".to_string(),
+                                        })],
+                                        AssemblyExpression::FunctionCall(Box::new(
+                                            AssemblyFunctionCall {
+                                                loc: Loc::File(0, 232, 248),
+                                                function_name: Identifier {
+                                                    loc: Loc::File(0, 232, 235),
+                                                    name: "add".to_string(),
                                                 },
-                                                ty: Some(
-                                                    Identifier {
-                                                        loc: Loc::File(
-                                                            0,
-                                                            434,
-                                                            437,
-                                                        ),
-                                                        name: "u16".to_string(),
-                                                    },
-                                                ) }
-                                                ],
-                                                Some(AssemblyExpression::FunctionCall(
-                                                    Box::new(AssemblyFunctionCall{
-                                                        loc: Loc::File(
-                                                            0,
-                                                            441,
-                                                            451,
-                                                        ),
-                                                        function_name: Identifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                441,
-                                                                449,
-                                                            ),
-                                                            name: "funcCall".to_string(),
-                                                    },
-                                                    arguments: vec![],
-                                                    })
-                                                ))
-                                            ),
-                                            AssemblyStatement::Switch(
-                                                Loc::File(
-                                                    0,
-                                                    477,
-                                                    714,
-                                                ),
-                                                AssemblyExpression::Variable(
-                                                    Identifier {
-                                                        loc: Loc::File(
-                                                            0,
-                                                            484,
-                                                            485,
-                                                        ),
+                                                arguments: vec![
+                                                    AssemblyExpression::Variable(Identifier {
+                                                        loc: Loc::File(0, 236, 237),
                                                         name: "x".to_string(),
-                                                    },
-                                                ),
-                                                vec![AssemblySwitch::Case(
-                                                    AssemblyExpression::NumberLiteral(
-                                                        Loc::File(
-                                                            0,
-                                                            515,
-                                                            516,
-                                                        ),
-                                                        BigInt::from(0),
+                                                    }),
+                                                    AssemblyExpression::FunctionCall(Box::new(
+                                                        AssemblyFunctionCall {
+                                                            loc: Loc::File(0, 239, 247),
+                                                            function_name: Identifier {
+                                                                loc: Loc::File(0, 239, 244),
+                                                                name: "mload".to_string(),
+                                                            },
+                                                            arguments: vec![
+                                                                AssemblyExpression::Variable(
+                                                                    Identifier {
+                                                                        loc: Loc::File(0, 245, 246),
+                                                                        name: "i".to_string(),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    )),
+                                                ],
+                                            },
+                                        )),
+                                    ),
+                                    AssemblyStatement::If(
+                                        Loc::File(0, 278, 362),
+                                        AssemblyExpression::FunctionCall(Box::new(
+                                            AssemblyFunctionCall {
+                                                loc: Loc::File(0, 281, 292),
+                                                function_name: Identifier {
+                                                    loc: Loc::File(0, 281, 283),
+                                                    name: "gt".to_string(),
+                                                },
+                                                arguments: vec![
+                                                    AssemblyExpression::Variable(Identifier {
+                                                        loc: Loc::File(0, 284, 285),
+                                                        name: "i".to_string(),
+                                                    }),
+                                                    AssemblyExpression::HexNumberLiteral(
+                                                        Loc::File(0, 287, 291),
+                                                        "0x10".to_string(),
                                                         None,
                                                     ),
-                                                    vec![AssemblyStatement::FunctionCall(
-                                                        Box::new(AssemblyFunctionCall{
-                                                            loc: Loc::File(
-                                                                0,
-                                                                547,
-                                                                559,
-                                                            ),
+                                                ],
+                                            },
+                                        )),
+                                        vec![AssemblyStatement::Break(Loc::File(0, 327, 332))],
+                                    ),
+                                ],
+                            ),
+                            AssemblyStatement::VariableDeclaration(
+                                Loc::File(0, 414, 451),
+                                vec![
+                                    AssemblyTypedIdentifier {
+                                        loc: Loc::File(0, 418, 425),
+                                        name: Identifier {
+                                            loc: Loc::File(0, 418, 419),
+                                            name: "h".to_string(),
+                                        },
+                                        ty: Some(Identifier {
+                                            loc: Loc::File(0, 422, 425),
+                                            name: "u32".to_string(),
+                                        }),
+                                    },
+                                    AssemblyTypedIdentifier {
+                                        loc: Loc::File(0, 427, 428),
+                                        name: Identifier {
+                                            loc: Loc::File(0, 427, 428),
+                                            name: "y".to_string(),
+                                        },
+                                        ty: None,
+                                    },
+                                    AssemblyTypedIdentifier {
+                                        loc: Loc::File(0, 430, 437),
+                                        name: Identifier {
+                                            loc: Loc::File(0, 430, 431),
+                                            name: "z".to_string(),
+                                        },
+                                        ty: Some(Identifier {
+                                            loc: Loc::File(0, 434, 437),
+                                            name: "u16".to_string(),
+                                        }),
+                                    },
+                                ],
+                                Some(AssemblyExpression::FunctionCall(Box::new(
+                                    AssemblyFunctionCall {
+                                        loc: Loc::File(0, 441, 451),
+                                        function_name: Identifier {
+                                            loc: Loc::File(0, 441, 449),
+                                            name: "funcCall".to_string(),
+                                        },
+                                        arguments: vec![],
+                                    },
+                                ))),
+                            ),
+                            AssemblyStatement::Switch(
+                                Loc::File(0, 477, 714),
+                                AssemblyExpression::Variable(Identifier {
+                                    loc: Loc::File(0, 484, 485),
+                                    name: "x".to_string(),
+                                }),
+                                vec![AssemblySwitch::Case(
+                                    AssemblyExpression::NumberLiteral(
+                                        Loc::File(0, 515, 516),
+                                        BigInt::from(0),
+                                        None,
+                                    ),
+                                    vec![AssemblyStatement::FunctionCall(Box::new(
+                                        AssemblyFunctionCall {
+                                            loc: Loc::File(0, 547, 559),
+                                            function_name: Identifier {
+                                                loc: Loc::File(0, 547, 553),
+                                                name: "revert".to_string(),
+                                            },
+                                            arguments: vec![
+                                                AssemblyExpression::NumberLiteral(
+                                                    Loc::File(0, 554, 555),
+                                                    BigInt::from(0),
+                                                    None,
+                                                ),
+                                                AssemblyExpression::NumberLiteral(
+                                                    Loc::File(0, 557, 558),
+                                                    BigInt::from(0),
+                                                    None,
+                                                ),
+                                            ],
+                                        },
+                                    ))],
+                                )],
+                                Some(AssemblySwitch::Default(vec![AssemblyStatement::Leave(
+                                    Loc::File(0, 683, 688),
+                                )])),
+                            ),
+                        ],
+                        dialect: Some(StringLiteral {
+                            loc: Loc::File(0, 63, 71),
+                            string: "evmasm".to_string(),
+                        }),
+                    },
+                    Statement::Assembly {
+                        loc: Loc::File(0, 758, 1027),
+                        statements: vec![AssemblyStatement::FunctionDefinition(Box::new(
+                            AssemblyFunctionDefinition {
+                                loc: Loc::File(0, 794, 1005),
+                                name: Identifier {
+                                    loc: Loc::File(0, 803, 808),
+                                    name: "power".to_string(),
+                                },
+                                params: vec![
+                                    AssemblyTypedIdentifier {
+                                        loc: Loc::File(0, 809, 820),
+                                        name: Identifier {
+                                            loc: Loc::File(0, 809, 813),
+                                            name: "base".to_string(),
+                                        },
+                                        ty: Some(Identifier {
+                                            loc: Loc::File(0, 816, 820),
+                                            name: "u256".to_string(),
+                                        }),
+                                    },
+                                    AssemblyTypedIdentifier {
+                                        loc: Loc::File(0, 822, 830),
+                                        name: Identifier {
+                                            loc: Loc::File(0, 822, 830),
+                                            name: "exponent".to_string(),
+                                        },
+                                        ty: None,
+                                    },
+                                ],
+                                returns: vec![AssemblyTypedIdentifier {
+                                    loc: Loc::File(0, 835, 841),
+                                    name: Identifier {
+                                        loc: Loc::File(0, 835, 841),
+                                        name: "result".to_string(),
+                                    },
+                                    ty: None,
+                                }],
+                                body: vec![
+                                    AssemblyStatement::VariableDeclaration(
+                                        Loc::File(0, 896, 940),
+                                        vec![AssemblyTypedIdentifier {
+                                            loc: Loc::File(0, 900, 901),
+                                            name: Identifier {
+                                                loc: Loc::File(0, 900, 901),
+                                                name: "y".to_string(),
+                                            },
+                                            ty: None,
+                                        }],
+                                        Some(AssemblyExpression::FunctionCall(Box::new(
+                                            AssemblyFunctionCall {
+                                                loc: Loc::File(0, 905, 940),
+                                                function_name: Identifier {
+                                                    loc: Loc::File(0, 905, 908),
+                                                    name: "and".to_string(),
+                                                },
+                                                arguments: vec![
+                                                    AssemblyExpression::StringLiteral(
+                                                        StringLiteral {
+                                                            loc: Loc::File(0, 909, 914),
+                                                            string: "abc".to_string(),
+                                                        },
+                                                        Some(Identifier {
+                                                            loc: Loc::File(0, 915, 918),
+                                                            name: "u32".to_string(),
+                                                        }),
+                                                    ),
+                                                    AssemblyExpression::FunctionCall(Box::new(
+                                                        AssemblyFunctionCall {
+                                                            loc: Loc::File(0, 920, 939),
                                                             function_name: Identifier {
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    547,
-                                                                    553,
-                                                                ),
-                                                                name: "revert".to_string(),
+                                                                loc: Loc::File(0, 920, 923),
+                                                                name: "add".to_string(),
                                                             },
                                                             arguments: vec![
                                                                 AssemblyExpression::NumberLiteral(
-                                                                    Loc::File(
-                                                                        0,
-                                                                        554,
-                                                                        555,
-                                                                    ),
-                                                                    BigInt::from(0),
-                                                                    None,
+                                                                    Loc::File(0, 924, 930),
+                                                                    BigInt::from(3),
+                                                                    Some(Identifier {
+                                                                        loc: Loc::File(0, 926, 930),
+                                                                        name: "u256".to_string(),
+                                                                    }),
                                                                 ),
                                                                 AssemblyExpression::NumberLiteral(
-                                                                    Loc::File(
-                                                                        0,
-                                                                        557,
-                                                                        558,
-                                                                    ),
-                                                                    BigInt::from(0),
-                                                                    None,
+                                                                    Loc::File(0, 932, 938),
+                                                                    BigInt::from(2),
+                                                                    Some(Identifier {
+                                                                        loc: Loc::File(0, 934, 938),
+                                                                        name: "u256".to_string(),
+                                                                    }),
                                                                 ),
                                                             ],
-                                                        })
-                                                    )]
-                                                )],
-                                                Some(AssemblySwitch::Default(
-                                                    vec![
-                                                        AssemblyStatement::Leave(Loc::File(
-                                                            0,
-                                                            683,
-                                                            688,
-                                                        ))
-                                                    ]
-                                                ))
-                                            ),
-                                        ],
-                                        dialect: Some(StringLiteral{
-                                            loc: Loc::File(0, 63, 71),
-                                            string: "evmasm".to_string(),
-                                        })
-                                    },
-                                    Statement::Assembly {
-                                        loc: Loc::File(
-                                            0,
-                                            758,
-                                            1027,
-                                        ),
-                                        statements: vec![
-                                            AssemblyStatement::FunctionDefinition(Box::new(
-                                                AssemblyFunctionDefinition {
-                                                    loc: Loc::File(
-                                                        0,
-                                                        794,
-                                                        1005,
-                                                    ),
-                                                    name: Identifier {
-                                                        loc: Loc::File(
-                                                            0,
-                                                            803,
-                                                            808,
-                                                        ),
-                                                        name: "power".to_string(),
-                                                    },
-                                                    params: vec![
-                                                        AssemblyTypedIdentifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                809,
-                                                                820,
-                                                            ),
-                                                            name: Identifier {
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    809,
-                                                                    813,
-                                                                ),
-                                                                name: "base".to_string(),
-                                                            },
-                                                            ty: Some(
-                                                                Identifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        816,
-                                                                        820,
-                                                                    ),
-                                                                    name: "u256".to_string(),
-                                                                },
-                                                            ),
                                                         },
-                                                        AssemblyTypedIdentifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                822,
-                                                                830,
-                                                            ),
-                                                            name: Identifier {
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    822,
-                                                                    830,
-                                                                ),
-                                                                name: "exponent".to_string(),
-                                                            },
-                                                            ty: None,
-                                                        },
-                                                    ],
-                                                    returns: vec![
-                                                        AssemblyTypedIdentifier {
-                                                            loc: Loc::File(
-                                                                0,
-                                                                835,
-                                                                841,
-                                                            ),
-                                                            name: Identifier {
-                                                                loc: Loc::File(
-                                                                    0,
-                                                                    835,
-                                                                    841,
-                                                                ),
-                                                                name: "result".to_string(),
-                                                            },
-                                                            ty: None,
-                                                        }
-                                                    ],
-                                                    body: vec![
-                                                        AssemblyStatement::VariableDeclaration(
-                                                            Loc::File(
-                                                                0,
-                                                                896,
-                                                                940,
-                                                            ),
-                                                            vec![
-                                                                AssemblyTypedIdentifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        900,
-                                                                        901,
-                                                                    ),
-                                                                    name: Identifier {
-                                                                        loc: Loc::File(
-                                                                            0,
-                                                                            900,
-                                                                            901,
-                                                                        ),
-                                                                        name: "y".to_string(),
-                                                                    },
-                                                                    ty: None,
-                                                                },
-                                                            ],
-                                                            Some(
-                                                                AssemblyExpression::FunctionCall(
-                                                                    Box::new(
-                                                                        AssemblyFunctionCall {
-                                                                            loc: Loc::File(
-                                                                                0,
-                                                                                905,
-                                                                                940,
-                                                                            ),
-                                                                            function_name: Identifier {
-                                                                                loc: Loc::File(
-                                                                                    0,
-                                                                                    905,
-                                                                                    908,
-                                                                                ),
-                                                                                name: "and".to_string(),
-                                                                            },
-                                                                            arguments: vec![
-                                                                                AssemblyExpression::StringLiteral(
-                                                                                    StringLiteral {
-                                                                                        loc: Loc::File(
-                                                                                            0,
-                                                                                            909,
-                                                                                            914,
-                                                                                        ),
-                                                                                        string: "abc".to_string(),
-                                                                                    },
-                                                                                    Some(
-                                                                                        Identifier {
-                                                                                            loc: Loc::File(
-                                                                                                0,
-                                                                                                915,
-                                                                                                918,
-                                                                                            ),
-                                                                                            name: "u32".to_string(),
-                                                                                        })
-                                                                                ),
-                                                                                AssemblyExpression::FunctionCall(
-                                                                                    Box::new(
-                                                                                        AssemblyFunctionCall {
-                                                                                            loc: Loc::File(
-                                                                                                0,
-                                                                                                920,
-                                                                                                939,
-                                                                                            ),
-                                                                                            function_name: Identifier {
-                                                                                                loc: Loc::File(
-                                                                                                    0,
-                                                                                                    920,
-                                                                                                    923,
-                                                                                                ),
-                                                                                                name: "add".to_string(),
-                                                                                            },
-                                                                                            arguments: vec![
-                                                                                                AssemblyExpression::NumberLiteral(
-                                                                                                    Loc::File(
-                                                                                                        0,
-                                                                                                        924,
-                                                                                                        930,
-                                                                                                    ),
-                                                                                                    BigInt::from(3),
-                                                                                                    Some(
-                                                                                                        Identifier {
-                                                                                                            loc: Loc::File(
-                                                                                                                0,
-                                                                                                                926,
-                                                                                                                930,
-                                                                                                            ),
-                                                                                                            name: "u256".to_string(),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ),
-                                                                                                AssemblyExpression::NumberLiteral(
-                                                                                                    Loc::File(
-                                                                                                        0,
-                                                                                                        932,
-                                                                                                        938,
-                                                                                                    ),
-                                                                                                    BigInt::from(2),
-                                                                                                    Some(
-                                                                                                        Identifier {
-                                                                                                            loc: Loc::File(
-                                                                                                                0,
-                                                                                                                934,
-                                                                                                                938,
-                                                                                                            ),
-                                                                                                            name: "u256".to_string(),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                )
-                                                                                            ]
-                                                                                        }
-                                                                                    )
-                                                                                )]
-                                                                        }
-                                                                    )))),
-                                                        AssemblyStatement::VariableDeclaration(
-                                                            Loc::File(
-                                                                0,
-                                                                969,
-                                                                979,
-                                                            ),
-                                                            vec![
-                                                                AssemblyTypedIdentifier {
-                                                                    loc: Loc::File(
-                                                                        0,
-                                                                        973,
-                                                                        979,
-                                                                    ),
-                                                                    name: Identifier {
-                                                                        loc: Loc::File(
-                                                                            0,
-                                                                            973,
-                                                                            979,
-                                                                        ),
-                                                                        name: "result".to_string(),
-                                                                    },
-                                                                    ty: None,
-                                                                },
-                                                            ],
-                                                            None
-                                                        )
-                                                    ]
-                                                }
-                                            )
-                                            )
-                                        ],
-                                        dialect: None,
-                                    }
-                                ]
-                            }
-                        )
-                    }
-                    )
-                )
-            ]
-        );
+                                                    )),
+                                                ],
+                                            },
+                                        ))),
+                                    ),
+                                    AssemblyStatement::VariableDeclaration(
+                                        Loc::File(0, 969, 979),
+                                        vec![AssemblyTypedIdentifier {
+                                            loc: Loc::File(0, 973, 979),
+                                            name: Identifier {
+                                                loc: Loc::File(0, 973, 979),
+                                                name: "result".to_string(),
+                                            },
+                                            ty: None,
+                                        }],
+                                        None,
+                                    ),
+                                ],
+                            },
+                        ))],
+                        dialect: None,
+                    },
+                ],
+            }),
+        },
+    ))]);
 
-        assert_eq!(expected_parse_tree, actual_parse_tree);
+    assert_eq!(expected_parse_tree, actual_parse_tree);
 
-        assert_eq!(
-            comments,
-            vec![
-                Comment::Block(Loc::File(0, 222, 231), "/* meh */".to_string()),
-                Comment::Line(Loc::File(0, 588, 594), "// feh".to_string())
-            ]
-        );
-    }
+    assert_eq!(
+        comments,
+        vec![
+            Comment::Block(Loc::File(0, 222, 231), "/* meh */".to_string()),
+            Comment::Line(Loc::File(0, 588, 594), "// feh".to_string())
+        ]
+    );
 }


### PR DESCRIPTION
Added
 - On Solana, the accounts that were passed into the transactions are listed in the `tx.accounts` builtin. There is also a builtin struct `AccountInfo`
 - A new common subexpression elimination pass was added, thanks to [LucasSte](https://github.com/hyperledger-labs/solang/pull/550)
 - A graphviz dot file can be generated from the ast, using `--emit ast-dot`
 - Many improvements to the solidity parser, and the parser has been spun out in it's own create `solang-parser`.
    
Changed
 - Solang now uses LLVM 13.0, based on the [Solana LLVM tree](https://github.com/solana-labs/llvm-project/)
 - The ast datastructure has been simplified.
 - Many bugfixes across the entire tree.