### PR TITLE
Add support for functions without parameters

### DIFF
--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -890,17 +890,13 @@ YulExpression: YulExpression = {
 }
 
 YulFunctionDefinition: YulStatement = {
-    <l:@L> "function" <name: YulIdentifier> "(" <params: YulTypedIdentifierList> ")" <returns:("->" <YulTypedIdentifierList>)?>
+    <l:@L> "function" <name: YulIdentifier> "(" <params: YulTypedIdentifierList?> ")" <returns:("->" <YulTypedIdentifierList>)?>
     <body: YulBlock> <r:@R> => {
-        let returns = match returns {
-            Some(content) => content,
-            None => vec![]
-        };
         YulStatement::FunctionDefinition(Box::new(YulFunctionDefinition{
             loc: Loc::File(file_no, l, r),
             id: name,
-            params,
-            returns,
+            params: params.unwrap_or_default(),
+            returns: returns.unwrap_or_default(),
             body
             }
           )

--- a/solang-parser/src/test.rs
+++ b/solang-parser/src/test.rs
@@ -1165,3 +1165,22 @@ fn parse_user_defined_value_type() {
 
     assert_eq!(actual_parse_tree, expected_parse_tree);
 }
+
+#[test]
+fn parse_no_parameters_yul_function() {
+    let src = r#"
+contract C {
+	function testing() pure public {
+		assembly {
+			function multiple() -> ret1, ret2 {
+				ret1 := 1
+				ret2 := 2
+			}
+		}
+	}
+}
+    "#;
+
+    let (actual_parse_tree, _) = crate::parse(src, 0).unwrap();
+    assert_eq!(actual_parse_tree.0.len(), 1);
+}


### PR DESCRIPTION
While working on code generation for Yul statements, I found that the parser did not support yul functions declared without parameters. This PR updates the parser to support this.