### PR TITLE
refactor(arguments): Replace -O command line option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Cargo.lock
 /target
 **/*.rs.bk
 
+#IntelliJ-like IDE configuration
+/.idea/

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -64,9 +64,15 @@ fn main() {
             Arg::new("OPT")
                 .help("Set llvm optimizer level")
                 .short('O')
+                .use_value_delimiter(false)
+                .long_help("\
+None = 0,      // -O0
+Less = 1,      // -O1
+Default = 2,   // -O2, -Os, -OS
+Aggressive = 3 // -O3")
                 .takes_value(true)
-                .possible_values(&["none", "less", "default", "aggressive"])
-                .default_value("default"),
+                .possible_values(&["0", "1", "2", "3", "s", "S"])
+                .default_value("2"),
         )
         .arg(
             Arg::new("TARGET")
@@ -301,10 +307,13 @@ fn main() {
         }
     } else {
         let opt_level = match matches.value_of("OPT").unwrap() {
-            "none" => OptimizationLevel::None,
-            "less" => OptimizationLevel::Less,
-            "default" => OptimizationLevel::Default,
-            "aggressive" => OptimizationLevel::Aggressive,
+            "0" => OptimizationLevel::None,
+            "1" => OptimizationLevel::Less,
+            "2" => OptimizationLevel::Default,
+            // According to https://llvm.org/doxygen/CodeGen_8h_source.html -O2 and -Os are default
+            "s" => OptimizationLevel::Default,
+            "S" => OptimizationLevel::Default,
+            "3" => OptimizationLevel::Aggressive,
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
Replace llvm-like -O command with gcc-like
optimization
commands
according
to
https://llvm.org/doxygen/CodeGen_8h_source.html

Limit the command
to
only one argument
(one type of optimization)

Add basic help for the
-O
command to improve usability

BREAKING CHANGE: Optimization command -O now takes GCC-like arguments
(0,1,2 or s and 3)

Closes #534