### PR TITLE
Fix clippy warnings when using upcoming rust 1.62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to [Solang](https://github.com/hyperledger-labs/solang/)
 will be documented here.
 
-## v0.1.12 Cario
+## v0.1.12 Cairo
 
 ### Added
 - Added spl-token integration for Solana

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -15,3 +15,4 @@
 - Wait for build to succeed
 - `cargo publish`
 - Release new version of vscode plugin if needed
+- Mention release in Discord (Solana, Hyperledger) and Hyperledger /dev/weekly

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1,8 +1,8 @@
 use indexmap::IndexMap;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::fmt;
 use std::str;
 use std::sync::Arc;
+use std::{fmt, fmt::Write};
 
 use super::statements::{statement, LoopScopes};
 use super::{
@@ -1027,20 +1027,23 @@ impl ControlFlowGraph {
         let mut s = format!("block{}: # {}\n", pos, self.blocks[pos].name);
 
         if let Some(ref phis) = self.blocks[pos].phis {
-            s.push_str(&format!(
-                "\t# phis: {}\n",
+            writeln!(
+                s,
+                "\t# phis: {}",
                 phis.iter()
                     .map(|p| -> &str { &self.vars[p].id.name })
                     .collect::<Vec<&str>>()
                     .join(",")
-            ));
+            )
+            .unwrap();
         }
 
         let defs = &self.blocks[pos].defs;
 
         if !defs.is_empty() {
-            s.push_str(&format!(
-                "\t# reaching:{}\n",
+            writeln!(
+                s,
+                "\t# reaching:{}",
                 defs.iter()
                     .map(|(var_no, defs)| format!(
                         " {}:[{}]",
@@ -1052,11 +1055,12 @@ impl ControlFlowGraph {
                     ))
                     .collect::<Vec<String>>()
                     .join(", ")
-            ));
+            )
+            .unwrap();
         }
 
         for ins in &self.blocks[pos].instr {
-            s.push_str(&format!("\t{}\n", self.instr_to_string(contract, ns, ins)));
+            writeln!(s, "\t{}", self.instr_to_string(contract, ns, ins)).unwrap();
         }
 
         s
@@ -1692,31 +1696,38 @@ impl Contract {
 
         for cfg in &self.cfg {
             if !cfg.is_placeholder() {
-                out += &format!(
-                    "\n# {} {} public:{} selector:{} nonpayable:{}\n",
+                writeln!(
+                    out,
+                    "\n# {} {} public:{} selector:{} nonpayable:{}",
                     cfg.ty,
                     cfg.name,
                     cfg.public,
                     hex::encode(cfg.selector.to_be_bytes()),
                     cfg.nonpayable,
-                );
+                )
+                .unwrap();
 
-                out += &format!(
-                    "# params: {}\n",
+                writeln!(
+                    out,
+                    "# params: {}",
                     cfg.params
                         .iter()
                         .map(|p| p.ty.to_string(ns))
                         .collect::<Vec<String>>()
                         .join(",")
-                );
-                out += &format!(
-                    "# returns: {}\n",
+                )
+                .unwrap();
+
+                writeln!(
+                    out,
+                    "# returns: {}",
                     cfg.returns
                         .iter()
                         .map(|p| p.ty.to_string(ns))
                         .collect::<Vec<String>>()
                         .join(",")
-                );
+                )
+                .unwrap();
 
                 out += &cfg.to_string(self, ns);
             }

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -1,9 +1,13 @@
-use super::ast::*;
-use crate::parser::pt;
-use crate::sema::symtable::Symtable;
-use crate::sema::yul::ast::{YulBlock, YulExpression, YulStatement};
-use crate::sema::yul::builtin::YulBuiltInFunction;
-use solang_parser::pt::Loc;
+use crate::sema::{
+    ast::*,
+    symtable::Symtable,
+    yul::{
+        ast::{YulBlock, YulExpression, YulStatement},
+        builtin::YulBuiltInFunction,
+    },
+};
+use solang_parser::{pt, pt::Loc};
+use std::fmt::Write;
 
 struct Node {
     name: String,
@@ -37,25 +41,31 @@ impl Dot {
 
         for node in &self.nodes {
             if !node.labels.is_empty() {
-                result.push_str(&format!(
-                    "\t{} [label=\"{}\"]\n",
+                writeln!(
+                    result,
+                    "\t{} [label=\"{}\"]",
                     node.name,
                     node.labels.join("\\n")
-                ));
+                )
+                .unwrap();
             }
         }
 
         for edge in &self.edges {
             if let Some(label) = &edge.label {
-                result.push_str(&format!(
-                    "\t{} -> {} [label=\"{}\"]\n",
+                writeln!(
+                    result,
+                    "\t{} -> {} [label=\"{}\"]",
                     self.nodes[edge.from].name, self.nodes[edge.to].name, label
-                ));
+                )
+                .unwrap();
             } else {
-                result.push_str(&format!(
-                    "\t{} -> {}\n",
+                writeln!(
+                    result,
+                    "\t{} -> {}",
                     self.nodes[edge.from].name, self.nodes[edge.to].name
-                ));
+                )
+                .unwrap();
             }
         }
 

--- a/src/sema/tags.rs
+++ b/src/sema/tags.rs
@@ -1,5 +1,6 @@
 use super::ast::{Diagnostic, Namespace, Parameter, Tag};
 use crate::parser::pt;
+use std::fmt::Write;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum DocComment {
@@ -321,7 +322,7 @@ pub fn render(tags: &[Tag]) -> String {
     }
 
     if let Some(tag) = tags.iter().find(|e| e.tag == "author") {
-        s.push_str(&format!("Author: {}", &tag.value));
+        write!(s, "Author: {}", &tag.value).unwrap();
     }
 
     s

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -8,13 +8,11 @@ use super::{
     tags::{parse_doccomments, DocComment},
     SOLANA_SPARSE_ARRAY_SIZE,
 };
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
+use crate::parser::{pt, pt::CodeLocation};
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::{One, Zero};
-use std::collections::HashMap;
-use std::ops::Mul;
+use std::{collections::HashMap, fmt::Write, ops::Mul};
 
 /// List the types which should be resolved later
 pub struct ResolveFields<'a> {
@@ -839,18 +837,20 @@ impl Type {
                 );
 
                 if !mutability.is_default() {
-                    s.push_str(&format!(" {}", mutability));
+                    write!(s, " {}", mutability).unwrap();
                 }
 
                 if !returns.is_empty() {
-                    s.push_str(&format!(
+                    write!(
+                        s,
                         " returns ({})",
                         returns
                             .iter()
                             .map(|ty| ty.to_string(ns))
                             .collect::<Vec<String>>()
                             .join(",")
-                    ));
+                    )
+                    .unwrap();
                 }
 
                 s

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -3,7 +3,7 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use rand::Rng;
 use sha2::{Digest, Sha256};
-use std::{collections::HashMap, ffi::OsStr, fmt};
+use std::{collections::HashMap, ffi::OsStr, fmt, fmt::Write};
 use tiny_keccak::{Hasher, Keccak};
 use wasmi::memory_units::Pages;
 use wasmi::*;
@@ -1170,9 +1170,9 @@ impl MockSubstrate {
                             break;
                         }
                         let b = buf[offset + i];
-                        hex.push_str(&format!(" {:02x}", b));
+                        write!(hex, " {:02x}", b).unwrap();
                         if b.is_ascii() && !b.is_ascii_control() {
-                            chars.push_str(&format!("  {}", b as char));
+                            write!(chars, "  {}", b as char).unwrap();
                         } else {
                             chars.push_str("   ");
                         }


### PR DESCRIPTION
rust 1.62 will be released on the 30th of June. This PR fixes the clippy warnings that will appear when that version is used.