### PR TITLE
Fix cast to address

### DIFF
--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -679,9 +679,9 @@ impl Expression {
                         Expression::Trunc(*loc, address_to_int, Box::new(self.clone()))
                     } else if *from_len < address_bits {
                         if from.is_signed_int() {
-                            Expression::ZeroExt(*loc, to.clone(), Box::new(self.clone()))
+                            Expression::ZeroExt(*loc, address_to_int, Box::new(self.clone()))
                         } else {
-                            Expression::SignExt(*loc, to.clone(), Box::new(self.clone()))
+                            Expression::SignExt(*loc, address_to_int, Box::new(self.clone()))
                         }
                     } else {
                         self.clone()

--- a/tests/codegen_testcases/address_cast.sol
+++ b/tests/codegen_testcases/address_cast.sol
@@ -1,0 +1,10 @@
+// RUN: --target solana --emit cfg
+
+contract DTron {
+    // BEGIN-CHECK: DTron::DTron::function::moneyDeposit__address:_uint256:
+    function moneyDeposit(address[] memory thanksCash, uint256[] memory amount) public payable {
+        // CHECK: ty:address payable %receiver = address payable(address((sext uint256 (trunc uint160 uint256((load (subscript address[] (arg #0)[uint32 2])))))))
+        address payable receiver = payable(address(uint160(thanksCash[2])));
+        receiver.transfer(amount[2]);
+    }
+}


### PR DESCRIPTION
There was a small mistake when casting from integer to address. The type we pass on to `SingExt` and `ZeroExt` was wrong. This PR fix this and resolves issue #813.