### PR TITLE
Create codegen::Expression and refactor codegen

### DIFF
--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -1,6 +1,7 @@
 use clap::ArgMatches;
 use serde_json::Value;
 use solang::{
+    codegen,
     codegen::codegen,
     file_resolver::FileResolver,
     parse_and_resolve,
@@ -209,15 +210,15 @@ impl SolangServer {
                 msg = format!("{} {}", msg, _param.name_as_str());
                 if let Some(expr) = ns.var_constants.get(loc) {
                     match expr {
-                        ast::Expression::BytesLiteral(_, ast::Type::Bytes(_), bs)
-                        | ast::Expression::BytesLiteral(_, ast::Type::DynamicBytes, bs) => {
+                        codegen::Expression::BytesLiteral(_, ast::Type::Bytes(_), bs)
+                        | codegen::Expression::BytesLiteral(_, ast::Type::DynamicBytes, bs) => {
                             msg.push_str(&format!(" = hex\"{}\"", hex::encode(&bs)));
                         }
-                        ast::Expression::BytesLiteral(_, ast::Type::String, bs) => {
+                        codegen::Expression::BytesLiteral(_, ast::Type::String, bs) => {
                             msg.push_str(&format!(" = \"{}\"", String::from_utf8_lossy(bs)));
                         }
-                        ast::Expression::NumberLiteral(_, ast::Type::Uint(_), n)
-                        | ast::Expression::NumberLiteral(_, ast::Type::Int(_), n) => {
+                        codegen::Expression::NumberLiteral(_, ast::Type::Uint(_), n)
+                        | codegen::Expression::NumberLiteral(_, ast::Type::Int(_), n) => {
                             msg.push_str(&format!(" = {}", n));
                         }
                         _ => (),
@@ -506,15 +507,15 @@ impl SolangServer {
 
                 if let Some(expr) = ns.var_constants.get(loc) {
                     match expr {
-                        ast::Expression::BytesLiteral(_, ast::Type::Bytes(_), bs)
-                        | ast::Expression::BytesLiteral(_, ast::Type::DynamicBytes, bs) => {
+                        codegen::Expression::BytesLiteral(_, ast::Type::Bytes(_), bs)
+                        | codegen::Expression::BytesLiteral(_, ast::Type::DynamicBytes, bs) => {
                             msg.push_str(&format!(" hex\"{}\"", hex::encode(&bs)));
                         }
-                        ast::Expression::BytesLiteral(_, ast::Type::String, bs) => {
+                        codegen::Expression::BytesLiteral(_, ast::Type::String, bs) => {
                             msg.push_str(&format!(" \"{}\"", String::from_utf8_lossy(bs)));
                         }
-                        ast::Expression::NumberLiteral(_, ast::Type::Uint(_), n)
-                        | ast::Expression::NumberLiteral(_, ast::Type::Int(_), n) => {
+                        codegen::Expression::NumberLiteral(_, ast::Type::Uint(_), n)
+                        | codegen::Expression::NumberLiteral(_, ast::Type::Int(_), n) => {
                             msg.push_str(&format!(" {}", n));
                         }
                         _ => (),
@@ -802,19 +803,6 @@ impl SolangServer {
                 if let Some(space) = space {
                     SolangServer::construct_expr(space, lookup_tbl, symtab, fnc_map, ns);
                 }
-            }
-
-            // Hash table operation expression
-            ast::Expression::Keccak256(_locs, _typ, expr) => {
-                for expp in expr {
-                    SolangServer::construct_expr(expp, lookup_tbl, symtab, fnc_map, ns);
-                }
-                lookup_tbl.push((_locs.start(), _locs.end(), String::from("Keccak256 hash")));
-            }
-
-            ast::Expression::ReturnData(locs) => {
-                let msg = String::from("Return");
-                lookup_tbl.push((locs.start(), locs.end(), msg));
             }
             ast::Expression::Builtin(_locs, _typ, _builtin, expr) => {
                 let msg = SolangServer::construct_builtins(_builtin, ns);

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -1,7 +1,9 @@
 use super::cfg::{ControlFlowGraph, Instr};
 use super::reaching_definitions;
+use crate::codegen::Expression;
 use crate::parser::pt::Loc;
-use crate::sema::ast::{Builtin, Diagnostic, Expression, Namespace, StringLocation, Type};
+use crate::sema::ast::RetrieveType;
+use crate::sema::ast::{Builtin, Diagnostic, Namespace, StringLocation, Type};
 use num_bigint::{BigInt, Sign};
 use num_traits::{ToPrimitive, Zero};
 use ripemd::Ripemd160;
@@ -820,14 +822,6 @@ fn expression(
 
             (Expression::Load(*loc, ty.clone(), Box::new(expr)), false)
         }
-        Expression::StorageLoad(loc, ty, expr) => {
-            let (expr, _) = expression(expr, vars, cfg, ns);
-
-            (
-                Expression::StorageLoad(*loc, ty.clone(), Box::new(expr)),
-                false,
-            )
-        }
         Expression::Cast(loc, ty, expr) => {
             let (expr, _) = expression(expr, vars, cfg, ns);
 
@@ -892,22 +886,6 @@ fn expression(
 
             (
                 Expression::NotEqual(*loc, Box::new(left.0), Box::new(right.0)),
-                false,
-            )
-        }
-        Expression::Ternary(loc, ty, cond, left, right) => {
-            let cond = expression(cond, vars, cfg, ns);
-            let left = expression(left, vars, cfg, ns);
-            let right = expression(right, vars, cfg, ns);
-
-            (
-                Expression::Ternary(
-                    *loc,
-                    ty.clone(),
-                    Box::new(cond.0),
-                    Box::new(left.0),
-                    Box::new(right.0),
-                ),
                 false,
             )
         }

--- a/src/codegen/dead_storage.rs
+++ b/src/codegen/dead_storage.rs
@@ -1,6 +1,7 @@
 use super::cfg::{BasicBlock, ControlFlowGraph, Instr};
+use crate::codegen::Expression;
 use crate::parser::pt::Loc;
-use crate::sema::ast::{Expression, Namespace};
+use crate::sema::ast::Namespace;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 

--- a/src/codegen/external_functions.rs
+++ b/src/codegen/external_functions.rs
@@ -1,4 +1,5 @@
 use crate::sema::ast::{DestructureField, Expression, Namespace, Statement};
+use crate::sema::Recurse;
 use indexmap::IndexSet;
 
 #[derive(Default)]

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod cfg;
+pub mod cfg;
 mod constant_folding;
 mod dead_storage;
 mod expression;
@@ -24,11 +24,17 @@ use crate::sema::ast::{Layout, Namespace};
 use crate::sema::contracts::visit_bases;
 use crate::sema::diagnostics::any_errors;
 use crate::Target;
+use std::cmp::Ordering;
 
 use crate::ast::Function;
+use crate::ast::{Builtin, FormatArg, RetrieveType, StringLocation, Type};
 use crate::codegen::cfg::ASTFunction;
-use num_bigint::BigInt;
-use num_traits::Zero;
+use crate::sema::Recurse;
+use num_bigint::{BigInt, Sign};
+use num_rational::BigRational;
+use num_traits::{FromPrimitive, Zero};
+use solang_parser::pt;
+use solang_parser::pt::{CodeLocation, Loc};
 
 // The sizeof(struct account_data_header)
 pub const SOLANA_FIRST_OFFSET: u64 = 16;
@@ -325,5 +331,792 @@ impl LLVMName for Function {
         }
 
         sig
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Expression {
+    AbiEncode {
+        loc: pt::Loc,
+        tys: Vec<Type>,
+        packed: Vec<Expression>,
+        args: Vec<Expression>,
+    },
+    Add(pt::Loc, Type, bool, Box<Expression>, Box<Expression>),
+    AllocDynamicArray(pt::Loc, Type, Box<Expression>, Option<Vec<u8>>),
+    ArrayLiteral(pt::Loc, Type, Vec<u32>, Vec<Expression>),
+    BitwiseAnd(pt::Loc, Type, Box<Expression>, Box<Expression>),
+    BitwiseOr(pt::Loc, Type, Box<Expression>, Box<Expression>),
+    BitwiseXor(pt::Loc, Type, Box<Expression>, Box<Expression>),
+    BoolLiteral(pt::Loc, bool),
+    Builtin(pt::Loc, Vec<Type>, Builtin, Vec<Expression>),
+    BytesCast(pt::Loc, Type, Type, Box<Expression>),
+    BytesLiteral(pt::Loc, Type, Vec<u8>),
+    Cast(pt::Loc, Type, Box<Expression>),
+    CodeLiteral(pt::Loc, usize, bool),
+    Complement(pt::Loc, Type, Box<Expression>),
+    ConstArrayLiteral(pt::Loc, Type, Vec<u32>, Vec<Expression>),
+    Divide(pt::Loc, Type, Box<Expression>, Box<Expression>),
+    Equal(pt::Loc, Box<Expression>, Box<Expression>),
+    ExternalFunction {
+        loc: pt::Loc,
+        ty: Type,
+        address: Box<Expression>,
+        function_no: usize,
+    },
+    FormatString(pt::Loc, Vec<(FormatArg, Expression)>),
+    FunctionArg(pt::Loc, Type, usize),
+    GetRef(pt::Loc, Type, Box<Expression>),
+    InternalFunctionCfg(usize),
+    Keccak256(pt::Loc, Type, Vec<Expression>),
+    List(pt::Loc, Vec<Expression>),
+    Less(pt::Loc, Box<Expression>, Box<Expression>),
+    LessEqual(pt::Loc, Box<Expression>, Box<Expression>),
+    Load(pt::Loc, Type, Box<Expression>),
+    Modulo(pt::Loc, Type, Box<Expression>, Box<Expression>),
+    More(pt::Loc, Box<Expression>, Box<Expression>),
+    MoreEqual(pt::Loc, Box<Expression>, Box<Expression>),
+    Multiply(pt::Loc, Type, bool, Box<Expression>, Box<Expression>),
+    Not(pt::Loc, Box<Expression>),
+    NotEqual(pt::Loc, Box<Expression>, Box<Expression>),
+    NumberLiteral(pt::Loc, Type, BigInt),
+    Poison,
+    Power(pt::Loc, Type, bool, Box<Expression>, Box<Expression>),
+    RationalNumberLiteral(pt::Loc, Type, BigRational),
+    ReturnData(pt::Loc),
+    SignExt(pt::Loc, Type, Box<Expression>),
+    ShiftLeft(pt::Loc, Type, Box<Expression>, Box<Expression>),
+    ShiftRight(pt::Loc, Type, Box<Expression>, Box<Expression>, bool),
+    StorageArrayLength {
+        loc: pt::Loc,
+        ty: Type,
+        array: Box<Expression>,
+        elem_ty: Type,
+    },
+    StringCompare(
+        pt::Loc,
+        StringLocation<Expression>,
+        StringLocation<Expression>,
+    ),
+    StringConcat(
+        pt::Loc,
+        Type,
+        StringLocation<Expression>,
+        StringLocation<Expression>,
+    ),
+    StructLiteral(pt::Loc, Type, Vec<Expression>),
+    StructMember(pt::Loc, Type, Box<Expression>, usize),
+    Subscript(pt::Loc, Type, Type, Box<Expression>, Box<Expression>),
+    Subtract(pt::Loc, Type, bool, Box<Expression>, Box<Expression>),
+    Trunc(pt::Loc, Type, Box<Expression>),
+    UnaryMinus(pt::Loc, Type, Box<Expression>),
+    Undefined(Type),
+    Variable(pt::Loc, Type, usize),
+    ZeroExt(pt::Loc, Type, Box<Expression>),
+}
+
+impl CodeLocation for Expression {
+    fn loc(&self) -> Loc {
+        match self {
+            Expression::AbiEncode { loc, .. }
+            | Expression::StorageArrayLength { loc, .. }
+            | Expression::ExternalFunction { loc, .. }
+            | Expression::Builtin(loc, ..)
+            | Expression::Cast(loc, ..)
+            | Expression::NumberLiteral(loc, ..)
+            | Expression::Keccak256(loc, ..)
+            | Expression::MoreEqual(loc, ..)
+            | Expression::ReturnData(loc, ..)
+            | Expression::Subscript(loc, ..)
+            | Expression::Trunc(loc, ..)
+            | Expression::Variable(loc, ..)
+            | Expression::SignExt(loc, ..)
+            | Expression::GetRef(loc, ..)
+            | Expression::Load(loc, ..)
+            | Expression::BytesLiteral(loc, ..)
+            | Expression::Add(loc, ..)
+            | Expression::Multiply(loc, ..)
+            | Expression::Subtract(loc, ..)
+            | Expression::FormatString(loc, ..)
+            | Expression::LessEqual(loc, ..)
+            | Expression::BoolLiteral(loc, ..)
+            | Expression::Divide(loc, ..)
+            | Expression::Modulo(loc, ..)
+            | Expression::Power(loc, ..)
+            | Expression::BitwiseOr(loc, ..)
+            | Expression::BitwiseAnd(loc, ..)
+            | Expression::BitwiseXor(loc, ..)
+            | Expression::Equal(loc, ..)
+            | Expression::NotEqual(loc, ..)
+            | Expression::Complement(loc, ..)
+            | Expression::UnaryMinus(loc, ..)
+            | Expression::Less(loc, ..)
+            | Expression::Not(loc, ..)
+            | Expression::StructLiteral(loc, ..)
+            | Expression::ArrayLiteral(loc, ..)
+            | Expression::ConstArrayLiteral(loc, ..)
+            | Expression::StructMember(loc, ..)
+            | Expression::StringCompare(loc, ..)
+            | Expression::StringConcat(loc, ..)
+            | Expression::FunctionArg(loc, ..)
+            | Expression::CodeLiteral(loc, ..)
+            | Expression::List(loc, ..)
+            | Expression::ShiftRight(loc, ..)
+            | Expression::ShiftLeft(loc, ..)
+            | Expression::RationalNumberLiteral(loc, ..)
+            | Expression::AllocDynamicArray(loc, ..)
+            | Expression::BytesCast(loc, ..)
+            | Expression::More(loc, ..)
+            | Expression::ZeroExt(loc, ..) => *loc,
+
+            Expression::InternalFunctionCfg(_) | Expression::Poison | Expression::Undefined(_) => {
+                pt::Loc::Codegen
+            }
+        }
+    }
+}
+
+impl Recurse for Expression {
+    type ArgType = Expression;
+    fn recurse<T>(&self, cx: &mut T, f: fn(expr: &Expression, ctx: &mut T) -> bool) {
+        if !f(self, cx) {
+            return;
+        }
+        match self {
+            Expression::AbiEncode { packed, args, .. } => {
+                for item in packed {
+                    item.recurse(cx, f);
+                }
+
+                for arg in args {
+                    arg.recurse(cx, f);
+                }
+            }
+
+            Expression::BitwiseAnd(_, _, left, right)
+            | Expression::BitwiseOr(_, _, left, right)
+            | Expression::Divide(_, _, left, right)
+            | Expression::Equal(_, left, right)
+            | Expression::Less(_, left, right)
+            | Expression::LessEqual(_, left, right)
+            | Expression::BitwiseXor(_, _, left, right)
+            | Expression::More(_, left, right)
+            | Expression::MoreEqual(_, left, right)
+            | Expression::Multiply(_, _, _, left, right)
+            | Expression::NotEqual(_, left, right)
+            | Expression::ShiftLeft(_, _, left, right)
+            | Expression::ShiftRight(_, _, left, right, _)
+            | Expression::Power(_, _, _, left, right)
+            | Expression::Subscript(_, _, _, left, right)
+            | Expression::Subtract(_, _, _, left, right)
+            | Expression::Add(_, _, _, left, right) => {
+                left.recurse(cx, f);
+                right.recurse(cx, f);
+            }
+
+            Expression::BytesCast(_, _, _, exp)
+            | Expression::Cast(_, _, exp)
+            | Expression::GetRef(_, _, exp)
+            | Expression::Not(_, exp)
+            | Expression::Trunc(_, _, exp)
+            | Expression::UnaryMinus(_, _, exp)
+            | Expression::ZeroExt(_, _, exp)
+            | Expression::SignExt(_, _, exp)
+            | Expression::Complement(_, _, exp)
+            | Expression::ExternalFunction { address: exp, .. }
+            | Expression::Load(_, _, exp)
+            | Expression::StorageArrayLength { array: exp, .. }
+            | Expression::StructMember(_, _, exp, _)
+            | Expression::AllocDynamicArray(_, _, exp, _) => {
+                exp.recurse(cx, f);
+            }
+
+            Expression::Builtin(_, _, _, vec)
+            | Expression::ConstArrayLiteral(_, _, _, vec)
+            | Expression::Keccak256(_, _, vec)
+            | Expression::StructLiteral(_, _, vec)
+            | Expression::ArrayLiteral(_, _, _, vec) => {
+                for item in vec {
+                    item.recurse(cx, f);
+                }
+            }
+
+            Expression::FormatString(_, vec) => {
+                for item in vec {
+                    item.1.recurse(cx, f);
+                }
+            }
+
+            Expression::StringCompare(_, left, right)
+            | Expression::StringConcat(_, _, left, right) => {
+                if let StringLocation::RunTime(exp) = left {
+                    exp.recurse(cx, f);
+                }
+
+                if let StringLocation::RunTime(exp) = right {
+                    exp.recurse(cx, f);
+                }
+            }
+
+            _ => (),
+        }
+    }
+}
+
+impl RetrieveType for Expression {
+    fn ty(&self) -> Type {
+        match self {
+            Expression::AbiEncode { .. }
+            | Expression::CodeLiteral(..)
+            | Expression::ReturnData(_) => Type::DynamicBytes,
+            Expression::Builtin(_, returns, ..) => {
+                assert_eq!(returns.len(), 1);
+                returns[0].clone()
+            }
+            Expression::Keccak256(_, ty, ..)
+            | Expression::Undefined(ty)
+            | Expression::Variable(_, ty, ..)
+            | Expression::Trunc(_, ty, ..)
+            | Expression::ZeroExt(_, ty, ..)
+            | Expression::Cast(_, ty, ..)
+            | Expression::SignExt(_, ty, ..)
+            | Expression::GetRef(_, ty, ..)
+            | Expression::Load(_, ty, ..)
+            | Expression::BytesLiteral(_, ty, ..)
+            | Expression::Add(_, ty, ..)
+            | Expression::NumberLiteral(_, ty, ..)
+            | Expression::Multiply(_, ty, ..)
+            | Expression::Subtract(_, ty, ..)
+            | Expression::Divide(_, ty, ..)
+            | Expression::Modulo(_, ty, ..)
+            | Expression::Power(_, ty, ..)
+            | Expression::BitwiseOr(_, ty, ..)
+            | Expression::BitwiseAnd(_, ty, ..)
+            | Expression::BitwiseXor(_, ty, ..)
+            | Expression::ShiftLeft(_, ty, ..)
+            | Expression::ShiftRight(_, ty, ..)
+            | Expression::Complement(_, ty, ..)
+            | Expression::StorageArrayLength { ty, .. }
+            | Expression::UnaryMinus(_, ty, ..)
+            | Expression::StructLiteral(_, ty, ..)
+            | Expression::ArrayLiteral(_, ty, ..)
+            | Expression::ConstArrayLiteral(_, ty, ..)
+            | Expression::ExternalFunction { ty, .. }
+            | Expression::StructMember(_, ty, ..)
+            | Expression::StringConcat(_, ty, ..)
+            | Expression::FunctionArg(_, ty, ..)
+            | Expression::AllocDynamicArray(_, ty, ..)
+            | Expression::BytesCast(_, ty, ..)
+            | Expression::RationalNumberLiteral(_, ty, ..)
+            | Expression::Subscript(_, ty, ..) => ty.clone(),
+
+            Expression::BoolLiteral(..)
+            | Expression::MoreEqual(..)
+            | Expression::More(..)
+            | Expression::Not(..)
+            | Expression::NotEqual(..)
+            | Expression::Less(..)
+            | Expression::Equal(..)
+            | Expression::StringCompare(..)
+            | Expression::LessEqual(..) => Type::Bool,
+
+            Expression::List(_, list) => {
+                assert_eq!(list.len(), 1);
+
+                list[0].ty()
+            }
+
+            Expression::FormatString(..) => Type::String,
+            Expression::InternalFunctionCfg(_) => Type::Unreachable,
+            Expression::Poison => unreachable!("Expression does not have a type"),
+        }
+    }
+}
+
+impl Expression {
+    pub(crate) fn cast(&self, to: &Type, ns: &Namespace) -> Expression {
+        let from = self.ty();
+
+        if &from == to {
+            return self.clone();
+        }
+
+        let address_bits = ns.address_length as u16 * 8;
+
+        // When converting from literals, there is not need to trunc or extend.
+        match (self, &from, to) {
+            (&Expression::NumberLiteral(_, _, ref n), p, &Type::Uint(to_len))
+                if p.is_primitive() =>
+            {
+                return if n.sign() == Sign::Minus {
+                    let mut bs = n.to_signed_bytes_le();
+                    bs.resize(to_len as usize / 8, 0xff);
+                    Expression::NumberLiteral(
+                        self.loc(),
+                        Type::Uint(to_len),
+                        BigInt::from_bytes_le(Sign::Plus, &bs),
+                    )
+                } else {
+                    Expression::NumberLiteral(self.loc(), Type::Uint(to_len), n.clone())
+                }
+            }
+            (&Expression::NumberLiteral(_, _, ref n), p, &Type::Int(to_len))
+                if p.is_primitive() =>
+            {
+                return Expression::NumberLiteral(self.loc(), Type::Int(to_len), n.clone());
+            }
+            (&Expression::NumberLiteral(_, _, ref n), p, &Type::Bytes(to_len))
+                if p.is_primitive() =>
+            {
+                return Expression::NumberLiteral(self.loc(), Type::Bytes(to_len), n.clone());
+            }
+            (&Expression::NumberLiteral(_, _, ref n), p, &Type::Address(payable))
+                if p.is_primitive() =>
+            {
+                return Expression::NumberLiteral(self.loc(), Type::Address(payable), n.clone());
+            }
+
+            (&Expression::BytesLiteral(_, _, ref bs), p, &Type::Bytes(to_len))
+                if p.is_primitive() =>
+            {
+                let mut bs = bs.to_owned();
+                bs.resize(to_len as usize, 0);
+                return Expression::BytesLiteral(self.loc(), Type::Bytes(to_len), bs);
+            }
+            (&Expression::BytesLiteral(loc, _, ref init), _, &Type::DynamicBytes)
+            | (&Expression::BytesLiteral(loc, _, ref init), _, &Type::String) => {
+                return Expression::AllocDynamicArray(
+                    loc,
+                    to.clone(),
+                    Box::new(Expression::NumberLiteral(
+                        loc,
+                        Type::Uint(32),
+                        BigInt::from(init.len()),
+                    )),
+                    Some(init.clone()),
+                );
+            }
+            (&Expression::NumberLiteral(_, _, ref n), _, &Type::Rational) => {
+                return Expression::RationalNumberLiteral(
+                    self.loc(),
+                    Type::Rational,
+                    BigRational::from(n.clone()),
+                );
+            }
+
+            _ => (),
+        }
+
+        let from = match (&from, to) {
+            (Type::Enum(enum_no), Type::Uint(_)) | (Type::Enum(enum_no), Type::Int(_)) => {
+                let enum_ty = &ns.enums[*enum_no];
+                let from_width = enum_ty.ty.bits(ns);
+                Type::Uint(from_width)
+            }
+
+            (Type::Value, Type::Uint(_)) | (Type::Value, Type::Int(_)) => {
+                let from_len = (ns.value_length as u16) * 8;
+                Type::Int(from_len)
+            }
+
+            _ => from,
+        };
+
+        #[allow(clippy::comparison_chain)]
+        match (&from, to) {
+            (Type::Uint(from_width), Type::Enum(enum_no))
+            | (Type::Int(from_width), Type::Enum(enum_no)) => {
+                let enum_ty = &ns.enums[*enum_no];
+                // Not checking eval const number
+                let to_width = enum_ty.ty.bits(ns);
+                match from_width.cmp(&to_width) {
+                    Ordering::Greater => {
+                        Expression::Trunc(self.loc(), to.clone(), Box::new(self.clone()))
+                    }
+                    Ordering::Less => {
+                        Expression::ZeroExt(self.loc(), to.clone(), Box::new(self.clone()))
+                    }
+                    Ordering::Equal => {
+                        Expression::Cast(self.loc(), to.clone(), Box::new(self.clone()))
+                    }
+                }
+            }
+
+            (Type::Bytes(1), Type::Uint(8)) | (Type::Uint(8), Type::Bytes(1)) => self.clone(),
+
+            (Type::Uint(from_len), Type::Uint(to_len))
+            | (Type::Uint(from_len), Type::Int(to_len)) => match from_len.cmp(to_len) {
+                Ordering::Greater => {
+                    Expression::Trunc(self.loc(), to.clone(), Box::new(self.clone()))
+                }
+                Ordering::Less => {
+                    Expression::ZeroExt(self.loc(), to.clone(), Box::new(self.clone()))
+                }
+                Ordering::Equal => Expression::Cast(self.loc(), to.clone(), Box::new(self.clone())),
+            },
+
+            (Type::Int(from_len), Type::Uint(to_len))
+            | (Type::Int(from_len), Type::Int(to_len)) => match from_len.cmp(to_len) {
+                Ordering::Greater => {
+                    Expression::Trunc(self.loc(), to.clone(), Box::new(self.clone()))
+                }
+                Ordering::Less => {
+                    Expression::SignExt(self.loc(), to.clone(), Box::new(self.clone()))
+                }
+                Ordering::Equal => Expression::Cast(self.loc(), to.clone(), Box::new(self.clone())),
+            },
+
+            (Type::Uint(from_len), Type::Address(_)) | (Type::Int(from_len), Type::Address(_)) => {
+                let address_to_int = if from.is_signed_int() {
+                    Type::Int(address_bits)
+                } else {
+                    Type::Uint(address_bits)
+                };
+
+                let expr = if *from_len > address_bits {
+                    Expression::Trunc(self.loc(), address_to_int, Box::new(self.clone()))
+                } else if *from_len < address_bits {
+                    if from.is_signed_int() {
+                        Expression::ZeroExt(self.loc(), to.clone(), Box::new(self.clone()))
+                    } else {
+                        Expression::SignExt(self.loc(), to.clone(), Box::new(self.clone()))
+                    }
+                } else {
+                    self.clone()
+                };
+
+                Expression::Cast(self.loc(), to.clone(), Box::new(expr))
+            }
+            (Type::Address(_), Type::Uint(to_len)) | (Type::Address(_), Type::Int(to_len)) => {
+                let address_to_int = if to.is_signed_int() {
+                    Type::Int(address_bits)
+                } else {
+                    Type::Uint(address_bits)
+                };
+
+                let expr = Expression::Cast(self.loc(), address_to_int, Box::new(self.clone()));
+
+                // now resize int to request size with sign extension etc
+                if *to_len < address_bits {
+                    Expression::Trunc(self.loc(), to.clone(), Box::new(expr))
+                } else if *to_len > address_bits {
+                    if to.is_signed_int() {
+                        Expression::ZeroExt(self.loc(), to.clone(), Box::new(expr))
+                    } else {
+                        Expression::SignExt(self.loc(), to.clone(), Box::new(expr))
+                    }
+                } else {
+                    expr
+                }
+            }
+            (Type::Bytes(from_len), Type::Bytes(to_len)) => {
+                if to_len > from_len {
+                    let shift = (to_len - from_len) * 8;
+
+                    Expression::ShiftLeft(
+                        self.loc(),
+                        to.clone(),
+                        Box::new(Expression::ZeroExt(
+                            self.loc(),
+                            to.clone(),
+                            Box::new(self.clone()),
+                        )),
+                        Box::new(Expression::NumberLiteral(
+                            self.loc(),
+                            Type::Uint(*to_len as u16 * 8),
+                            BigInt::from_u8(shift).unwrap(),
+                        )),
+                    )
+                } else {
+                    let shift = (from_len - to_len) * 8;
+
+                    Expression::Trunc(
+                        self.loc(),
+                        to.clone(),
+                        Box::new(Expression::ShiftRight(
+                            self.loc(),
+                            from.clone(),
+                            Box::new(self.clone()),
+                            Box::new(Expression::NumberLiteral(
+                                self.loc(),
+                                Type::Uint(*from_len as u16 * 8),
+                                BigInt::from_u8(shift).unwrap(),
+                            )),
+                            false,
+                        )),
+                    )
+                }
+            }
+            // Conversion from rational will never happen in codegen
+            (Type::Uint(_) | Type::Int(_) | Type::Value, Type::Rational) => {
+                Expression::Cast(self.loc(), to.clone(), Box::new(self.clone()))
+            }
+
+            (Type::Bytes(_), Type::DynamicBytes) | (Type::DynamicBytes, Type::Bytes(_)) => {
+                Expression::BytesCast(self.loc(), from.clone(), to.clone(), Box::new(self.clone()))
+            }
+
+            (Type::Bytes(_), Type::Uint(_))
+            | (Type::Bytes(_), Type::Int(_))
+            | (Type::Uint(_), Type::Bytes(_))
+            | (Type::Int(_), Type::Bytes(_))
+            | (Type::Bytes(_), Type::Address(_))
+            | (Type::Address(false), Type::Address(true))
+            | (Type::Address(_), Type::Contract(_))
+            | (Type::Contract(_), Type::Address(_))
+            | (Type::Contract(_), Type::Contract(_))
+            | (Type::Address(true), Type::Address(false))
+            | (Type::Address(_), Type::Bytes(_))
+            | (Type::String, Type::DynamicBytes)
+            | (Type::DynamicBytes, Type::String)
+            | (Type::InternalFunction { .. }, Type::InternalFunction { .. })
+            | (Type::ExternalFunction { .. }, Type::ExternalFunction { .. }) => {
+                Expression::Cast(self.loc(), to.clone(), Box::new(self.clone()))
+            }
+
+            _ => self.clone(),
+        }
+    }
+
+    /// Recurse over expression and copy each element through a filter. This allows the optimizer passes to create
+    /// copies of expressions while modifying the results slightly
+    #[must_use]
+    pub fn copy_filter<T, F>(&self, ctx: &mut T, filter: F) -> Expression
+    where
+        F: Fn(&Expression, &mut T) -> Expression,
+    {
+        filter(
+            &match self {
+                Expression::StructLiteral(loc, ty, args) => Expression::StructLiteral(
+                    *loc,
+                    ty.clone(),
+                    args.iter().map(|e| filter(e, ctx)).collect(),
+                ),
+                Expression::ArrayLiteral(loc, ty, lengths, args) => Expression::ArrayLiteral(
+                    *loc,
+                    ty.clone(),
+                    lengths.clone(),
+                    args.iter().map(|e| filter(e, ctx)).collect(),
+                ),
+                Expression::ConstArrayLiteral(loc, ty, lengths, args) => {
+                    Expression::ConstArrayLiteral(
+                        *loc,
+                        ty.clone(),
+                        lengths.clone(),
+                        args.iter().map(|e| filter(e, ctx)).collect(),
+                    )
+                }
+                Expression::Add(loc, ty, unchecked, left, right) => Expression::Add(
+                    *loc,
+                    ty.clone(),
+                    *unchecked,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::Subtract(loc, ty, unchecked, left, right) => Expression::Subtract(
+                    *loc,
+                    ty.clone(),
+                    *unchecked,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::Multiply(loc, ty, unchecked, left, right) => Expression::Multiply(
+                    *loc,
+                    ty.clone(),
+                    *unchecked,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::Divide(loc, ty, left, right) => Expression::Divide(
+                    *loc,
+                    ty.clone(),
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::Power(loc, ty, unchecked, left, right) => Expression::Power(
+                    *loc,
+                    ty.clone(),
+                    *unchecked,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::BitwiseOr(loc, ty, left, right) => Expression::BitwiseOr(
+                    *loc,
+                    ty.clone(),
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::BitwiseAnd(loc, ty, left, right) => Expression::BitwiseAnd(
+                    *loc,
+                    ty.clone(),
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::BitwiseXor(loc, ty, left, right) => Expression::BitwiseXor(
+                    *loc,
+                    ty.clone(),
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::ShiftLeft(loc, ty, left, right) => Expression::ShiftLeft(
+                    *loc,
+                    ty.clone(),
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::ShiftRight(loc, ty, left, right, sign_extend) => {
+                    Expression::ShiftRight(
+                        *loc,
+                        ty.clone(),
+                        Box::new(filter(left, ctx)),
+                        Box::new(filter(right, ctx)),
+                        *sign_extend,
+                    )
+                }
+                Expression::Load(loc, ty, expr) => {
+                    Expression::Load(*loc, ty.clone(), Box::new(filter(expr, ctx)))
+                }
+                Expression::ZeroExt(loc, ty, expr) => {
+                    Expression::ZeroExt(*loc, ty.clone(), Box::new(filter(expr, ctx)))
+                }
+                Expression::SignExt(loc, ty, expr) => {
+                    Expression::SignExt(*loc, ty.clone(), Box::new(filter(expr, ctx)))
+                }
+                Expression::Trunc(loc, ty, expr) => {
+                    Expression::Trunc(*loc, ty.clone(), Box::new(filter(expr, ctx)))
+                }
+                Expression::Cast(loc, ty, expr) => {
+                    Expression::Cast(*loc, ty.clone(), Box::new(filter(expr, ctx)))
+                }
+                Expression::BytesCast(loc, ty, from, expr) => Expression::BytesCast(
+                    *loc,
+                    ty.clone(),
+                    from.clone(),
+                    Box::new(filter(expr, ctx)),
+                ),
+                Expression::More(loc, left, right) => Expression::More(
+                    *loc,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::Less(loc, left, right) => Expression::Less(
+                    *loc,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::MoreEqual(loc, left, right) => Expression::MoreEqual(
+                    *loc,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::LessEqual(loc, left, right) => Expression::LessEqual(
+                    *loc,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::Equal(loc, left, right) => Expression::Equal(
+                    *loc,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::NotEqual(loc, left, right) => Expression::NotEqual(
+                    *loc,
+                    Box::new(filter(left, ctx)),
+                    Box::new(filter(right, ctx)),
+                ),
+                Expression::Not(loc, expr) => Expression::Not(*loc, Box::new(filter(expr, ctx))),
+                Expression::Complement(loc, ty, expr) => {
+                    Expression::Complement(*loc, ty.clone(), Box::new(filter(expr, ctx)))
+                }
+                Expression::UnaryMinus(loc, ty, expr) => {
+                    Expression::UnaryMinus(*loc, ty.clone(), Box::new(filter(expr, ctx)))
+                }
+                Expression::Subscript(loc, elem_ty, array_ty, left, right) => {
+                    Expression::Subscript(
+                        *loc,
+                        elem_ty.clone(),
+                        array_ty.clone(),
+                        Box::new(filter(left, ctx)),
+                        Box::new(filter(right, ctx)),
+                    )
+                }
+                Expression::StructMember(loc, ty, expr, field) => {
+                    Expression::StructMember(*loc, ty.clone(), Box::new(filter(expr, ctx)), *field)
+                }
+                Expression::AllocDynamicArray(loc, ty, expr, initializer) => {
+                    Expression::AllocDynamicArray(
+                        *loc,
+                        ty.clone(),
+                        Box::new(filter(expr, ctx)),
+                        initializer.clone(),
+                    )
+                }
+                Expression::StorageArrayLength {
+                    loc,
+                    ty,
+                    array,
+                    elem_ty,
+                } => Expression::StorageArrayLength {
+                    loc: *loc,
+                    ty: ty.clone(),
+                    array: Box::new(filter(array, ctx)),
+                    elem_ty: elem_ty.clone(),
+                },
+                Expression::StringCompare(loc, left, right) => Expression::StringCompare(
+                    *loc,
+                    match left {
+                        StringLocation::CompileTime(_) => left.clone(),
+                        StringLocation::RunTime(expr) => {
+                            StringLocation::RunTime(Box::new(filter(expr, ctx)))
+                        }
+                    },
+                    match right {
+                        StringLocation::CompileTime(_) => right.clone(),
+                        StringLocation::RunTime(expr) => {
+                            StringLocation::RunTime(Box::new(filter(expr, ctx)))
+                        }
+                    },
+                ),
+                Expression::StringConcat(loc, ty, left, right) => Expression::StringConcat(
+                    *loc,
+                    ty.clone(),
+                    match left {
+                        StringLocation::CompileTime(_) => left.clone(),
+                        StringLocation::RunTime(expr) => {
+                            StringLocation::RunTime(Box::new(filter(expr, ctx)))
+                        }
+                    },
+                    match right {
+                        StringLocation::CompileTime(_) => right.clone(),
+                        StringLocation::RunTime(expr) => {
+                            StringLocation::RunTime(Box::new(filter(expr, ctx)))
+                        }
+                    },
+                ),
+                Expression::ExternalFunction {
+                    loc,
+                    ty,
+                    address,
+                    function_no,
+                } => Expression::ExternalFunction {
+                    loc: *loc,
+                    ty: ty.clone(),
+                    address: Box::new(filter(address, ctx)),
+                    function_no: *function_no,
+                },
+                Expression::FormatString(loc, args) => {
+                    let args = args.iter().map(|(f, e)| (*f, filter(e, ctx))).collect();
+
+                    Expression::FormatString(*loc, args)
+                }
+                Expression::Builtin(loc, tys, builtin, args) => {
+                    let args = args.iter().map(|e| filter(e, ctx)).collect();
+
+                    Expression::Builtin(*loc, tys.clone(), *builtin, args)
+                }
+                _ => self.clone(),
+            },
+            ctx,
+        )
     }
 }

--- a/src/codegen/reaching_definitions.rs
+++ b/src/codegen/reaching_definitions.rs
@@ -1,5 +1,5 @@
 use super::cfg::{BasicBlock, ControlFlowGraph, Instr};
-use crate::sema::ast::Expression;
+use crate::codegen::Expression;
 use indexmap::IndexMap;
 use std::collections::HashSet;
 use std::fmt;

--- a/src/codegen/storage.rs
+++ b/src/codegen/storage.rs
@@ -1,3 +1,5 @@
+use crate::ast;
+use crate::codegen::Expression;
 use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 use num_traits::One;
@@ -10,7 +12,8 @@ use super::{
     vartable::Vartable,
 };
 use crate::parser::pt;
-use crate::sema::ast::{Expression, Function, Namespace, Type};
+use crate::sema::ast::RetrieveType;
+use crate::sema::ast::{Function, Namespace, Type};
 
 /// Given a storage slot which is the start of the array, calculate the
 /// offset of the array element. This function exists to avoid doing
@@ -67,7 +70,7 @@ pub fn array_offset(
 /// Push() method on dynamic array in storage
 pub fn storage_slots_array_push(
     loc: &pt::Loc,
-    args: &[Expression],
+    args: &[ast::Expression],
     cfg: &mut ControlFlowGraph,
     contract_no: usize,
     func: Option<&Function>,
@@ -81,7 +84,7 @@ pub fn storage_slots_array_push(
 
     let var_expr = expression(&args[0], cfg, contract_no, func, ns, vartab, opt);
 
-    let expr = load_storage(loc, &slot_ty, var_expr.clone(), cfg, vartab, opt);
+    let expr = load_storage(loc, &slot_ty, var_expr.clone(), cfg, vartab);
 
     cfg.add(
         vartab,
@@ -156,7 +159,7 @@ pub fn storage_slots_array_push(
 /// Pop() method on dynamic array in storage
 pub fn storage_slots_array_pop(
     loc: &pt::Loc,
-    args: &[Expression],
+    args: &[ast::Expression],
     return_ty: &Type,
     cfg: &mut ControlFlowGraph,
     contract_no: usize,
@@ -173,7 +176,7 @@ pub fn storage_slots_array_pop(
     let ty = args[0].ty();
     let var_expr = expression(&args[0], cfg, contract_no, func, ns, vartab, opt);
 
-    let expr = load_storage(loc, &length_ty, var_expr.clone(), cfg, vartab, opt);
+    let expr = load_storage(loc, &length_ty, var_expr.clone(), cfg, vartab);
 
     cfg.add(
         vartab,
@@ -254,7 +257,6 @@ pub fn storage_slots_array_pop(
             Expression::Variable(*loc, elem_ty.clone(), entry_pos),
             cfg,
             vartab,
-            opt,
         );
 
         cfg.add(
@@ -294,7 +296,7 @@ pub fn storage_slots_array_pop(
 /// Push() method on array or bytes in storage
 pub fn array_push(
     loc: &pt::Loc,
-    args: &[Expression],
+    args: &[ast::Expression],
     cfg: &mut ControlFlowGraph,
     contract_no: usize,
     func: Option<&Function>,
@@ -342,7 +344,7 @@ pub fn array_push(
 /// Pop() method on array or bytes in storage
 pub fn array_pop(
     loc: &pt::Loc,
-    args: &[Expression],
+    args: &[ast::Expression],
     return_ty: &Type,
     cfg: &mut ControlFlowGraph,
     contract_no: usize,

--- a/src/codegen/strength_reduce.rs
+++ b/src/codegen/strength_reduce.rs
@@ -1,6 +1,7 @@
 use super::cfg::{ControlFlowGraph, Instr};
-use crate::sema::ast::{Expression, Namespace, Type};
-use crate::sema::expression::cast;
+use crate::codegen::Expression;
+use crate::sema::ast::RetrieveType;
+use crate::sema::ast::{Namespace, Type};
 use bitvec::prelude::*;
 use itertools::Itertools;
 use num_bigint::{BigInt, Sign};
@@ -205,7 +206,6 @@ fn expression_reduce(expr: &Expression, vars: &Variables, ns: &mut Namespace) ->
         match expr {
             Expression::Multiply(loc, ty, unchecked, left, right) => {
                 let bits = ty.bits(ns) as usize;
-
                 if bits >= 128 {
                     let left_values = expression_values(left, vars, ns);
                     let right_values = expression_values(right, vars, ns);
@@ -261,28 +261,8 @@ fn expression_reduce(expr: &Expression, vars: &Variables, ns: &mut Namespace) ->
                                         *loc,
                                         Type::Int(64),
                                         *unchecked,
-                                        Box::new(
-                                            cast(
-                                                loc,
-                                                left.as_ref().clone(),
-                                                &Type::Int(64),
-                                                false,
-                                                ns,
-                                                &mut Vec::new(),
-                                            )
-                                            .unwrap(),
-                                        ),
-                                        Box::new(
-                                            cast(
-                                                loc,
-                                                right.as_ref().clone(),
-                                                &Type::Int(64),
-                                                false,
-                                                ns,
-                                                &mut Vec::new(),
-                                            )
-                                            .unwrap(),
-                                        ),
+                                        Box::new(left.as_ref().clone().cast(&Type::Int(64), ns)),
+                                        Box::new(right.as_ref().clone().cast(&Type::Int(64), ns)),
                                     )),
                                 );
                             }
@@ -308,28 +288,8 @@ fn expression_reduce(expr: &Expression, vars: &Variables, ns: &mut Namespace) ->
                                     *loc,
                                     Type::Uint(64),
                                     *unchecked,
-                                    Box::new(
-                                        cast(
-                                            loc,
-                                            left.as_ref().clone(),
-                                            &Type::Uint(64),
-                                            false,
-                                            ns,
-                                            &mut Vec::new(),
-                                        )
-                                        .unwrap(),
-                                    ),
-                                    Box::new(
-                                        cast(
-                                            loc,
-                                            right.as_ref().clone(),
-                                            &Type::Uint(64),
-                                            false,
-                                            ns,
-                                            &mut Vec::new(),
-                                        )
-                                        .unwrap(),
-                                    ),
+                                    Box::new(left.as_ref().clone().cast(&Type::Uint(64), ns)),
+                                    Box::new(right.as_ref().clone().cast(&Type::Uint(64), ns)),
                                 )),
                             );
                         }
@@ -395,28 +355,8 @@ fn expression_reduce(expr: &Expression, vars: &Variables, ns: &mut Namespace) ->
                                     Box::new(Expression::Divide(
                                         *loc,
                                         Type::Int(64),
-                                        Box::new(
-                                            cast(
-                                                loc,
-                                                left.as_ref().clone(),
-                                                &Type::Int(64),
-                                                false,
-                                                ns,
-                                                &mut Vec::new(),
-                                            )
-                                            .unwrap(),
-                                        ),
-                                        Box::new(
-                                            cast(
-                                                loc,
-                                                right.as_ref().clone(),
-                                                &Type::Int(64),
-                                                false,
-                                                ns,
-                                                &mut Vec::new(),
-                                            )
-                                            .unwrap(),
-                                        ),
+                                        Box::new(left.as_ref().clone().cast(&Type::Int(64), ns)),
+                                        Box::new(right.as_ref().clone().cast(&Type::Int(64), ns)),
                                     )),
                                 );
                             }
@@ -438,28 +378,8 @@ fn expression_reduce(expr: &Expression, vars: &Variables, ns: &mut Namespace) ->
                                 Box::new(Expression::Divide(
                                     *loc,
                                     Type::Uint(64),
-                                    Box::new(
-                                        cast(
-                                            loc,
-                                            left.as_ref().clone(),
-                                            &Type::Uint(64),
-                                            false,
-                                            ns,
-                                            &mut Vec::new(),
-                                        )
-                                        .unwrap(),
-                                    ),
-                                    Box::new(
-                                        cast(
-                                            loc,
-                                            right.as_ref().clone(),
-                                            &Type::Uint(64),
-                                            false,
-                                            ns,
-                                            &mut Vec::new(),
-                                        )
-                                        .unwrap(),
-                                    ),
+                                    Box::new(left.as_ref().clone().cast(&Type::Uint(64), ns)),
+                                    Box::new(right.as_ref().clone().cast(&Type::Uint(64), ns)),
                                 )),
                             );
                         }
@@ -523,28 +443,8 @@ fn expression_reduce(expr: &Expression, vars: &Variables, ns: &mut Namespace) ->
                                     Box::new(Expression::Modulo(
                                         *loc,
                                         Type::Int(64),
-                                        Box::new(
-                                            cast(
-                                                loc,
-                                                left.as_ref().clone(),
-                                                &Type::Int(64),
-                                                false,
-                                                ns,
-                                                &mut Vec::new(),
-                                            )
-                                            .unwrap(),
-                                        ),
-                                        Box::new(
-                                            cast(
-                                                loc,
-                                                right.as_ref().clone(),
-                                                &Type::Int(64),
-                                                false,
-                                                ns,
-                                                &mut Vec::new(),
-                                            )
-                                            .unwrap(),
-                                        ),
+                                        Box::new(left.as_ref().clone().cast(&Type::Int(64), ns)),
+                                        Box::new(right.as_ref().clone().cast(&Type::Int(64), ns)),
                                     )),
                                 );
                             }
@@ -566,28 +466,8 @@ fn expression_reduce(expr: &Expression, vars: &Variables, ns: &mut Namespace) ->
                                 Box::new(Expression::Modulo(
                                     *loc,
                                     Type::Uint(64),
-                                    Box::new(
-                                        cast(
-                                            loc,
-                                            left.as_ref().clone(),
-                                            &Type::Uint(64),
-                                            false,
-                                            ns,
-                                            &mut Vec::new(),
-                                        )
-                                        .unwrap(),
-                                    ),
-                                    Box::new(
-                                        cast(
-                                            loc,
-                                            right.as_ref().clone(),
-                                            &Type::Uint(64),
-                                            false,
-                                            ns,
-                                            &mut Vec::new(),
-                                        )
-                                        .unwrap(),
-                                    ),
+                                    Box::new(left.as_ref().clone().cast(&Type::Uint(64), ns)),
+                                    Box::new(right.as_ref().clone().cast(&Type::Uint(64), ns)),
                                 )),
                             );
                         }
@@ -1617,57 +1497,6 @@ fn expression_values(expr: &Expression, vars: &Variables, ns: &Namespace) -> Has
                 })
                 .collect()
         }
-        Expression::Or(_, left, right) => {
-            let left = expression_values(left, vars, ns);
-            let right = expression_values(right, vars, ns);
-
-            left.iter()
-                .cartesian_product(right.iter())
-                .map(|(l, r)| {
-                    let mut known_bits = BitArray::new([0u8; 32]);
-                    let mut value = BitArray::new([0u8; 32]);
-
-                    if l.known_bits[0] && r.known_bits[0] {
-                        known_bits.set(0, true);
-                        value.set(0, l.value[0] || r.value[0]);
-                    } else if (l.known_bits[0] && l.value[0]) || (r.known_bits[0] && r.value[0]) {
-                        known_bits.set(0, true);
-                        value.set(0, true);
-                    }
-
-                    Value {
-                        value,
-                        known_bits,
-                        bits: 1,
-                    }
-                })
-                .collect()
-        }
-        Expression::And(_, left, right) => {
-            let left = expression_values(left, vars, ns);
-            let right = expression_values(right, vars, ns);
-
-            left.iter()
-                .cartesian_product(right.iter())
-                .map(|(l, r)| {
-                    let mut known_bits = BitArray::new([0u8; 32]);
-                    let mut value = BitArray::new([0u8; 32]);
-
-                    if l.known_bits[0] && r.known_bits[0] {
-                        known_bits.set(0, true);
-                        value.set(0, l.value[0] && r.value[0]);
-                    } else if (l.known_bits[0] && !l.value[0]) || (r.known_bits[0] && !r.value[0]) {
-                        known_bits.set(0, true);
-                    }
-
-                    Value {
-                        value,
-                        known_bits,
-                        bits: 1,
-                    }
-                })
-                .collect()
-        }
         Expression::Complement(_, _, expr) => {
             let vals = expression_values(expr, vars, ns);
 
@@ -2628,78 +2457,4 @@ fn expresson_known_bits() {
 
     assert!(v.known_bits[0]);
     assert!(v.value[0]);
-
-    /////////////
-    // test: or
-    /////////////
-    let vars = HashMap::new();
-
-    // true or unknown => true
-    let res = expression_values(
-        &Expression::Or(
-            loc,
-            Box::new(Expression::BoolLiteral(loc, true)),
-            Box::new(Expression::FunctionArg(loc, Type::Bool, 0)),
-        ),
-        &vars,
-        &ns,
-    );
-
-    assert_eq!(res.len(), 1);
-    let v = res.iter().next().unwrap();
-
-    assert!(v.known_bits[0]);
-    assert!(v.value[0]);
-
-    // false or unknown => unknown
-    let res = expression_values(
-        &Expression::Or(
-            loc,
-            Box::new(Expression::BoolLiteral(loc, false)),
-            Box::new(Expression::FunctionArg(loc, Type::Bool, 0)),
-        ),
-        &vars,
-        &ns,
-    );
-
-    assert_eq!(res.len(), 1);
-    let v = res.iter().next().unwrap();
-
-    assert!(!v.known_bits[0]);
-
-    /////////////
-    // test: and
-    /////////////
-    let vars = HashMap::new();
-
-    // true and unknown => unknown
-    let res = expression_values(
-        &Expression::And(
-            loc,
-            Box::new(Expression::BoolLiteral(loc, true)),
-            Box::new(Expression::FunctionArg(loc, Type::Bool, 0)),
-        ),
-        &vars,
-        &ns,
-    );
-
-    assert_eq!(res.len(), 1);
-    let v = res.iter().next().unwrap();
-    assert!(!v.known_bits[0]);
-
-    // false and unknown => false
-    let res = expression_values(
-        &Expression::And(
-            loc,
-            Box::new(Expression::BoolLiteral(loc, false)),
-            Box::new(Expression::FunctionArg(loc, Type::Bool, 0)),
-        ),
-        &vars,
-        &ns,
-    );
-
-    assert_eq!(res.len(), 1);
-    let v = res.iter().next().unwrap();
-    assert!(v.known_bits[0]);
-    assert!(!v.value[0]);
 }

--- a/src/codegen/subexpression_elimination/available_expression.rs
+++ b/src/codegen/subexpression_elimination/available_expression.rs
@@ -2,7 +2,7 @@ use crate::codegen::subexpression_elimination::{
     AvailableExpression, AvailableExpressionSet, AvailableVariable, BasicExpression,
     ExpressionType, NodeId,
 };
-use crate::sema::ast::Expression;
+use crate::codegen::Expression;
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/codegen/subexpression_elimination/available_expression_set.rs
+++ b/src/codegen/subexpression_elimination/available_expression_set.rs
@@ -4,7 +4,8 @@ use crate::codegen::subexpression_elimination::AvailableExpression;
 use crate::codegen::subexpression_elimination::{
     AvailableExpressionSet, BasicExpression, ExpressionType, NodeId,
 };
-use crate::sema::ast::{Expression, StringLocation};
+use crate::codegen::Expression;
+use crate::sema::ast::StringLocation;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -193,8 +194,8 @@ impl AvailableExpressionSet {
                 return Some(ave.add_variable_node(exp, self));
             }
 
-            Expression::ConstantVariable(..)
-            | Expression::NumberLiteral(..)
+            //Expression::ConstantVariable(..)
+            Expression::NumberLiteral(..)
             | Expression::BoolLiteral(..)
             | Expression::BytesLiteral(..) => {
                 let key = exp.get_constant_expression_type();
@@ -304,8 +305,8 @@ impl AvailableExpressionSet {
                 return self.expr_map.get(&ExpressionType::Variable(*pos)).copied();
             }
 
-            Expression::ConstantVariable(..)
-            | Expression::NumberLiteral(..)
+            //Expression::ConstantVariable(..)
+            Expression::NumberLiteral(..)
             | Expression::BoolLiteral(..)
             | Expression::BytesLiteral(..) => {
                 let key = exp.get_constant_expression_type();
@@ -419,7 +420,7 @@ impl AvailableExpressionSet {
             // Variables, constants and literals will never be substituted
             Expression::FunctionArg(..)
             | Expression::Variable(..)
-            | Expression::ConstantVariable(..)
+            //| Expression::ConstantVariable(..)
             | Expression::NumberLiteral(..)
             | Expression::BoolLiteral(..)
             | Expression::BytesLiteral(..) => {

--- a/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
+++ b/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
@@ -1,11 +1,12 @@
 use crate::codegen::subexpression_elimination::{BasicExpression, ExpressionType};
 use crate::codegen::{
     vartable::{Storage, Variable},
-    ControlFlowGraph, Instr,
+    ControlFlowGraph, Expression, Instr,
 };
 use crate::parser::pt::OptionalCodeLocation;
 use crate::parser::pt::{Identifier, Loc};
-use crate::sema::ast::{Expression, Namespace, Type};
+use crate::sema::ast::RetrieveType;
+use crate::sema::ast::{Namespace, Type};
 use std::collections::HashMap;
 
 #[derive(Clone)]
@@ -45,8 +46,7 @@ impl CommonSubExpressionTracker {
             Expression::FunctionArg(..)
                 | Expression::Variable(..)
                 | Expression::BytesLiteral(..)
-                | Expression::NumberLiteral(..)
-                | Expression::ConstantVariable(..)
+                | Expression::NumberLiteral(..) //| Expression::ConstantVariable(..)
         ) {
             return;
         }

--- a/src/codegen/subexpression_elimination/expression.rs
+++ b/src/codegen/subexpression_elimination/expression.rs
@@ -1,5 +1,6 @@
 use crate::codegen::subexpression_elimination::{ConstantType, ExpressionType};
-use crate::sema::ast::{Expression, StringLocation};
+use crate::codegen::Expression;
+use crate::sema::ast::StringLocation;
 
 impl Expression {
     /// Rebuild a binary expression given the new left and right subexpressions
@@ -42,15 +43,6 @@ impl Expression {
                 Box::new(left.clone()),
                 Box::new(right.clone()),
             ),
-
-            Expression::Or(loc, ..) => {
-                Expression::Or(*loc, Box::new(left.clone()), Box::new(right.clone()))
-            }
-
-            Expression::And(loc, ..) => {
-                Expression::And(*loc, Box::new(left.clone()), Box::new(right.clone()))
-            }
-
             Expression::Equal(loc, ..) => {
                 Expression::Equal(*loc, Box::new(left.clone()), Box::new(right.clone()))
             }
@@ -206,8 +198,6 @@ impl Expression {
             | Expression::BitwiseOr(_, _, left, right)
             | Expression::BitwiseAnd(_, _, left, right)
             | Expression::BitwiseXor(_, _, left, right)
-            | Expression::Or(_, left, right)
-            | Expression::And(_, left, right)
             | Expression::Equal(_, left, right)
             | Expression::NotEqual(_, left, right) => Some((left, right)),
 
@@ -255,10 +245,6 @@ impl Expression {
             Expression::BoolLiteral(_, value) => ConstantType::Bool(*value),
             Expression::NumberLiteral(_, _, value) => ConstantType::Number(value.clone()),
             Expression::BytesLiteral(_, _, value) => ConstantType::Bytes(value.clone()),
-            Expression::ConstantVariable(_, _, contract_no, var_no) => {
-                ConstantType::ConstantVariable(*contract_no, *var_no)
-            }
-
             _ => unreachable!("Not a constant expression"),
         };
 

--- a/src/codegen/subexpression_elimination/instruction.rs
+++ b/src/codegen/subexpression_elimination/instruction.rs
@@ -2,7 +2,7 @@ use crate::codegen::cfg::Instr;
 use crate::codegen::subexpression_elimination::common_subexpression_tracker::CommonSubExpressionTracker;
 use crate::codegen::subexpression_elimination::AvailableExpression;
 use crate::codegen::subexpression_elimination::{AvailableExpressionSet, AvailableVariable};
-use crate::sema::ast::Expression;
+use crate::codegen::Expression;
 
 impl AvailableExpressionSet {
     /// Check if we can add the expressions of an instruction to the graph

--- a/src/codegen/subexpression_elimination/mod.rs
+++ b/src/codegen/subexpression_elimination/mod.rs
@@ -62,7 +62,6 @@ pub enum ConstantType {
     Bool(bool),
     Bytes(Vec<u8>),
     Number(BigInt),
-    ConstantVariable(Option<usize>, usize),
 }
 
 /// The type of expression that a node represents

--- a/src/codegen/subexpression_elimination/operator.rs
+++ b/src/codegen/subexpression_elimination/operator.rs
@@ -1,4 +1,4 @@
-use crate::sema::ast::Expression;
+use crate::codegen::Expression;
 
 /// This enum defines operator types for the graph
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
@@ -14,8 +14,6 @@ pub enum Operator {
     BitwiseXor,
     ShiftLeft,
     ShiftRight,
-    Or,
-    And,
     More,
     Less,
     MoreEqual,
@@ -50,8 +48,6 @@ impl Expression {
             Expression::BitwiseXor(..) => Operator::BitwiseXor,
             Expression::ShiftLeft(..) => Operator::ShiftLeft,
             Expression::ShiftRight(..) => Operator::ShiftRight,
-            Expression::Or(..) => Operator::Or,
-            Expression::And(..) => Operator::And,
             Expression::Not(..) => Operator::Not,
             Expression::ZeroExt(..) => Operator::ZeroExt,
             Expression::SignExt(..) => Operator::SignExt,

--- a/src/codegen/subexpression_elimination/tests.rs
+++ b/src/codegen/subexpression_elimination/tests.rs
@@ -3,8 +3,9 @@
 use crate::codegen::cfg::Instr;
 use crate::codegen::subexpression_elimination::common_subexpression_tracker::CommonSubExpressionTracker;
 use crate::codegen::subexpression_elimination::{AvailableExpression, AvailableExpressionSet};
+use crate::codegen::Expression;
 use crate::parser::pt::Loc;
-use crate::sema::ast::{Expression, StringLocation, Type};
+use crate::sema::ast::{StringLocation, Type};
 use num_bigint::{BigInt, Sign};
 
 #[test]
@@ -37,7 +38,8 @@ fn add_variable_function_arg() {
 
 #[test]
 fn add_constants() {
-    let var = Expression::ConstantVariable(Loc::Codegen, Type::Int(2), None, 1);
+    let var =
+        Expression::NumberLiteral(Loc::Codegen, Type::Int(2), BigInt::new(Sign::Plus, vec![3]));
     let num =
         Expression::NumberLiteral(Loc::Codegen, Type::Int(1), BigInt::new(Sign::Plus, vec![2]));
     let sub = Expression::Subtract(
@@ -62,9 +64,15 @@ fn add_constants() {
 
 #[test]
 fn add_commutative() {
-    let cte = Expression::BoolLiteral(Loc::Codegen, false);
-    let var = Expression::Variable(Loc::Codegen, Type::Bool, 3);
-    let expr = Expression::Or(Loc::Codegen, Box::new(cte.clone()), Box::new(var.clone()));
+    let cte = Expression::NumberLiteral(Loc::Codegen, Type::Int(32), BigInt::from(20));
+    let var = Expression::Variable(Loc::Codegen, Type::Int(32), 3);
+    let expr = Expression::Add(
+        Loc::Codegen,
+        Type::Int(32),
+        true,
+        Box::new(cte.clone()),
+        Box::new(var.clone()),
+    );
 
     let instr = Instr::ValueTransfer {
         success: None,
@@ -72,7 +80,13 @@ fn add_commutative() {
         value: expr.clone(),
     };
 
-    let expr_other = Expression::Or(Loc::Codegen, Box::new(var), Box::new(cte));
+    let expr_other = Expression::Add(
+        Loc::Codegen,
+        Type::Int(32),
+        true,
+        Box::new(var),
+        Box::new(cte),
+    );
 
     let mut ave = AvailableExpression::default();
     let mut set = AvailableExpressionSet::default();
@@ -205,7 +219,7 @@ fn invalid() {
 #[test]
 fn complex_expression() {
     let var = Expression::Variable(Loc::Codegen, Type::Int(8), 2);
-    let cte = Expression::ConstantVariable(Loc::Codegen, Type::Int(8), Some(2), 3);
+    let cte = Expression::NumberLiteral(Loc::Codegen, Type::Int(8), BigInt::from(3));
     let arg = Expression::FunctionArg(Loc::Codegen, Type::Int(9), 5);
 
     let sum = Expression::Add(
@@ -343,7 +357,7 @@ fn string() {
 #[test]
 fn kill() {
     let var = Expression::Variable(Loc::Codegen, Type::Int(8), 2);
-    let cte = Expression::ConstantVariable(Loc::Codegen, Type::Int(8), Some(2), 3);
+    let cte = Expression::NumberLiteral(Loc::Codegen, Type::Int(8), BigInt::from(3));
     let arg = Expression::FunctionArg(Loc::Codegen, Type::Int(9), 5);
 
     let sum = Expression::Add(
@@ -432,7 +446,7 @@ fn kill() {
 #[test]
 fn clone() {
     let var = Expression::Variable(Loc::Codegen, Type::Int(8), 2);
-    let cte = Expression::ConstantVariable(Loc::Codegen, Type::Int(8), Some(2), 3);
+    let cte = Expression::NumberLiteral(Loc::Codegen, Type::Int(8), BigInt::from(3));
     let arg = Expression::FunctionArg(Loc::Codegen, Type::Int(9), 5);
 
     let sum = Expression::Add(
@@ -519,7 +533,7 @@ fn clone() {
 #[test]
 fn intersect() {
     let var = Expression::Variable(Loc::Codegen, Type::Int(8), 1);
-    let cte = Expression::ConstantVariable(Loc::Codegen, Type::Int(8), Some(2), 3);
+    let cte = Expression::NumberLiteral(Loc::Codegen, Type::Int(8), BigInt::from(3));
     let arg = Expression::FunctionArg(Loc::Codegen, Type::Int(9), 5);
 
     let sum = Expression::Add(

--- a/src/codegen/undefined_variable.rs
+++ b/src/codegen/undefined_variable.rs
@@ -1,8 +1,10 @@
 use crate::codegen::cfg::{ControlFlowGraph, Instr};
 use crate::codegen::reaching_definitions::{apply_transfers, VarDefs};
-use crate::parser::pt::{CodeLocation, Loc, StorageLocation};
-use crate::sema::ast::{Builtin, Diagnostic, ErrorType, Expression, Level, Namespace, Note};
+use crate::codegen::Expression;
+use crate::parser::pt::{Loc, StorageLocation};
+use crate::sema::ast::{Builtin, Diagnostic, ErrorType, Level, Namespace, Note};
 use crate::sema::symtable;
+use solang_parser::pt::CodeLocation;
 use std::collections::HashMap;
 
 /// We use this struct in expression.recurse function to provide all the

--- a/src/codegen/vector_to_slice.rs
+++ b/src/codegen/vector_to_slice.rs
@@ -1,7 +1,8 @@
 use super::cfg::{BasicBlock, ControlFlowGraph, Instr};
 use super::reaching_definitions::{Def, Transfer};
 use crate::codegen::cfg::ASTFunction;
-use crate::sema::ast::{Expression, Namespace, Type};
+use crate::codegen::Expression;
+use crate::sema::ast::{Namespace, Type};
 use indexmap::IndexMap;
 use std::collections::HashSet;
 

--- a/src/emit/ewasm.rs
+++ b/src/emit/ewasm.rs
@@ -1,3 +1,4 @@
+use crate::codegen;
 use crate::codegen::cfg::HashTy;
 use crate::parser::pt;
 use crate::sema::ast;
@@ -1850,7 +1851,7 @@ impl<'a> TargetRuntime<'a> for EwasmTarget {
     fn builtin<'b>(
         &self,
         binary: &Binary<'b>,
-        expr: &ast::Expression,
+        expr: &codegen::Expression,
         vartab: &HashMap<usize, Variable<'b>>,
         function: FunctionValue<'b>,
         ns: &ast::Namespace,
@@ -1911,37 +1912,37 @@ impl<'a> TargetRuntime<'a> for EwasmTarget {
         }
 
         match expr {
-            ast::Expression::Builtin(_, _, ast::Builtin::BlockNumber, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::BlockNumber, _) => {
                 straight_call!("block_number", "getBlockNumber")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Gasleft, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Gasleft, _) => {
                 straight_call!("gas_left", "getGasLeft")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::GasLimit, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::GasLimit, _) => {
                 straight_call!("gas_limit", "getBlockGasLimit")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Timestamp, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Timestamp, _) => {
                 straight_call!("time_stamp", "getBlockTimestamp")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::BlockDifficulty, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::BlockDifficulty, _) => {
                 single_int_stack!("block_difficulty", "getBlockDifficulty", 256)
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Origin, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Origin, _) => {
                 single_address_stack!("origin", "getTxOrigin")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Sender, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Sender, _) => {
                 single_address_stack!("caller", "getCaller")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::BlockCoinbase, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::BlockCoinbase, _) => {
                 single_address_stack!("coinbase", "getBlockCoinbase")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Gasprice, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Gasprice, _) => {
                 single_int_stack!("gas_price", "getTxGasPrice", ns.value_length as u32 * 8)
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Value, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Value, _) => {
                 single_int_stack!("value", "getCallValue", ns.value_length as u32 * 8)
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Calldata, _) => binary
+            codegen::Expression::Builtin(_, _, ast::Builtin::Calldata, _) => binary
                 .builder
                 .build_call(
                     binary.module.get_function("vector_new").unwrap(),
@@ -1961,7 +1962,7 @@ impl<'a> TargetRuntime<'a> for EwasmTarget {
                 .try_as_basic_value()
                 .left()
                 .unwrap(),
-            ast::Expression::Builtin(_, _, ast::Builtin::BlockHash, args) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::BlockHash, args) => {
                 let block_number = self.expression(binary, &args[0], vartab, function, ns);
 
                 let value = binary
@@ -1986,7 +1987,7 @@ impl<'a> TargetRuntime<'a> for EwasmTarget {
 
                 binary.builder.build_load(value, "block_hash")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::GetAddress, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::GetAddress, _) => {
                 let value = binary
                     .builder
                     .build_alloca(binary.address_type(ns), "self_address");
@@ -2006,7 +2007,7 @@ impl<'a> TargetRuntime<'a> for EwasmTarget {
 
                 binary.builder.build_load(value, "self_address")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Balance, addr) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Balance, addr) => {
                 let addr = self
                     .expression(binary, &addr[0], vartab, function, ns)
                     .into_array_value();

--- a/src/emit/solana.rs
+++ b/src/emit/solana.rs
@@ -1,7 +1,7 @@
 use crate::codegen::cfg::HashTy;
 use crate::parser::pt;
 use crate::sema::ast;
-use crate::Target;
+use crate::{codegen, Target};
 use std::collections::HashMap;
 use std::str;
 
@@ -3322,13 +3322,13 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     fn builtin<'b>(
         &self,
         binary: &Binary<'b>,
-        expr: &ast::Expression,
+        expr: &codegen::Expression,
         vartab: &HashMap<usize, Variable<'b>>,
         function: FunctionValue<'b>,
         ns: &ast::Namespace,
     ) -> BasicValueEnum<'b> {
         match expr {
-            ast::Expression::Builtin(_, _, ast::Builtin::Timestamp, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Timestamp, _) => {
                 let parameters = self.sol_parameters(binary);
 
                 let sol_clock = binary.module.get_function("sol_clock").unwrap();
@@ -3354,7 +3354,12 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
                 binary.builder.build_load(timestamp, "timestamp")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::BlockNumber | ast::Builtin::Slot, _) => {
+            codegen::Expression::Builtin(
+                _,
+                _,
+                ast::Builtin::BlockNumber | ast::Builtin::Slot,
+                _,
+            ) => {
                 let parameters = self.sol_parameters(binary);
 
                 let sol_clock = binary.module.get_function("sol_clock").unwrap();
@@ -3377,7 +3382,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
                 binary.builder.build_load(slot, "timestamp")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Sender, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Sender, _) => {
                 let parameters = self.sol_parameters(binary);
 
                 let sender = binary
@@ -3399,10 +3404,10 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
                 binary.builder.build_load(sender_address, "sender_address")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Value, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Value, _) => {
                 self.value_transferred(binary, ns).into()
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::GetAddress, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::GetAddress, _) => {
                 let parameters = self.sol_parameters(binary);
 
                 let account_id = binary
@@ -3424,7 +3429,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
                 binary.builder.build_load(value, "self_address")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Calldata, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Calldata, _) => {
                 let sol_params = self.sol_parameters(binary);
 
                 let input = binary
@@ -3470,7 +3475,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .left()
                     .unwrap()
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Signature, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Signature, _) => {
                 let sol_params = self.sol_parameters(binary);
 
                 let input = binary
@@ -3502,7 +3507,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .left()
                     .unwrap()
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::SignatureVerify, args) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::SignatureVerify, args) => {
                 assert_eq!(args.len(), 3);
 
                 let address = binary.build_alloca(function, binary.address_type(ns), "address");
@@ -3564,7 +3569,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     )
                     .into()
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Balance, args) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Balance, args) => {
                 assert_eq!(args.len(), 1);
 
                 let address = binary.build_alloca(function, binary.address_type(ns), "address");
@@ -3604,7 +3609,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
                 binary.builder.build_load(lamport, "lamport")
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::Accounts, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::Accounts, _) => {
                 let parameters = self.sol_parameters(binary);
 
                 unsafe {
@@ -3620,7 +3625,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 }
                 .into()
             }
-            ast::Expression::Builtin(_, _, ast::Builtin::ArrayLength, _) => {
+            codegen::Expression::Builtin(_, _, ast::Builtin::ArrayLength, _) => {
                 let parameters = self.sol_parameters(binary);
 
                 let ka_num = binary
@@ -3635,7 +3640,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .build_int_truncate(ka_num, binary.context.i32_type(), "ka_num_32bits")
                     .into()
             }
-            ast::Expression::StructMember(_, _, a, member) => {
+            codegen::Expression::StructMember(_, _, a, member) => {
                 let account_info = self
                     .expression(binary, a, vartab, function, ns)
                     .into_pointer_value();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 pub mod abi;
 pub mod codegen;
 #[cfg(feature = "llvm")]

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -1195,21 +1195,12 @@ impl Dot {
                     self.add_expression(expr, func, ns, node, format!("entry #{}", no));
                 }
             }
-
-            Expression::InternalFunctionCfg(..)
-            | Expression::ReturnData(..)
-            | Expression::Poison
-            | Expression::AbiEncode { .. }
-            | Expression::Undefined(..)
-            | Expression::Keccak256(..) => {
-                panic!("should not present in ast");
-            }
         }
     }
 
     fn add_string_location(
         &mut self,
-        loc: &StringLocation,
+        loc: &StringLocation<Expression>,
         func: Option<&Function>,
         ns: &Namespace,
         parent: usize,

--- a/src/sema/format.rs
+++ b/src/sema/format.rs
@@ -1,8 +1,9 @@
 use super::ast::{Diagnostic, Expression, FormatArg, Namespace, Type};
-use super::expression::{cast, expression, ExprContext, ResolveTo};
+use super::expression::{expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
 use crate::parser::pt;
 use crate::parser::pt::CodeLocation;
+use crate::sema::ast::RetrieveType;
 
 use std::iter::Peekable;
 use std::slice::Iter;
@@ -29,7 +30,10 @@ pub fn string_format(
 
         let ty = expr.ty();
 
-        resolved_args.push(cast(&arg.loc(), expr, ty.deref_any(), true, ns, diagnostics).unwrap());
+        resolved_args.push(
+            expr.cast(&arg.loc(), ty.deref_any(), true, ns, diagnostics)
+                .unwrap(),
+        );
     }
 
     let mut format_iterator = FormatIterator::new(literals).peekable();

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -1,4 +1,5 @@
 use crate::parser::{parse, pt};
+use crate::sema::ast::RetrieveType;
 use crate::Target;
 use ast::{Diagnostic, Mutability};
 use num_bigint::BigInt;
@@ -1590,4 +1591,10 @@ impl ast::Symbol {
             _ => false,
         }
     }
+}
+
+pub trait Recurse {
+    type ArgType;
+    /// recurse over a structure
+    fn recurse<T>(&self, cx: &mut T, f: fn(expr: &Self::ArgType, ctx: &mut T) -> bool);
 }

--- a/src/sema/mutability.rs
+++ b/src/sema/mutability.rs
@@ -4,7 +4,9 @@ use super::ast::{
 };
 use super::diagnostics;
 use crate::parser::pt;
+use crate::sema::ast::RetrieveType;
 use crate::sema::yul::ast::{YulExpression, YulStatement};
+use crate::sema::Recurse;
 
 /// check state mutability
 pub fn mutability(file_no: usize, ns: &mut Namespace) {

--- a/src/sema/tests/mod.rs
+++ b/src/sema/tests/mod.rs
@@ -24,7 +24,7 @@ fn test_statement_reachable() {
     let test_cases: Vec<(Statement, bool)> = vec![
         (Statement::Underscore(loc), true),
         (
-            Statement::Destructure(loc, vec![], Expression::Undefined(Type::Bool)),
+            Statement::Destructure(loc, vec![], Expression::BoolLiteral(loc, true)),
             true,
         ),
         (
@@ -53,7 +53,7 @@ fn test_statement_reachable() {
             true,
         ),
         (
-            Statement::Delete(loc, Type::Bool, Expression::Undefined(Type::Bool)),
+            Statement::Delete(loc, Type::Bool, Expression::BoolLiteral(loc, true)),
             true,
         ),
         (Statement::Continue(loc), false),
@@ -63,22 +63,22 @@ fn test_statement_reachable() {
             Statement::If(
                 loc,
                 false,
-                Expression::Undefined(Type::Bool),
+                Expression::BoolLiteral(loc, false),
                 vec![],
                 vec![],
             ),
             false,
         ),
         (
-            Statement::While(loc, true, Expression::Undefined(Type::Bool), vec![]),
+            Statement::While(loc, true, Expression::BoolLiteral(loc, false), vec![]),
             true,
         ),
         (
-            Statement::DoWhile(loc, false, vec![], Expression::Undefined(Type::Bool)),
+            Statement::DoWhile(loc, false, vec![], Expression::BoolLiteral(loc, true)),
             false,
         ),
         (
-            Statement::Expression(loc, true, Expression::Undefined(Type::Bool)),
+            Statement::Expression(loc, true, Expression::BoolLiteral(loc, false)),
             true,
         ),
         (
@@ -97,7 +97,7 @@ fn test_statement_reachable() {
                 loc,
                 true,
                 TryCatch {
-                    expr: Expression::Poison,
+                    expr: Expression::BoolLiteral(loc, false),
                     returns: vec![],
                     ok_stmt: vec![],
                     errors: vec![],

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -2,7 +2,7 @@ use super::ast::{
     BuiltinStruct, Diagnostic, Expression, Function, Namespace, Parameter, Statement, Symbol, Type,
     Variable,
 };
-use super::expression::{cast, expression, ExprContext, ResolveTo};
+use super::expression::{expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
 use super::tags::resolve_tags;
 use crate::parser::pt;
@@ -259,7 +259,7 @@ pub fn var_decl(
         ) {
             Ok(res) => {
                 // implicitly conversion to correct ty
-                match cast(&s.loc, res, &ty, true, ns, &mut diagnostics) {
+                match res.cast(&s.loc, &ty, true, ns, &mut diagnostics) {
                     Ok(res) => Some(res),
                     Err(_) => {
                         ns.diagnostics.extend(diagnostics);

--- a/src/sema/yul/ast.rs
+++ b/src/sema/yul/ast.rs
@@ -1,6 +1,7 @@
 use crate::ast::{Parameter, Type};
 use crate::sema::symtable::Symtable;
 use crate::sema::yul::builtin::YulBuiltInFunction;
+use crate::sema::Recurse;
 use num_bigint::BigInt;
 use solang_parser::pt;
 use solang_parser::pt::{CodeLocation, StorageLocation};
@@ -124,9 +125,9 @@ pub struct CaseBlock {
     pub block: YulBlock,
 }
 
-impl YulExpression {
-    /// Recurse over the expressions
-    pub fn recurse<T>(&self, cx: &mut T, f: fn(expr: &YulExpression, ctx: &mut T) -> bool) {
+impl Recurse for YulExpression {
+    type ArgType = YulExpression;
+    fn recurse<T>(&self, cx: &mut T, f: fn(expr: &YulExpression, ctx: &mut T) -> bool) {
         if !f(self, cx) {
             return;
         }


### PR DESCRIPTION
This PR refactor code generation. The main addition was the `codegen::Expression`. This means we no longer depend on `ast::Expression` to build the CFG. I've managed to improve some other stuff:

1. Now, we have a `cast` function for codegen. 
2. Sema's `cast` function is now a method of `ast::Expression`.
3. I created traits for common functions to facilitate implementing methods with generic arguments.
4. I removed from the AST expressions that do not belong there, except `FunctionArg`, to which I couldn't find an easy solution.
5. Some AST expressions do not exist is the CFG, so I removed references to them in codegen.
6. As we are branching at every AND and OR expression, they do not exist in `codegen::Expression`. However, I left some block comments containing the code to handle those cases, in case we add them in nearby future.

PS: This PR modifies 56 files, so please, @seanyoung, be pedantic!