### PR TITLE
Rust 1.59.0 is now required

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get clean
 RUN apt-get autoclean
 
 # Get Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.56.1
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.59.0
 
 COPY --from=builder /llvm13.0 /llvm13.0/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Add LLVM to Path
       run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
     - name: Rust stable
-      run: rustup default 1.56.1
+      run: rustup default 1.59.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -74,7 +74,7 @@ jobs:
     - name: Add LLVM to Path
       run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
     - name: Rust stable
-      run: rustup default 1.56.1
+      run: rustup default 1.59.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       # checkout@v2 requires git 2.18 or higher, which is not in our image
       uses: actions/checkout@v1
     - name: Rust stable
-      run: rustup default 1.56.1
+      run: rustup default 1.59.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -61,7 +61,7 @@ jobs:
       # checkout@v2 requires git 2.18 or higher, which is not in our image
       uses: actions/checkout@v1
     - name: Rust stable
-      run: rustup default 1.56.1
+      run: rustup default 1.59.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . src
 WORKDIR /src/stdlib/
 RUN make
 
-RUN rustup default 1.56.1
+RUN rustup default 1.59.0
 
 WORKDIR /src
 RUN cargo build --release

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -49,7 +49,7 @@ Then you can build the image using:
 Building Solang from source
 ---------------------------
 
-In order to build Solang from source, you will need rust 1.56.1 or higher,
+In order to build Solang from source, you will need rust 1.59.0 or higher,
 and a build of llvm based on the Solana llvm tree. There are a few patches which are not upstream yet.
 First, follow the steps below for installing llvm and then proceed from there.
 


### PR DESCRIPTION
solang uses tower-lsp, which depends on dashmap. The latest version of
dashmap requires rust 1.59.0.

dashmap uses `std::thread::available_parallelism()`.

Signed-off-by: Sean Young <sean@mess.org>