### PR TITLE
Only local function pointers should support suffixes

### DIFF
--- a/src/sema/yul/expression.rs
+++ b/src/sema/yul/expression.rs
@@ -533,9 +533,7 @@ fn resolve_member_access(
             return Err(());
         }
 
-        YulExpression::SolidityLocalVariable(_, Type::ExternalFunction { .. }, ..)
-        | YulExpression::ConstantVariable(_, Type::ExternalFunction { .. }, ..)
-        | YulExpression::StorageVariable(_, Type::ExternalFunction { .. }, ..) => {
+        YulExpression::SolidityLocalVariable(_, Type::ExternalFunction { .. }, ..) => {
             if id.name != "selector" && id.name != "address" {
                 ns.diagnostics.push(Diagnostic::error(
                     id.loc,


### PR DESCRIPTION
Function pointers saved as state variables should no support suffixes "address" and "selector". Only Solidity local variables of type external function pointer support them.