### PR TITLE
Fix associativity of power

### DIFF
--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -352,7 +352,7 @@ Precedence4: Expression = {
 }
 
 Precedence3: Expression = {
-    <l:Precedence3> <a:@L> "**" <b:@R> <r:Precedence2> => Expression::Power(Loc::File(file_no, a, b), Box::new(l), Box::new(r)),
+    <l:Precedence2> <a:@L> "**" <b:@R> <r:Precedence3> => Expression::Power(Loc::File(file_no, a, b), Box::new(l), Box::new(r)),
     Precedence2,
 }
 

--- a/tests/contract_testcases/solana/power.dot
+++ b/tests/contract_testcases/solana/power.dot
@@ -1,0 +1,22 @@
+strict digraph "tests/contract_testcases/solana/power.sol" {
+	contract [label="contract AstExample\ntests/contract_testcases/solana/power.sol:2:1-3:21"]
+	node_3 [label="constructor \ncontract: AstExample\ntests/contract_testcases/solana/power.sol:4:5-19\nsignature ()\nvisibility public\nmutability nonpayable"]
+	expr [label="expression\ntests/contract_testcases/solana/power.sol:5:9-20"]
+	power [label="power\nuint256\ntests/contract_testcases/solana/power.sol:5:11-13"]
+	number_literal [label="uint256 literal: 1\ntests/contract_testcases/solana/power.sol:5:9-10"]
+	power_7 [label="power\nuint256\ntests/contract_testcases/solana/power.sol:5:16-18"]
+	number_literal_8 [label="uint256 literal: 2\ntests/contract_testcases/solana/power.sol:5:14-15"]
+	number_literal_9 [label="uint256 literal: 3\ntests/contract_testcases/solana/power.sol:5:19-20"]
+	diagnostic [label="pragma ‘solidity’ is ignored\nlevel Debug\ntests/contract_testcases/solana/power.sol:1:1-24"]
+	diagnostic_12 [label="found contract ‘AstExample’\nlevel Debug\ntests/contract_testcases/solana/power.sol:2:1-3:21"]
+	contracts -> contract
+	contract -> node_3 [label="constructor"]
+	node_3 -> expr [label="body"]
+	expr -> power [label="expr"]
+	power -> number_literal [label="left"]
+	power -> power_7 [label="right"]
+	power_7 -> number_literal_8 [label="left"]
+	power_7 -> number_literal_9 [label="right"]
+	diagnostics -> diagnostic [label="Debug"]
+	diagnostics -> diagnostic_12 [label="Debug"]
+}

--- a/tests/contract_testcases/solana/power.sol
+++ b/tests/contract_testcases/solana/power.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.10;
+
+contract AstExample {
+    constructor() {
+        1 ** 2 ** 3;
+    }
+}

--- a/tests/solana_tests/expressions.rs
+++ b/tests/solana_tests/expressions.rs
@@ -218,3 +218,24 @@ fn assignment_in_ternary() {
         );
     }
 }
+
+#[test]
+fn power() {
+    let mut vm = build_solidity(
+        r#"
+        contract foo {
+            function power() public returns (uint) {
+                return 2 ** 3 ** 4;
+            }
+        }"#,
+    );
+
+    vm.constructor("foo", &[], 0);
+
+    let returns = vm.function("power", &[], &[], 0, None);
+
+    assert_eq!(
+        returns,
+        vec![Token::Uint(U256::from(2417851639229258349412352u128))]
+    );
+}


### PR DESCRIPTION
1 ** 2 ** 3 should be parsed like 1 ** (2 ** 3), not (1 ** 2) ** 3.

See https://github.com/foundry-rs/foundry/issues/781#issuecomment-1112109532

Signed-off-by: Sean Young <sean@mess.org>