### PR TITLE
Don't run the linux-arm64 tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,8 @@ jobs:
   linux-arm:
     name: Linux Arm
     runs-on: linux-arm64
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    # Don't run linux-arm64 on pull requests, it takes 38 minutes and only has one runner
+    if: ${{ github.repository_owner == 'hyperledger-labs' && github.ref == 'refs/heads/main' }}
     container: ghcr.io/hyperledger-labs/solang:ci
     steps:
     - name: Checkout sources


### PR DESCRIPTION
These tests are run on a single traverse ten64, and this takes 38
minutes. This is too long is holding up PR merges and test completion.

Signed-off-by: Sean Young <sean@mess.org>