### PR TITLE
Yul documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,17 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
-    container: ubuntu:22.04
+    container: ubuntu:20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Install sphinx
+      - name: Install Python
         run: |
-          export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y python3-sphinx python3-sphinx-rtd-theme
+          apt-get install -y python3-pip
+      - name: Install Docs requiremets
+        run : |
+          pip install -r requirements.txt
       - name: Build docs
         run: make html
         working-directory: docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ will be documented here.
 
 ### Added
 - Added spl-token integration for Solana
+- Solang now generates code for inline assembly, including many Yul builtins
 
 ### Changed
 - The documentation has been re-arranged for readability.

--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Here is a brief description of what we envision for the next versions.
 
 ### V0.4
 
-| Milestone                         | Status       |
-|-----------------------------------|--------------|
-| Call Solidity from Rust           | Not started  |
-| Generate code for inline assembly | Not started  |
-| Improve management over optimization passes | Not Started  |
-| Dead code elimination | Not started  |
-| ewasm target | Not started  |
+| Milestone                         | Status      |
+|-----------------------------------|-------------|
+| Call Solidity from Rust           | Not started |
+| Generate code for inline assembly | Completed   |
+| Improve management over optimization passes | Not Started |
+| Dead code elimination | Not started |
+| ewasm target | Not started |
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,12 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import os
 
+from pygments_lexer_solidity import SolidityLexer, YulLexer
+
+def setup(sphinx):
+    sphinx.add_lexer('Solidity', SolidityLexer)
+    sphinx.add_lexer('Yul', YulLexer)
+
 # -- Project information -----------------------------------------------------
 
 project = 'Solang Solidity Compiler'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,17 @@ Contents
    language/managing_values.rst
    language/builtins.rst
    language/tags.rst
+   language/inline_assembly.rst
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Yul language
+
+   yul_language/yul.rst
+   yul_language/statements.rst
+   yul_language/types.rst
+   yul_language/functions.rst
+   yul_language/builtins.rst
 
 .. toctree::
    :maxdepth: 3

--- a/docs/language/inline_assembly.rst
+++ b/docs/language/inline_assembly.rst
@@ -1,0 +1,116 @@
+Inline Assembly
+===============
+
+In Solidity functions, developers are allowed to write assembly blocks containing Yul code. For more information about
+the Yul programming language, please refer to the :ref:`yul section <yul_section>`.
+
+In an assembly block, you can access solidity local variables freely and modify them as well. Bear in mind, however,
+that reference types like strings, vectors and structs are memory addresses in yul, so manipulating them can be unsafe
+unless done correctly. Any assignment to those variables will change the address the reference points to and
+may cause the program to crash if not managed correctly.
+
+.. code-block:: solidity
+
+    contract foo {
+        struct test_stru {
+            uint a;
+            uint b;
+        }
+
+        function bar(uint64 a) public pure returns (uint64 ret) {
+            uint64 b = 6;
+            uint64[] memory vec;
+            vec.push(4);
+            string str = "cafe";
+            test_stru tts = test_stru({a: 1, b: 2});
+            assembly {
+                // The following statements modify variables directly
+                a := add(a, 3)
+                b := mul(b, 2)
+                ret := sub(a, b)
+
+                // The following modify the reference address
+                str := 5
+                vec := 6
+                tts := 7
+            }
+
+            // Any access to 'str', 'vec' or 'tts' here may crash the program.
+        }
+
+    }
+
+
+Storage variables cannot be accessed nor assigned directly. You must use the ``.slot`` and ``.offset`` suffix to use storage
+variables. Storage variables should be read with the ``sload`` and saved with ``sstore`` builtins, but they are not implemented yet.
+Solang does not implement offsets for storage variables, so the ``.offset`` suffix will always return zero.
+Assignments to the offset are only allowed to Solidity local variables that are a reference to the storage.
+
+.. code-block:: solidity
+
+    contract foo {
+        struct test_stru {
+            uint a;
+            uint b;
+        }
+
+        test_stru storage_struct;
+        function bar() public pure {
+            test_stru storage tts = storage_struct;
+            assembly {
+                // The variables 'a' and 'b' contain zero
+                let a := storage_struct.offset
+                let b := tts.offset
+
+                // This changes the reference slot of 'tts'
+                tts.slot := 5
+            }
+        }
+    }
+
+
+
+Dynamic calldata arrays should be accessed with the ``.offset`` and ``.length`` suffixes. The offset suffix returns the
+array's memory address. Assignments to ``.length`` are not yet implemented.
+
+.. code-block:: solidity
+
+    contract foo {
+        function bar(int[] calldata vl) public pure {
+            test_stru storage tts = storage_struct;
+            assembly {
+                // 'a' contains vl memory address
+                let a := vl.offset
+
+                // 'b' contains vl length
+                let b := vl.length
+
+                // This will change the reference of vl
+                vl.offset := 5
+            }
+            // Any usage of vl here may crash the program
+        }
+    }
+
+
+External functions in Yul can be accessed and modified with the ``.selector`` and ``.address`` suffixes. The assignment
+to those values, however, are not yet implemented.
+
+.. code-block:: solidity
+
+    contract foo {
+        function sum(uint64 a, uint64 b) public pure returns (uint64) {
+            return a + b;
+        }
+
+        function bar() public view {
+            function (uint64, uint64) external returns (uint64) fPtr = this.sum;
+            assembly {
+                // 'a' contains 'sum' selector
+                let a := fPtr.selector
+
+                // 'b' contains 'sum' address
+                let b := vl.address
+            }
+        }
+    }

--- a/docs/yul_language/builtins.rst
+++ b/docs/yul_language/builtins.rst
@@ -1,0 +1,209 @@
+Builtins
+========
+
+Most operations in Yul are performed via builtin functions. Solang supports
+most builtins, however memory operations and chain operations are not implemented.
+Yul builtins are low level instructions and many are `ethereum specific <https://ethereum.org/en/developers/docs/evm/opcodes/>`_.
+On Solana and Substrate, some builtins, like ``delegatecall`` and ``staticcall``, for instance, are not available
+because the concept they implement does not exist in neither chains.
+
+.. warning::
+    In addition to nonexistent builtins, due to low-level differences between
+    blockchain virtual machines, it is impossible to replicate the builtin's behavior outside Ethereum. ``pop``, for example,
+    removes an item from the stack in EVM, however, in Solana there is no stack, for its virtual machine is register based.
+
+This is the comprehensive list of the existing Yul builtins and their compatibility on Solang. Arithmetic operations
+always return the widest integer between the arguments. Signed numbers are represented in two's complement. The
+descriptions in the table have been slightly modified from the `Solc documentation <https://docs.soliditylang.org/en/latest/yul.html#evm-dialect>`_.
+
+
++-------------------------+-------------+-------------------------------------------+-----------------+
+| Builtin                 | Returns     | Explanation                               | Availability    |
++=========================+=============+===========================================+=================+
+| stop()                  | None        | stop execution                            | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| add(x, y)               | Integer     | x + y                                     | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| sub(x, y)               | Integer     | x - y                                     | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| mul(x, y)               | Integer     | x * y                                     | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| div(x, y)               | Integer     | x / y or 0 if y == 0                      | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| sdiv(x, y)              | Integer     | x / y or 0 if y == 0, for signed integers | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| mod(x, y)               | Integer     | x % y or 0 if y == 0                      | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| smod(x, y)              | Integer     | x % y or 0 if y == 0, for signed integers | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| exp(x, y)               | Integer     | x to the power of y                       | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| not(x)                  | Integer     | negation of every bit of x                | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| lt(x, y)                | Bool        | x < y                                     | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| gt(x, y)                | Bool        | x > y                                     | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| slt(x, y)               | Bool        | x < y, for signed integers                | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| sgt(x, y)               | Bool        | x > y, for signed integers                | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| eq(x, y)                | Bool        | x == y                                    | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| iszero(x)               | Bool        | x == 0                                    | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| and(x, y)               | Integer     | bitwise AND of x and y                    | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| or(x, y)                | Integer     | bitwise OR of x and y                     | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| xor(x, y)               | Integer     | bitwise XOR of x and y                    | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| byte(n, x)              | Integer     | nth byte of x, where 0 is the most        | Yes             |
+|                         |             | significant bit                           |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| shl(x, y)               | Integer     | y << x                                    | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| shr(x, y)               | Integer     | y >> x                                    | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| sar(x, y)               | Integer     | y >> x, for signed integers               | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| addmod(x, y, m)         | Integer     | (x + y) % m or 0 if m == 0                | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| mulmod(x, y, m)         | Integer     | (x * y) % m or 0 if m == 0                | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| signextend(i, x)        | Integer     | | sign extend from (i*8+7)th bit, where   | No              |
+|                         |             | | 0th is the least significant bit        |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| keccak256(p, n)         | Integer     | keccak(mem[p...(p+n)))                    | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| pc()                    | Integer     | program counter                           | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| pop(x)                  | None        | discard value x from the stack            | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| mload(p)                | Integer     | load from memory mem[p...(p+32))          | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| mstore(p, v)            | None        | store v in memory mem[p...(p+32))         | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| mstore8(p, v)           | None        | store v & 0xff byte in memory mem[p]      | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| sload(p)                | Integer     | Load from storage slot p                  | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| sstore(p, v)            | Integer     | store v in storage slot p                 | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| msize()                 | Integer     | largest accessed memory index             | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| gas()                   | Integer     | gas still available to execution          | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| address()               | Integer     | address of the current contract           | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| balance(a)              | Integer     | balance at address a                      | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| selfbalance()           | Integer     | equivalent to balance(address())          | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| caller()                | Integer     | call sender (excluding ``delegatecall``)  | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| callvalue()             | Integer     | wei sent together with the current call   | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| calldataload(p)         | Integer     | load call data starting from position p   | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| calldatasize()          | Integer     | size of call data in bytes                | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| calldatacopy(t, f, s)   | None        | | copy s bytes from calldata at position  | No              |
+|                         |             | | f to mem at position t                  |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| codesize()              | Integer     | | size of the code of the current         | No              |
+|                         |             | | contract or execution context           |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| codecopy(t, f, s)       | None        | | copy s bytes from code at position f    | No              |
+|                         |             | | to mem at position t                    |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| extcodesize(a)          | Integer     | size of the code at address a             | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| extcodecopy(a, t, f, s) | None        | | like codecopy(t, f, s),                 | No              |
+|                         |             | | but take code at address a              |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| returndatasize()        | Integer     | size of the last returndata               | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| returndatacopy(t, f, s) | None        | | copy s bytes from returndata at         | No              |
+|                         |             | | position f to mem at position t         |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| extcodehash(a)          | Integer     | code hash of address a                    | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| create(v, p, n)         | Integer     | | create new contract with code           | No              |
+|                         |             | | mem[p...(p+n)) and send v wei and       |                 |
+|                         |             | | return the new address; returns 0       |                 |
+|                         |             | | on error                                |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| create2(v, p, n, s)     | Integer     | | create new contract with code           | No              |
+|                         |             | | mem[p...(p+n)) at address resulting     |                 |
+|                         |             | | from the keccak256 hash of              |                 |
+|                         |             | | 0xff.this.s.keccak256(mem[p..(p+n)])    |                 |
+|                         |             | | and send v wei and return the new       |                 |
+|                         |             | | address, where ``0xff`` is a 1 byte     |                 |
+|                         |             | | value, ``this`` is the current          |                 |
+|                         |             | | contract's address as a 20 byte value   |                 |
+|                         |             | | and ``s`` is a big-endian 256-bit       |                 |
+|                         |             | | value; returns 0 on error               |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| | call(g, a, v, in,     | Integer     | | call contract at address a with in      | No              |
+| | insize, out, outsize) |             | | mem[in...(in+insize)) providing g gas   |                 |
+|                         |             | | and v wei and output area               |                 |
+|                         |             | | mem[out...(out+outsize)) returning 0    |                 |
+|                         |             | | on error (eg. out of gas) and 1 on      |                 |
+|                         |             | | success                                 |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| | callcode(g, a, v, in, | Integer     | | identical to ``call`` but only use the  | No              |
+| | insize, out, outsize) |             | | code from a and stay in the context of  |                 |
+|                         |             | | the current contract otherwise          |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| | delegatecall(g, a, in,| Integer     | | identical to ``callcode`` but also keep | No              |
+| | insize, out, outsize) |             | | ``caller`` and ``callvalue``            |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| | staticcall(g, a, in,  | Integer     | | identical to ``call`` but do not allow  | No              |
+| | insize, out, outsize) |             | | state modifications                     |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| return(p, s)            | None        | end execution, return data mem[p...(p+s)) | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| revert(p, s)            | None        | | end execution, revert state changes,    | No              |
+|                         |             | | return data mem[p...(p+s))              |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| selfdestruct(a)         | None        | | end execution, destroy current          | No              |
+|                         |             | | contract and send funds to a            |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| invalid()               | None        | end execution with invalid instruction    | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| log0(p, s)              | None        | log without topics and data mem[p...(p+s)]| No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| log1(p, s, t1)          | None        | log with topic t1 and data mem[p...(p+s)] | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| log2(p, s, t1, t2)      | None        | | log with topics t1, t2 and data         | No              |
+|                         |             | | mem[p...(p+s))                          |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| log3(p, s, t1, t2, t3)  | None        | | log with topics t1, t2, t3 and data     | No              |
+|                         |             | | mem[p...(p+s))                          |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| | log4(p, s, t1, t2, t3,| None        | | log with topics t1, t2, t3, t4 and      | No              |
+| | t4)                   |             | | data mem[p...(p+s))                     |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| chainid()               | Integer     | ID of the executing chain                 | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| basefee()               | Integer     | current block's base fee                  | No              |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| origin()                | Integer     | transaction sender                        | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| gasprice()              | Integer     | gas price of the transaction              | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| blockhash(b)            | Integer     | | hash of block nr b - only for last      | Yes             |
+|                         |             | | 256 blocks excluding current            |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| coinbase()              | Integer     | current mining beneficiary                | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| timestamp()             | Integer     | | timestamp of the current block in       | Yes             |
+|                         |             | | seconds since the epoch                 |                 |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| number()                | Integer     | current block number                      | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| difficulty()            | Integer     | difficulty of the current block           | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+
+| gaslimit()              | Integer     | block gas limit of the current block      | Yes             |
++-------------------------+-------------+-------------------------------------------+-----------------+

--- a/docs/yul_language/functions.rst
+++ b/docs/yul_language/functions.rst
@@ -1,0 +1,62 @@
+Functions
+=========
+
+Functions in Yul cannot access any variable outside their scope, i.e. they can
+only operate with the variables they receive as arguments. You can define types for arguments and returns. If no
+type is specified, the compiler will default to ``u256``.
+
+.. warning::
+    Yul functions are only available within the scope there are defined. They cannot be accessed from Solidity
+    and from other inline assembly blocks, even if they are contained within the same Solidity function.
+
+Differently from solc, Solang allows name shadowing inside Yul
+functions. As they cannot access variables declared outside them, a redefinition of an outside name is allowed, if
+it has not been declared within the function yet. Builtin function names cannot be overdriven and verbatim functions
+supported by Solc are not implemented in Solang. ``verbatim``, nevertheless, is still a reserved keyword and
+cannot be the prefix of variable or function names.
+
+Function calls are identified by a name followed by parenthesis. If the types of the arguments passed to function
+calls do not match the respective parameter's type, Solang will implicitly convert them. Likewise, the returned
+values of function calls will be implicitly converted to match the type needed in an expression context.
+
+
+.. code-block:: yul
+
+    {
+        // return type defaulted to u256
+        function noArgs() -> ret
+        {
+            ret := 2
+        }
+
+        // Parameters defaulted to u256 and ret has type u64
+        function sum(a, b) -> ret : u64
+        {
+            ret := add(b, a)
+        }
+
+        function getMod(c : s32, d : u128, e) -> ret1, ret2 : u64
+        {
+            ret1 := mulmod(c, d, e)
+            ret2 := addmod(c, d, e)
+        }
+
+        function noReturns(a, b)
+        {
+            // Syntax of function calls
+            let x := noArgs()
+            // Arguments will be implicitly converted form u256 to s32 and u128, respectively.
+            // The returns will also be converted to u256
+            let c, d := getMod(a, b)
+            {
+                // 'doThis' cannot be called from outside the block defined the by curly brackets.
+                function doThis(f, g) -> ret {
+                    ret := sdiv(f, g)
+                }
+            }
+            // 'doThat' cannot be called from outside 'noReturns'
+            function doThat(f, g) -> ret {
+                ret := smod(g, f)
+            }
+        }
+    }

--- a/docs/yul_language/statements.rst
+++ b/docs/yul_language/statements.rst
@@ -1,0 +1,140 @@
+Statements
+==========
+
+For-loop
+________
+
+For-loops are completely supported in Solang. ``continue`` and ``break`` statements are also supported.
+The syntax for ``for`` is quite different from other commonly known programming languages. After the ``for`` keyword,
+the lexer expects a yul block delimited with curly brackets that initializes variables for the loop. This block can have
+as many statements as needed and is always executed.
+
+After the initialization block, there should be an Yul expression that contains the loop stopping condition. Then comes
+the update block, which contains all the statements executed after the main body block, but before the condition check.
+The body block is a set of instructions executed during each iteration.
+
+.. code-block:: yul
+
+    {
+        function foo()
+        {
+            // Simple for loop
+           for {let i := 0} lt(i, 10) {i := add(i, 10)} {
+                let p := funcCall(i, 10)
+                if eq(p, 5) {
+                    continue
+                }
+
+                if eq(p, 90) {
+                    break
+                }
+            }
+
+            let a := 0
+            // More complex loops are also possible
+            for {
+                let i := 0
+                let j := 3
+                i := add(j, i)
+            } or(lt(i, 10), lt(j, 5)) {
+                i := add(i, 1)
+                j := add(j, 3)
+            } {
+                a := add(a, mul(i, j))
+            }
+        }
+    }
+
+If-block
+________
+
+If-block conditions in Yul cannot have an `else`. They act only as a branch if the condition is true
+and are totally supported in Solang.
+
+.. code-block:: yul
+
+    {
+        if eq(5, 4) {
+            funcCall(4, 3)
+        } // There cannot be an 'else' here
+    }
+
+
+Switch
+_______
+
+Switch statements are not yet supported in Solang. If there is urgent need to support them,
+please, file a GitHub issue in the repository.
+
+Blocks
+______
+
+There can be blocks of code within Yul, defined by curly brackets. They have their own scope and any variable
+declared inside a block cannot be accessed outside it. Statements inside a block can access outside variables, though.
+
+.. code-block:: yul
+
+    {
+        function foo() -> ret {
+            let g := 0
+            { // This is a code block
+                let r := 7
+                ret := mul(g, r)
+            }
+        }
+    }
+
+
+Variable declaration
+____________________
+
+Variables can be declared in Yul using the `let` keyword. Multiple variables can be declared at the same line
+if there is no initializer or the initializer is a function that returns multiple values.
+
+The default type for variables in Yul is ``u256``. If you want to declare a variable with another type, use the colon.
+Note that if the variable type and the type of the right hand side of the assignment do not match, there will be an implicit
+type conversion to the correct type.
+
+.. code-block:: yul
+
+    {
+        let a, b, c
+        let d := funCall()
+        let e : u64 := funcCall()
+        let g, h, i := multipleReturns()
+        let j : u32, k : u8 := manyReturns()
+    }
+
+Assignments
+___________
+
+Variables can be assignment using the ``:=`` operator. If the types do not match,
+the compiler performs an implicit conversion, so that the right hand side type matches that of the variable.
+Multiple variables can be assigned in a single line if the right hand side is a function call that returns multiple
+values.
+
+
+.. code-block:: yul
+
+    {
+        a := 6
+        c, d := multipleReturns()
+    }
+
+Function calls
+______________
+
+Function calls in Yul are identified by the use of parenthesis after an identifier. Standalone function
+calls must not return anything. Functions that have multiple returns can only appear in an assignment or definition
+of multiple variables.
+
+.. code-block:: yul
+
+    {
+        noReturns()
+        a := singleReturn()
+        // multipleReturns() cannot be inside 'add'
+        let g := add(a, singleReturn())
+        f, d, e := multipleReturns()
+    }
+

--- a/docs/yul_language/types.rst
+++ b/docs/yul_language/types.rst
@@ -1,0 +1,26 @@
+Types
+=====
+
+
+The default type for variables in Yul is ``u256``. If there is no type specified, the compiler
+will default to that integer type. Variables can have a type specified during their declaration using the following
+syntax:
+
+
+.. code-block:: yul
+
+    {
+        let a : u32, b : s64, d : u128, e : bool := multipleReturns()
+    }
+
+Yul allows signed and unsigned integer types, in addition to the boolean type. If a conversion from an integer to a
+boolean is necessary, the compiler does the following operation ``number != 0``.
+
+The unsigned types are the following: ``u8``, ``u32``, ``u64``, ``u128`` and ``u256``.
+
+The signed types are the following: ``s8``, ``s32``, ``s64``, ``s128``, ``s256``.
+
+
+
+
+

--- a/docs/yul_language/yul.rst
+++ b/docs/yul_language/yul.rst
@@ -1,0 +1,14 @@
+Overview of Yul
+===============
+
+.. _yul_section:
+
+Yul, also know as EVM assembly, is a low level language for creating smart contracts and for providing more
+control over the execution environment when using Solidity as the primary language. Although it enables
+more possibilities to manage memory, using Yul does not imply a performance improvement. In Solang,
+all Yul constructs are processed using the same pipeline as Solidity.
+
+The support for Yul is only partial. We support all statements, except for the switch-block. In addition,
+some Yul builtins are not yet implemented. In the following sections,
+we'll describe the state of the compatibility of Yul in Solang.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
 docutils<0.18
+sphinx_rtd_theme>=0.5.2
+pygments-lexer-solidity>=0.7.0
+sphinx-a4doc>=1.2.1
+sphinx>=2.1.0
+


### PR DESCRIPTION
This PR adds documentation for Yul. Changes in `docs/conf.py` were necessary to support a new linter for both Solidity and Yul.