### PR TITLE
Make u256 the default type for YUL variables

### DIFF
--- a/src/sema/assembly/expression.rs
+++ b/src/sema/assembly/expression.rs
@@ -1,7 +1,6 @@
 use crate::ast::{Namespace, Type};
 use crate::sema::assembly::types::{get_default_type_from_identifier, get_type_from_string};
 use crate::sema::expression::unescape;
-use crate::Target;
 use num_bigint::{BigInt, Sign};
 use num_traits::Num;
 use solang_parser::diagnostics::{ErrorType, Level};
@@ -66,10 +65,10 @@ pub(crate) fn resolve_assembly_expression(
     }
 }
 
-fn get_type_from_big_int(big_int: &BigInt, target: &Target) -> Type {
+fn get_type_from_big_int(big_int: &BigInt) -> Type {
     match big_int.sign() {
-        Sign::Minus => Type::Int(target.ptr_size()),
-        _ => Type::Uint(target.ptr_size()),
+        Sign::Minus => Type::Int(256),
+        _ => Type::Uint(256),
     }
 }
 
@@ -123,7 +122,7 @@ fn resolve_number_literal(
             return Err(());
         }
     } else {
-        get_type_from_big_int(value, &ns.target)
+        get_type_from_big_int(value)
     };
 
     let type_size = new_type.get_type_size();

--- a/src/sema/assembly/tests/expression.rs
+++ b/src/sema/assembly/tests/expression.rs
@@ -48,7 +48,10 @@ fn resolve_number_literal() {
     let expr = pt::AssemblyExpression::NumberLiteral(
         loc,
         BigInt::from_u128(0xffffffffffffffffff).unwrap(),
-        None,
+        Some(Identifier {
+            loc,
+            name: "u64".to_string(),
+        }),
     );
     let parsed = resolve_assembly_expression(&expr, &mut ns);
     assert!(parsed.is_ok());
@@ -82,7 +85,7 @@ fn resolve_number_literal() {
     assert!(ns.diagnostics.is_empty());
     assert_eq!(
         parsed.unwrap(),
-        AssemblyExpression::NumberLiteral(loc, BigInt::from(20), Type::Uint(64))
+        AssemblyExpression::NumberLiteral(loc, BigInt::from(20), Type::Uint(256))
     );
 }
 
@@ -90,7 +93,14 @@ fn resolve_number_literal() {
 fn resolve_hex_number_literal() {
     let mut ns = Namespace::new(Target::Ewasm);
     let loc = Loc::File(0, 3, 5);
-    let expr = pt::AssemblyExpression::HexNumberLiteral(loc, "0xf23456789a".to_string(), None);
+    let expr = pt::AssemblyExpression::HexNumberLiteral(
+        loc,
+        "0xf23456789a".to_string(),
+        Some(Identifier {
+            loc,
+            name: "u32".to_string(),
+        }),
+    );
 
     let resolved = resolve_assembly_expression(&expr, &mut ns);
     assert!(resolved.is_ok());

--- a/src/sema/assembly/types.rs
+++ b/src/sema/assembly/types.rs
@@ -34,6 +34,6 @@ pub(crate) fn get_default_type_from_identifier(
             Err(())
         }
     } else {
-        Ok(Type::Uint(ns.target.ptr_size()))
+        Ok(Type::Uint(256))
     }
 }


### PR DESCRIPTION
After our discussion, I changed the default types for YUL variables to maintain compatibility with EVM.