### PR TITLE
feat(parser): event on source unit level isn't allowed

### DIFF
--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -127,7 +127,6 @@ pub enum SourceUnitPart {
     ImportDirective(Vec<DocComment>, Import),
     EnumDefinition(Box<EnumDefinition>),
     StructDefinition(Box<StructDefinition>),
-    EventDefinition(Box<EventDefinition>),
     ErrorDefinition(Box<ErrorDefinition>),
     FunctionDefinition(Box<FunctionDefinition>),
     VariableDefinition(Box<VariableDefinition>),

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -22,7 +22,6 @@ SourceUnitPart: SourceUnitPart = {
     ImportDirective => <>,
     EnumDefinition => SourceUnitPart::EnumDefinition(<>),
     StructDefinition => SourceUnitPart::StructDefinition(<>),
-    EventDefinition => SourceUnitPart::EventDefinition(<>),
     ErrorDefinition => SourceUnitPart::ErrorDefinition(<>),
     FunctionDefinition => SourceUnitPart::FunctionDefinition(<>),
     VariableDefinition => SourceUnitPart::VariableDefinition(<>),

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -62,36 +62,6 @@ pub fn resolve_typenames<'a>(
                     delay.structs.push((pos, def, None));
                 }
             }
-            pt::SourceUnitPart::EventDefinition(def) => {
-                let pos = ns.events.len();
-
-                if let Some(Symbol::Event(events)) =
-                    ns.variable_symbols
-                        .get_mut(&(file_no, None, def.name.name.to_owned()))
-                {
-                    events.push((def.name.loc, pos));
-                } else if !ns.add_symbol(
-                    file_no,
-                    None,
-                    &def.name,
-                    Symbol::Event(vec![(def.name.loc, pos)]),
-                ) {
-                    continue;
-                }
-
-                ns.events.push(EventDecl {
-                    tags: Vec::new(),
-                    name: def.name.name.to_owned(),
-                    loc: def.name.loc,
-                    contract: None,
-                    fields: Vec::new(),
-                    anonymous: def.anonymous,
-                    signature: String::new(),
-                    used: false,
-                });
-
-                delay.events.push((pos, def, None));
-            }
             pt::SourceUnitPart::TypeDefinition(ty) => {
                 type_decl(ty, file_no, None, ns);
             }


### PR DESCRIPTION
It's not allowed to have an `EventDefinition` on source unit level according to the [doc]( https://docs.soliditylang.org/en/v0.8.13/grammar.html#a4.SolidityParser.sourceUnit) and `solc` output:
```bash
echo 'event A();' | solc -

Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
 --> <stdin>:1:1:
  |
1 | event A();
  | ^^^^^
```

@seanyoung I'm not sure it's the best to disallow it because of backward compatibility. We can add a diagnostic message instead. If you're ok with that change, I'll fix the tests.