### PR TITLE
Update links to discord to the correct channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # solang - Solidity Compiler for Solana, Substrate, and ewasm
 
-[![Discord](https://img.shields.io/discord/905194001349627914?logo=Hyperledger&style=plastic)](https://discord.gg/hyperledger)
+[![Discord](https://img.shields.io/discord/905194001349627914?logo=Hyperledger&style=plastic)](https://discord.gg/jhn4rkqNsT)
 [![CI](https://github.com/hyperledger-labs/solang/workflows/test/badge.svg)](https://github.com/hyperledger-labs/solang/actions)
 [![Documentation Status](https://readthedocs.org/projects/solang/badge/?version=latest)](https://solang.readthedocs.io/en/latest/?badge=latest)
 [![license](https://img.shields.io/github/license/hyperledger-labs/solang.svg)](LICENSE)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ Welcome to the Solang Solidity Compiler. Using Solang, you can compile smart con
 Solang aims for source file compatibility with the Ethereum EVM Solidity compiler,
 version 0.7. Where differences exists, this is noted in the :ref:`language documentation <language>`.
 The source code repository can be found on `github <https://github.com/hyperledger-labs/solang>`_
-and we have a `channel #solang on Hyperledger Discord <https://discord.gg/hyperledger>`_, and
-a `channel #solang-solidity-compiler on Solana Discord <https://discord.gg/Solana>`_.
+and we have a `channel #solang on Hyperledger Discord <https://discord.gg/jhn4rkqNsT>`_, and
+a `channel #solang-solidity-compiler on Solana Discord <https://discord.gg/TmE2Ek5ZbW>`_.
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
The links to discord chat is to the discord server, but we can do better
than that and link to the correct channel on the server.

Signed-off-by: Sean Young <sean@mess.org>