### PR TITLE
Release v0.1.12 Cairo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to [Solang](https://github.com/hyperledger-labs/solang/)
 will be documented here.
 
-## [Unreleased]
+## v0.1.12 Cario
 
 ### Added
 - Added spl-token integration for Solana
@@ -18,7 +18,7 @@ will be documented here.
   `git submodule update --init --recursive` to fetch the test files, and
   then run the test with `cargo test --workspace`.
 
-## [0.1.11]
+## v0.1.11 Nuremberg
 
 ### Added
 - Added support for Solidity user types
@@ -34,7 +34,7 @@ will be documented here.
 - Fixed associativity of the power operator
 - A huge amount of fixes improving compatibility with solc
 
-## [0.1.10]
+## v0.1.10 Barcelona
 
 ### Added
 - On Solana, the accounts that were passed into the transactions are listed in
@@ -50,7 +50,7 @@ will be documented here.
 - The ast datastructure has been simplified.
 - Many bugfixes across the entire tree.
 
-## [0.1.9]
+## v0.1.9
 
 ### Added
 - Added support for solc import mapppings using `--importmap`
@@ -77,7 +77,7 @@ will be documented here.
 - The Sawtooth Sabre target has been removed.
 - The generic target has been removed.
 
-## [0.1.8]
+## v0.1.8
 
 ### Added
 - Added a strength reduce pass to eliminate 256/128 bit multiply, division,
@@ -111,7 +111,7 @@ will be documented here.
 - Fixed array support in the ethereum abi encoder and decoder
 - Fixed issues in arithmetic on non-power-of-2 types (e.g. uint112)
 
-## [0.1.7]
+## v0.1.7
 
 ### Added
 - Added a constant folding optimization pass to improve codegen. When variables fold
@@ -133,7 +133,7 @@ will be documented here.
 - Ewasm uses precompiles for keccak hashing
 - Various ewasm fixes for Hyperledger Burrow
 
-## [0.1.6]
+## v0.1.6
 
 ### Added
 - New Visual Studio Code extension developed under Hyperledger Mentorship
@@ -144,7 +144,7 @@ will be documented here.
 - Constants can be declared outside of contracts
 - String formatting using python style "..{}..".format(n)
 
-## [0.1.5]
+## v0.1.5
 
 ### Added
 - Function types are implemented
@@ -154,7 +154,7 @@ will be documented here.
 ### Changed
 - The Substrate target requires Substrate 2.0
 
-## [0.1.4]
+## v0.1.4
 
 ### Added
 - `event` can be declared and emitted with `emit`
@@ -163,7 +163,7 @@ will be documented here.
 - All major Solidity language features implemented, see our language status page:
   https://solang.readthedocs.io/en/latest/status.html
 
-## [0.1.3]
+## v0.1.3
 
 ### Added
 - `import` directives are supported

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"
@@ -42,7 +42,7 @@ itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.8"
 once_cell = "1.10"
-solang-parser = { path = "solang-parser", version = "0.1.13" }
+solang-parser = { path = "solang-parser", version = "0.1.14" }
 codespan-reporting = "0.11"
 phf = "0.10.1"
 rust-lapper = "1.0"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,10 +1,14 @@
 # Release Checklist
 
 - Update the version in `Cargo.toml`, `solang-parser/Cargo.toml`, the binary
-  links in `docs/installing.rst`, and `CHANGELOG.md`
-- Copy the contents of the CHANGELOG for this release into commit message
+  links in `docs/installing.rst`, and `CHANGELOG.md`. Remember to match the
+  solang-parser version in the top level `Cargo.toml`.
+- Copy the contents of the CHANGELOG for this release into commit message,
+  using `git commit -s --cleanup=whitespace` so the that the lines beginning
+  with `#` are not removed.
 - Ensure the cargo publish is happy `cargo publish --dry-run`
 - Try the release github actions by pushing a tag to your solang fork
+- Ensure the release text uses the markdown formatting
 - If build succeeds, merge the release commits
 - Apply tag to merged commit on main branch
 - Push tag to origin

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,11 +8,11 @@ Download release binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-mac-arm>`_
 
 On MacOS, remember to remove the quarantine attribute using ``xattr -d com.apple.quarantine solang-mac-arm``
 in the terminal.
@@ -22,7 +22,7 @@ Using ghcr.io/hyperledger-labs/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger-labs/solang/pkgs/container/solang>`_.
-There is a release `v0.1.11` tag and a `latest` tag:
+There is a release `v0.1.12` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -64,7 +64,7 @@ These patches make it possible to generate code for Solana, and fixes some
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger-labs/solang/releases/tag/v0.1.11>`_
+`github <https://github.com/hyperledger-labs/solang/releases/tag/v0.1.12>`_
 or build your own from source. After that, you need to add the `bin` directory to your
 path, so that the build system of Solang can find the correct version of llvm to use.
 
@@ -72,7 +72,7 @@ Installing LLVM on Linux
 ________________________
 
 A pre-built version of llvm, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/llvm13.0-linux-x86-64.tar.xz>`_.
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-linux-x86-64.tar.xz>`_.
 After downloading, untar the file in a terminal and add it to your path.
 
 .. code-block:: bash
@@ -84,7 +84,7 @@ Installing LLVM on Windows
 __________________________
 
 A pre-built version of llvm, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/llvm13.0-win.zip>`_.
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-win.zip>`_.
 
 After unzipping the file, add the bin directory to your path.
 
@@ -96,8 +96,8 @@ Installing LLVM on Mac
 ______________________
 
 A pre-built version of llvm for intel macs, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/llvm13.0-mac-arm.tar.xz>`_. After downloading,
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
+`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-mac-arm.tar.xz>`_. After downloading,
 untar the file in a terminal and add it to your path like so:
 
 .. code-block:: bash

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"


### PR DESCRIPTION
### Added
- Added spl-token integration for Solana
- Solang now generates code for inline assembly, including many Yul builtins

### Changed
- The documentation has been re-arranged for readability.
- The solang parser can parse the same syntax as Ethereum Solidity 0.8.

### Fixed
- Fixed many parser issues. Now solang-parser parses all files in the
  Ethereum Solidity test suite. First run
  `git submodule update --init --recursive` to fetch the test files, and
  then run the test with `cargo test --workspace`.

Signed-off-by: Sean Young <sean@mess.org>