### PR TITLE
Fix parse location of FunctionCallBlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ assert_cmd = "2.0"
 bincode = "1.3"
 ed25519-dalek = "1.0"
 path-slash = "0.1"
+pretty_assertions = "1.2"
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -375,7 +375,7 @@ FunctionCall: Expression = {
     <a:@L> <i:FunctionCallPrecedence> "(" <v:Comma<Expression>> ")" <b:@R> => {
         Expression::FunctionCall(Loc::File(file_no, a, b), Box::new(i), v)
     },
-    <i:FunctionCallPrecedence> <l:@L> <block:BlockStatement> <r:@R> => {
+    <l:@L> <i:FunctionCallPrecedence> <block:BlockStatement> <r:@R> => {
         Expression::FunctionCallBlock(Loc::File(file_no, l, r), Box::new(i), Box::new(block))
     },
     <a:@L> <i:FunctionCallPrecedence> "(" "{" <v:Comma<NamedArgument>> "}" ")" <b:@R> => {

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -93,7 +93,7 @@ fn parse_file(path: PathBuf, target: Target) -> io::Result<()> {
     // The dot files may have had their end of lines mangled on Windows
     let test_dot = test_dot.replace("\r\n", "\n");
 
-    assert_eq!(generated_dot, test_dot);
+    pretty_assertions::assert_eq!(generated_dot, test_dot);
 
     Ok(())
 }

--- a/tests/contract_testcases/solana/call/call_args_three_ways.dot
+++ b/tests/contract_testcases/solana/call/call_args_three_ways.dot
@@ -5,7 +5,7 @@ strict digraph "tests/contract_testcases/solana/call/call_args_three_ways.sol" {
 	constructor [label="constructor contract D\ntests/contract_testcases/solana/call/call_args_three_ways.sol:4:9-28"]
 	number_literal [label="uint64 literal: 1\ntests/contract_testcases/solana/call/call_args_three_ways.sol:4:23-24"]
 	var_decl_7 [label="variable decl contract D dd\ntests/contract_testcases/solana/call/call_args_three_ways.sol:5:3-29"]
-	constructor_8 [label="constructor contract D\ntests/contract_testcases/solana/call/call_args_three_ways.sol:5:17-27"]
+	constructor_8 [label="constructor contract D\ntests/contract_testcases/solana/call/call_args_three_ways.sol:5:10-27"]
 	number_literal_9 [label="uint64 literal: 1\ntests/contract_testcases/solana/call/call_args_three_ways.sol:5:25-26"]
 	var_decl_10 [label="variable decl contract D ddd\ntests/contract_testcases/solana/call/call_args_three_ways.sol:6:3-28"]
 	constructor_11 [label="constructor contract D\ntests/contract_testcases/solana/call/call_args_three_ways.sol:6:11-28"]


### PR DESCRIPTION
`Expression::FunctionCallBlock` location does not surround entire
expression, and this fixes that by moving the location start to the
beggining of the expression. This also adds `pretty_assertions`
for easier debugging of dot files in tests