### PR TITLE
Add keccak hash for addresses

### DIFF
--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -760,6 +760,9 @@ fn expression(
                                             bs.insert(0, 0);
                                         }
                                     }
+                                    Type::Address(_) => {
+                                        bs.resize(ns.address_length, 0);
+                                    }
                                     _ => unreachable!(),
                                 }
 

--- a/tests/codegen_testcases/constant_folding.sol
+++ b/tests/codegen_testcases/constant_folding.sol
@@ -1,0 +1,10 @@
+// RUN: --target ewasm --emit cfg
+
+contract CodeWithJD {
+    mapping(address => uint256) balances;
+    // BEGIN-CHECK: CodeWithJD::CodeWithJD::function::totalSupply
+    function totalSupply() public view returns (uint256) {
+        // CHECK: load storage slot(hex"57644ed870b18b050a0801bb92210bbd4c1bff6200ff20e5e51ab4aae9546da8") ty:uint256
+        return balances[address(0x00)];
+    }
+}


### PR DESCRIPTION
The constant folding pass calculates the Keccak256 hash for number literals, however it was ignoring such calculation for literals of type address. This PR fixes this and solves issue #777.

When this PR is merged, we can also close issue #780 because the contract I posted there builds correctly after this fix.

PS: Contracts for ewasm does not fail after this fix, however the ewasm target still doesn't work, because the emit stage is no implement.