### PR TITLE
feat: support projections in revert statement

### DIFF
--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -626,7 +626,7 @@ pub enum Statement {
     Continue(Loc),
     Break(Loc),
     Return(Loc, Option<Expression>),
-    Revert(Loc, Option<Identifier>, Vec<Expression>),
+    Revert(Loc, Vec<Identifier>, Vec<Expression>),
     Emit(Loc, Expression),
     Try(
         Loc,

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -125,7 +125,7 @@ IdentifierProject: Vec<Identifier> = {
     => vec![],
     <i:SolIdentifier> <v:("." SolIdentifier)*> => {
             let mut i = vec![i];
-            i.extend(v);
+            i.extend(v.into_iter().map(|(_, id)|id));
             i
     }
 }

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -121,6 +121,15 @@ StorageLocation: StorageLocation = {
     <l:@L> "calldata" <r:@R> => StorageLocation::Calldata(Loc::File(file_no, l, r)),
 }
 
+IdentifierProject: Vec<Identifier> = {
+    <i:SolIdentifier?> => vec![],
+    <i:SolIdentifier> <v:("." SolIdentifier)*> => {
+            let mut i = vec![i];
+            i.extend(v);
+            i
+  }
+}
+
 Identifier: Identifier = {
     <l:@L> <n:identifier> <r:@R> => Identifier{loc: Loc::File(file_no, l, r), name: n.to_string()}
 }
@@ -783,8 +792,9 @@ NonIfStatement: Statement = {
     <l:@L> "emit" <ty:FunctionCall> <r:@R> ";" => {
         Statement::Emit(Loc::File(file_no, l, r), ty)
     },
-    <l:@L> "revert" <error:SolIdentifier?> "(" <v:Comma<Expression>> ")" <r:@R> ";" => {
-        Statement::Revert(Loc::File(file_no, l, r), error, v)
+    // here
+    <l:@L> "revert" <i:IdentifierProject> "(" <v:Comma<Expression>> ")" <r:@R> ";" => {
+        Statement::Revert(Loc::File(file_no, l, r), i, v)
     },
 }
 

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -122,12 +122,12 @@ StorageLocation: StorageLocation = {
 }
 
 IdentifierProject: Vec<Identifier> = {
-    <i:SolIdentifier?> => vec![],
+    => vec![],
     <i:SolIdentifier> <v:("." SolIdentifier)*> => {
             let mut i = vec![i];
             i.extend(v);
             i
-  }
+    }
 }
 
 Identifier: Identifier = {

--- a/solang-parser/src/test.rs
+++ b/solang-parser/src/test.rs
@@ -1080,10 +1080,10 @@ fn parse_revert_test() {
                         unchecked: false,
                         statements: vec![Statement::Revert(
                             Loc::File(0, 107, 125),
-                            Some(Identifier {
+                            Some(Expression::Variable(Identifier {
                                 loc: Loc::File(0, 114, 123),
                                 name: "BAR_ERROR".to_string(),
-                            }),
+                            })),
                             vec![],
                         )],
                     }),
@@ -1093,4 +1093,24 @@ fn parse_revert_test() {
     ))]);
 
     assert_eq!(actual_parse_tree, expected_parse_tree);
+}
+
+#[test]
+fn parse_various_reverts() {
+    let src = r#"
+    contract ECDSA {
+        function doRevert() internal pure {
+             revert ('meh');
+        }
+        function doRevert2() internal pure {
+             revert IDCAHub.InvalidTokens();
+        }
+        function doRevert3() internal pure {
+             revert InvalidTokens();
+        }
+    }
+        "#;
+
+    let (actual_parse_tree, _) = crate::parse(src, 0).unwrap();
+    assert_eq!(actual_parse_tree.0.len(), 1);
 }

--- a/solang-parser/src/test.rs
+++ b/solang-parser/src/test.rs
@@ -257,7 +257,7 @@ fn parse_test() {
                                 unchecked: false,
                                 statements: vec![Statement::Revert(
                                     Loc::File(0, 905, 918),
-                                    None,
+                                    vec![],
                                     vec![Expression::StringLiteral(vec![StringLiteral {
                                         loc: Loc::File(0, 912, 917),
                                         string: "meh".to_string(),
@@ -285,7 +285,7 @@ fn parse_test() {
                                 unchecked: false,
                                 statements: vec![Statement::Revert(
                                     Loc::File(0, 1001, 1014),
-                                    None,
+                                    vec![],
                                     vec![Expression::Variable(Identifier {
                                         loc: Loc::File(0, 1008, 1013),
                                         name: "error".to_string(),
@@ -313,7 +313,7 @@ fn parse_test() {
                                 unchecked: false,
                                 statements: vec![Statement::Revert(
                                     Loc::File(0, 1084, 1097),
-                                    None,
+                                    vec![],
                                     vec![Expression::StringLiteral(vec![StringLiteral {
                                         loc: Loc::File(0, 1091, 1096),
                                         string: "feh".to_string(),
@@ -1080,10 +1080,10 @@ fn parse_revert_test() {
                         unchecked: false,
                         statements: vec![Statement::Revert(
                             Loc::File(0, 107, 125),
-                            Some(Expression::Variable(Identifier {
+                            vec![Identifier {
                                 loc: Loc::File(0, 114, 123),
                                 name: "BAR_ERROR".to_string(),
-                            })),
+                            }],
                             vec![],
                         )],
                     }),

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -4020,11 +4020,6 @@ pub trait TargetRuntime<'a> {
                             .map(|p| self.expression(bin, p, &w.vars, function, ns).into())
                             .collect::<Vec<BasicMetadataValueEnum>>();
 
-                        // on Solana, we need to pass the accounts parameter around
-                        if let Some(parameters) = bin.parameters {
-                            parms.push(parameters.into());
-                        }
-
                         if !res.is_empty() {
                             for ty in returns.iter() {
                                 parms.push(
@@ -4032,6 +4027,11 @@ pub trait TargetRuntime<'a> {
                                         .into(),
                                 );
                             }
+                        }
+
+                        // on Solana, we need to pass the accounts parameter around
+                        if let Some(parameters) = bin.parameters {
+                            parms.push(parameters.into());
                         }
 
                         let callable = CallableValue::try_from(
@@ -4050,7 +4050,7 @@ pub trait TargetRuntime<'a> {
                         let success = bin.builder.build_int_compare(
                             IntPredicate::EQ,
                             ret.into_int_value(),
-                            bin.context.i32_type().const_zero(),
+                            bin.return_values[&ReturnCode::Success],
                             "success",
                         );
 

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -818,12 +818,16 @@ fn statement(
             Ok(resolved_asm.1)
         }
         pt::Statement::Revert(loc, error, args) => {
-            if let Some(error) = error {
+            if !error.is_empty() {
                 ns.diagnostics.push(Diagnostic::error(
-                    error.loc,
+                    error[0].loc,
                     format!(
                         "revert with custom error ‘{}’ not supported yet",
-                        error.name
+                        error
+                            .iter()
+                            .map(|err| err.to_string())
+                            .collect::<Vec<_>>()
+                            .join(".")
                     ),
                 ));
                 return Err(());


### PR DESCRIPTION
I tried to fix this but I believe Hit some lalrpop issues, so this won't build I'm afraid. 
But not sure what the proper fix for this would be, so I'd need some help


Background

this is a valid revert:

```solidity
        function doRevert2() internal pure {
             revert LibName.ErrorName();
        }
```

if an error is defined inside a library `LibName` 

the solidity grammar states the revert stmt is `"revert" + expr + call-arg-list`
But I think only this is valid (Id)? ("." Id)*