### PR TITLE
Refactor unescape function

### DIFF
--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -22,6 +22,7 @@ pub mod printer;
 mod statements;
 pub mod symtable;
 pub mod tags;
+mod tests;
 mod types;
 mod unused_variable;
 mod variables;

--- a/src/sema/tests/mod.rs
+++ b/src/sema/tests/mod.rs
@@ -1,0 +1,16 @@
+#![cfg(test)]
+use crate::sema::expression::unescape;
+use solang_parser::Diagnostic;
+
+#[test]
+fn test_unescape() {
+    let s = r#"\u00f3"#;
+    let mut vec: Vec<Diagnostic> = Vec::new();
+    let res = unescape(s, 0, 0, &mut vec);
+    assert!(vec.is_empty());
+    assert_eq!(res, vec![0xc3, 0xb3]);
+    let s = r#"\xff"#;
+    let res = unescape(s, 0, 0, &mut vec);
+    assert!(vec.is_empty());
+    assert_eq!(res, vec![255]);
+}

--- a/tests/contract_testcases/substrate/strings/string_escape_06.dot
+++ b/tests/contract_testcases/substrate/strings/string_escape_06.dot
@@ -1,0 +1,14 @@
+strict digraph "tests/contract_testcases/substrate/strings/string_escape_06.sol" {
+	contract [label="contract foo\ntests/contract_testcases/substrate/strings/string_escape_06.sol:1:1-14"]
+	bar [label="function bar\ncontract: foo\ntests/contract_testcases/substrate/strings/string_escape_06.sol:2:5-48\nsignature bar()\nvisibility public\nmutability pure"]
+	returns [label="returns\nbytes4 "]
+	return [label="return\ntests/contract_testcases/substrate/strings/string_escape_06.sol:3:9-25"]
+	bytes_literal [label="bytes4 literal: 414243ff\ntests/contract_testcases/substrate/strings/string_escape_06.sol:3:16-25"]
+	diagnostic [label="found contract ‘foo’\nlevel Debug\ntests/contract_testcases/substrate/strings/string_escape_06.sol:1:1-14"]
+	contracts -> contract
+	contract -> bar [label="function"]
+	bar -> returns [label="returns"]
+	bar -> return [label="body"]
+	return -> bytes_literal [label="expr"]
+	diagnostics -> diagnostic [label="Debug"]
+}

--- a/tests/contract_testcases/substrate/strings/string_escape_06.sol
+++ b/tests/contract_testcases/substrate/strings/string_escape_06.sol
@@ -1,0 +1,5 @@
+contract foo {
+    function bar() public pure returns (bytes4) {
+        return "ABC\xff";
+    }
+}


### PR DESCRIPTION
The `unescape` function in `sema/expression` could not handle escape constructs, such as `\xf4` and `\u00c3`. This PR fixes such a bug.