### PR TITLE
Include trait for loc() functions

### DIFF
--- a/solang-parser/src/lexer.rs
+++ b/solang-parser/src/lexer.rs
@@ -9,7 +9,7 @@ use std::iter::Peekable;
 use std::str::CharIndices;
 use unicode_xid::UnicodeXID;
 
-use crate::pt::{Comment, Loc};
+use crate::pt::{CodeLocation, Comment, Loc};
 
 pub type Spanned<Token, Loc, Error> = Result<(Loc, Token, Loc), Error>;
 
@@ -377,19 +377,19 @@ impl fmt::Display for LexicalError {
     }
 }
 
-impl LexicalError {
-    pub fn loc(&self) -> &Loc {
+impl CodeLocation for LexicalError {
+    fn loc(&self) -> Loc {
         match self {
-            LexicalError::EndOfFileInComment(loc, ..) => loc,
-            LexicalError::EndOfFileInString(loc, ..) => loc,
-            LexicalError::EndofFileInHex(loc, ..) => loc,
-            LexicalError::MissingNumber(loc, ..) => loc,
-            LexicalError::InvalidCharacterInHexLiteral(loc, _) => loc,
-            LexicalError::UnrecognisedToken(loc, ..) => loc,
-            LexicalError::ExpectedFrom(loc, ..) => loc,
-            LexicalError::MissingExponent(loc, ..) => loc,
-            LexicalError::DoublePoints(loc, ..) => loc,
-            LexicalError::UnrecognisedDecimal(loc, ..) => loc,
+            LexicalError::EndOfFileInComment(loc, ..)
+            | LexicalError::EndOfFileInString(loc, ..)
+            | LexicalError::EndofFileInHex(loc, ..)
+            | LexicalError::MissingNumber(loc, ..)
+            | LexicalError::InvalidCharacterInHexLiteral(loc, _)
+            | LexicalError::UnrecognisedToken(loc, ..)
+            | LexicalError::ExpectedFrom(loc, ..)
+            | LexicalError::MissingExponent(loc, ..)
+            | LexicalError::DoublePoints(loc, ..)
+            | LexicalError::UnrecognisedDecimal(loc, ..) => *loc,
         }
     }
 }

--- a/solang-parser/src/lib.rs
+++ b/solang-parser/src/lib.rs
@@ -1,5 +1,6 @@
 //! Solidity file parser
 
+use crate::pt::CodeLocation;
 use lalrpop_util::ParseError;
 
 pub use diagnostics::Diagnostic;
@@ -45,7 +46,7 @@ pub fn parse(
                     expected.join(", ")
                 ),
             ),
-            ParseError::User { error } => Diagnostic::parser_error(*error.loc(), error.to_string()),
+            ParseError::User { error } => Diagnostic::parser_error(error.loc(), error.to_string()),
             ParseError::ExtraToken { token } => Diagnostic::parser_error(
                 pt::Loc::File(file_no, token.0, token.2),
                 format!("extra token `{}' encountered", token.0),

--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -15,6 +15,16 @@ pub enum Loc {
     File(usize, usize, usize),
 }
 
+/// Structs can implement this trait to easily return their loc
+pub trait CodeLocation {
+    fn loc(&self) -> Loc;
+}
+
+/// Structs should implement this trait to return an optional location
+pub trait OptionalCodeLocation {
+    fn loc(&self) -> Option<Loc>;
+}
+
 impl Loc {
     #[must_use]
     pub fn begin_range(&self) -> Self {
@@ -158,12 +168,12 @@ pub enum StorageLocation {
     Calldata(Loc),
 }
 
-impl StorageLocation {
-    pub fn loc(&self) -> &Loc {
+impl CodeLocation for StorageLocation {
+    fn loc(&self) -> Loc {
         match self {
-            StorageLocation::Memory(l) => l,
-            StorageLocation::Storage(l) => l,
-            StorageLocation::Calldata(l) => l,
+            StorageLocation::Memory(l)
+            | StorageLocation::Storage(l)
+            | StorageLocation::Calldata(l) => *l,
         }
     }
 }
@@ -409,8 +419,8 @@ pub enum Expression {
     This(Loc),
 }
 
-impl Expression {
-    pub fn loc(&self) -> Loc {
+impl CodeLocation for Expression {
+    fn loc(&self) -> Loc {
         match self {
             Expression::PostIncrement(loc, _)
             | Expression::PostDecrement(loc, _)
@@ -502,8 +512,8 @@ impl fmt::Display for Mutability {
     }
 }
 
-impl Mutability {
-    pub fn loc(&self) -> Loc {
+impl CodeLocation for Mutability {
+    fn loc(&self) -> Loc {
         match self {
             Mutability::Pure(loc)
             | Mutability::Constant(loc)
@@ -532,8 +542,8 @@ impl fmt::Display for Visibility {
     }
 }
 
-impl Visibility {
-    pub fn loc(&self) -> Option<Loc> {
+impl OptionalCodeLocation for Visibility {
+    fn loc(&self) -> Option<Loc> {
         match self {
             Visibility::Public(loc)
             | Visibility::External(loc)
@@ -704,8 +714,8 @@ pub enum AssemblySwitch {
     Default(Vec<AssemblyStatement>),
 }
 
-impl Statement {
-    pub fn loc(&self) -> Loc {
+impl CodeLocation for Statement {
+    fn loc(&self) -> Loc {
         match self {
             Statement::Block { loc, .. }
             | Statement::Assembly { loc, .. }

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::codegen::subexpression_elimination::common_sub_expression_elimination;
 use crate::codegen::undefined_variable;
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 use crate::sema::ast::{
     CallTy, Contract, Expression, Function, Namespace, Parameter, StringLocation, Type,
 };

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -8,6 +8,7 @@ use super::{
 };
 use crate::codegen::unused_variable::should_remove_assignment;
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 use crate::sema::ast::{
     Builtin, CallTy, Expression, FormatArg, Function, Namespace, Parameter, StringLocation, Type,
 };

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -11,6 +11,7 @@ use crate::codegen::unused_variable::{
     should_remove_assignment, should_remove_variable, SideEffectsCheckParameters,
 };
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 use crate::sema::ast::{
     Builtin, CallTy, DestructureField, Expression, Function, Namespace, Parameter, Statement,
     TryCatch, Type,

--- a/src/codegen/subexpression_elimination/available_variable.rs
+++ b/src/codegen/subexpression_elimination/available_variable.rs
@@ -1,4 +1,5 @@
 use crate::parser::pt::Loc;
+use crate::parser::pt::OptionalCodeLocation;
 
 /// This struct manages expressions assigned to an existing variable.
 #[derive(Clone)]
@@ -28,18 +29,20 @@ impl AvailableVariable {
         }
     }
 
-    pub fn get_var_loc(&self) -> Option<Loc> {
-        match self {
-            AvailableVariable::Available(_, loc) => Some(*loc),
-            _ => None,
-        }
-    }
-
     pub fn is_available(&self) -> bool {
         matches!(self, AvailableVariable::Available(..))
     }
 
     pub fn is_invalid(&self) -> bool {
         matches!(self, AvailableVariable::Invalidated)
+    }
+}
+
+impl OptionalCodeLocation for AvailableVariable {
+    fn loc(&self) -> Option<Loc> {
+        match self {
+            AvailableVariable::Available(_, loc) => Some(*loc),
+            _ => None,
+        }
     }
 }

--- a/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
+++ b/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
@@ -3,6 +3,7 @@ use crate::codegen::{
     vartable::{Storage, Variable},
     ControlFlowGraph, Instr,
 };
+use crate::parser::pt::OptionalCodeLocation;
 use crate::parser::pt::{Identifier, Loc};
 use crate::sema::ast::{Expression, Namespace, Type};
 use std::collections::HashMap;
@@ -60,7 +61,7 @@ impl CommonSubExpressionTracker {
         self.common_subexpressions.push(CommonSubexpression {
             in_cfg: node.available_variable.is_available(),
             var_no: node.available_variable.get_var_number(),
-            var_loc: node.available_variable.get_var_loc(),
+            var_loc: node.available_variable.loc(),
             instantiated: false,
             var_type: exp.ty(),
             block: node.block,

--- a/src/codegen/undefined_variable.rs
+++ b/src/codegen/undefined_variable.rs
@@ -1,6 +1,6 @@
 use crate::codegen::cfg::{ControlFlowGraph, Instr};
 use crate::codegen::reaching_definitions::{apply_transfers, VarDefs};
-use crate::parser::pt::{Loc, StorageLocation};
+use crate::parser::pt::{CodeLocation, Loc, StorageLocation};
 use crate::sema::ast::{Builtin, Diagnostic, ErrorType, Expression, Level, Namespace, Note};
 use crate::sema::symtable;
 use std::collections::HashMap;

--- a/src/sema/assembly/expression.rs
+++ b/src/sema/assembly/expression.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use num_bigint::{BigInt, Sign};
 use num_traits::Num;
 use solang_parser::diagnostics::{ErrorType, Level};
-use solang_parser::pt::{AssemblyFunctionCall, Identifier, Loc, StorageLocation};
+use solang_parser::pt::{AssemblyFunctionCall, CodeLocation, Identifier, Loc, StorageLocation};
 use solang_parser::{pt, Diagnostic};
 
 // TODO: State variables cannot be assigned to, only .slot can be assigned to, .length cannot be assigned to (check TypeChecker.cpp)
@@ -50,8 +50,8 @@ fn get_suffix_from_string(suffix_name: &str) -> Option<AssemblySuffix> {
     }
 }
 
-impl AssemblyExpression {
-    pub fn loc(&self) -> pt::Loc {
+impl CodeLocation for AssemblyExpression {
+    fn loc(&self) -> pt::Loc {
         match self {
             AssemblyExpression::BoolLiteral(loc, ..)
             | AssemblyExpression::NumberLiteral(loc, ..)

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -5,6 +5,7 @@ use super::eval::eval_const_number;
 use super::expression::{cast, expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::One;
@@ -1036,7 +1037,7 @@ pub fn resolve_namespace_call(
 
                         if let Some(storage) = &param.storage {
                             diagnostics.push(Diagnostic::error(
-                                *storage.loc(),
+                                storage.loc(),
                                 format!("storage modifier ‘{}’ not allowed", storage),
                             ));
                             broken = true;

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -1,4 +1,5 @@
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 use num_bigint::BigInt;
 use num_traits::Zero;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -311,9 +312,9 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
                         || prev.is_event() && sym.is_event())
                     {
                         ns.diagnostics.push(ast::Diagnostic::error_with_note(
-                            *sym.loc(),
+                            sym.loc(),
                             format!("already defined ‘{}’", name),
-                            *prev.loc(),
+                            prev.loc(),
                             format!("previous definition of ‘{}’", name),
                         ));
                     }

--- a/src/sema/diagnostics.rs
+++ b/src/sema/diagnostics.rs
@@ -1,8 +1,8 @@
 use super::ast::{Diagnostic, Level, Namespace};
 use crate::file_resolver::FileResolver;
+use crate::parser::pt::Loc;
 use codespan_reporting::{diagnostic, files, term};
 use serde::Serialize;
-use solang_parser::pt::Loc;
 use std::{io, sync::Arc};
 
 /// Print the diagnostics to stderr with fancy formatting

--- a/src/sema/eval.rs
+++ b/src/sema/eval.rs
@@ -7,6 +7,7 @@ use num_traits::Zero;
 
 use super::ast::{Diagnostic, Expression, Namespace};
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 
 /// Resolve an expression where a compile-time constant is expected
 pub fn eval_const_number(

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -24,6 +24,7 @@ use super::eval::eval_const_rational;
 use super::format::string_format;
 use super::symtable::Symtable;
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 use crate::sema::unused_variable::{
     assigned_variable, check_function_call, check_var_usage_expression, used_variable,
 };

--- a/src/sema/format.rs
+++ b/src/sema/format.rs
@@ -2,6 +2,7 @@ use super::ast::{Diagnostic, Expression, FormatArg, Namespace, Type};
 use super::expression::{cast, expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 
 use std::iter::Peekable;
 use std::slice::Iter;

--- a/src/sema/functions.rs
+++ b/src/sema/functions.rs
@@ -4,6 +4,8 @@ use super::ast::{
 use super::contracts::is_base;
 use super::tags::resolve_tags;
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
+use crate::parser::pt::OptionalCodeLocation;
 use crate::Target;
 
 /// Resolve function declaration in a contract
@@ -823,7 +825,7 @@ pub fn resolve_params(
                 let ty = if !ty.can_have_data_location() {
                     if let Some(storage) = &p.storage {
                         diagnostics.push(Diagnostic::error(
-                            *storage.loc(),
+                            storage.loc(),
                                 format!("data location ‘{}’ can only be specified for array, struct or mapping",
                                 storage)
                             ));
@@ -928,7 +930,7 @@ pub fn resolve_returns(
                 let ty = if !ty.can_have_data_location() {
                     if let Some(storage) = &r.storage {
                         diagnostics.push(Diagnostic::error(
-                            *storage.loc(),
+                            storage.loc(),
                                 format!("data location ‘{}’ can only be specified for array, struct or mapping",
                                 storage)
                             ));

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -35,6 +35,8 @@ use self::functions::{resolve_params, resolve_returns};
 use self::symtable::Symtable;
 use self::variables::var_decl;
 use crate::file_resolver::{FileResolver, ResolvedFile};
+use crate::parser::pt::CodeLocation;
+use crate::parser::pt::OptionalCodeLocation;
 use crate::sema::unused_variable::{check_unused_events, check_unused_namespace_variables};
 
 pub type ArrayDimension = Option<(pt::Loc, BigInt)>;

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -7,9 +7,11 @@ use super::expression::{
 };
 use super::symtable::{LoopScopes, Symtable};
 use crate::parser::pt;
+use crate::parser::pt::CatchClause;
+use crate::parser::pt::CodeLocation;
+use crate::parser::pt::OptionalCodeLocation;
 use crate::sema::symtable::VariableUsage;
 use crate::sema::unused_variable::{assigned_variable, check_function_call, used_variable};
-use solang_parser::pt::CatchClause;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 pub fn resolve_function_body(
@@ -1106,7 +1108,7 @@ fn destructure(
             }) => {
                 if let Some(storage) = storage {
                     diagnostics.push(Diagnostic::error(
-                        *storage.loc(),
+                        storage.loc(),
                         format!("storage modifier ‘{}’ not permitted on assignment", storage),
                     ));
                     return Err(());
@@ -1389,7 +1391,7 @@ fn resolve_var_decl_ty(
     if let Some(storage) = storage {
         if !var_ty.can_have_data_location() {
             diagnostics.push(Diagnostic::error(
-                *storage.loc(),
+                storage.loc(),
                 format!(
                     "data location ‘{}’ only allowed for array, struct or mapping type",
                     storage
@@ -1644,7 +1646,7 @@ pub fn parameter_list_to_expr_list<'a>(
                     ..
                 }) => {
                     diagnostics.push(Diagnostic::error(
-                        *storage.loc(),
+                        storage.loc(),
                         "storage specified not permitted here".to_string(),
                     ));
                     broken = true;

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -9,6 +9,7 @@ use super::{
     SOLANA_SPARSE_ARRAY_SIZE,
 };
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::{One, Zero};
@@ -318,7 +319,7 @@ pub fn struct_decl(
         // allowed as parameter/return types of public functions though.
         if let Some(storage) = &field.storage {
             ns.diagnostics.push(Diagnostic::error(
-                *storage.loc(),
+                storage.loc(),
                 format!(
                     "storage location ‘{}’ not allowed for struct field",
                     storage

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -6,6 +6,8 @@ use super::expression::{cast, expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
 use super::tags::resolve_tags;
 use crate::parser::pt;
+use crate::parser::pt::CodeLocation;
+use crate::parser::pt::OptionalCodeLocation;
 
 pub fn contract_variables(
     def: &pt::ContractDefinition,


### PR DESCRIPTION
This PR adds traits for `fn loc(&self) -> Loc` and `fn loc(&self) -> Option<Loc>`, so that we can maintain more uniformity throughout the code, while creating the loc() functions for many structs.