### PR TITLE
Do not re-export solang_parser from solang crate

### DIFF
--- a/src/abi/ethereum.rs
+++ b/src/abi/ethereum.rs
@@ -1,7 +1,7 @@
 // ethereum style ABIs
-use crate::parser::pt;
 use crate::sema::ast::{Namespace, Parameter, Type};
 use serde::Serialize;
+use solang_parser::pt;
 
 #[derive(Serialize)]
 #[allow(clippy::upper_case_acronyms)]

--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -1,5 +1,4 @@
 // Parity Substrate style ABIs/Abi
-use crate::parser::pt;
 use crate::sema::ast;
 use crate::sema::tags::render;
 use contract_metadata::*;
@@ -7,6 +6,7 @@ use num_traits::ToPrimitive;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use solang_parser::pt;
 use std::convert::TryInto;
 
 #[derive(Deserialize, Serialize)]

--- a/src/bin/doc/mod.rs
+++ b/src/bin/doc/mod.rs
@@ -4,9 +4,9 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
-use solang::parser::pt;
 use solang::sema::ast;
 use solang::sema::contracts::visit_bases;
+use solang_parser::pt;
 
 #[derive(Serialize)]
 struct Field<'a> {

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -6,10 +6,10 @@ use solang::{
     codegen::codegen,
     file_resolver::FileResolver,
     parse_and_resolve,
-    parser::pt,
     sema::{ast, builtin::get_prototype, symtable, tags::render},
     Target,
 };
+use solang_parser::pt;
 use std::{collections::HashMap, ffi::OsString, fmt::Write, path::PathBuf};
 use tokio::sync::Mutex;
 use tower_lsp::{jsonrpc::Result, lsp_types::*, Client, LanguageServer, LspService, Server};

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -15,13 +15,13 @@ use super::{
 use crate::ast::FunctionAttributes;
 use crate::codegen::subexpression_elimination::common_sub_expression_elimination;
 use crate::codegen::{undefined_variable, Expression, LLVMName};
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
 use crate::sema::ast::RetrieveType;
 use crate::sema::ast::{CallTy, Contract, Function, Namespace, Parameter, StringLocation, Type};
 use crate::sema::contracts::{collect_base_args, visit_bases};
 use crate::sema::Recurse;
 use crate::{ast, Target};
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -1,13 +1,13 @@
 use super::cfg::{ControlFlowGraph, Instr};
 use super::reaching_definitions;
 use crate::codegen::{Builtin, Expression};
-use crate::parser::pt::Loc;
 use crate::sema::ast::RetrieveType;
 use crate::sema::ast::{Diagnostic, Namespace, StringLocation, Type};
 use num_bigint::{BigInt, Sign};
 use num_traits::{ToPrimitive, Zero};
 use ripemd::Ripemd160;
 use sha2::{Digest, Sha256};
+use solang_parser::pt::Loc;
 use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
 use tiny_keccak::{Hasher, Keccak};
 

--- a/src/codegen/dead_storage.rs
+++ b/src/codegen/dead_storage.rs
@@ -1,7 +1,7 @@
 use super::cfg::{BasicBlock, ControlFlowGraph, Instr};
 use crate::codegen::Expression;
-use crate::parser::pt::Loc;
 use crate::sema::ast::{Namespace, RetrieveType, Type};
+use solang_parser::pt::Loc;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -8,8 +8,6 @@ use super::{
 };
 use crate::codegen::unused_variable::should_remove_assignment;
 use crate::codegen::{Builtin, Expression};
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
 use crate::sema::ast;
 use crate::sema::ast::RetrieveType;
 use crate::sema::ast::{CallTy, FormatArg, Function, Namespace, Parameter, StringLocation, Type};
@@ -18,6 +16,8 @@ use crate::sema::expression::{bigint_to_expression, ResolveTo};
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 use std::ops::Mul;
 
 pub fn expression(

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -13,14 +13,14 @@ use crate::codegen::unused_variable::{
 };
 use crate::codegen::yul::inline_assembly_cfg;
 use crate::codegen::{Builtin, Expression};
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
 use crate::sema::ast::RetrieveType;
 use crate::sema::ast::{
     CallTy, DestructureField, Function, Namespace, Parameter, Statement, TryCatch, Type,
 };
 use crate::sema::Recurse;
 use num_traits::Zero;
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 use tiny_keccak::{Hasher, Keccak};
 
 /// Resolve a statement, which might be a block of statements or an entire body of a function

--- a/src/codegen/storage.rs
+++ b/src/codegen/storage.rs
@@ -11,9 +11,9 @@ use super::{
     cfg::{ControlFlowGraph, Instr},
     vartable::Vartable,
 };
-use crate::parser::pt;
 use crate::sema::ast::RetrieveType;
 use crate::sema::ast::{Function, Namespace, Type};
+use solang_parser::pt;
 
 /// Given a storage slot which is the start of the array, calculate the
 /// offset of the array element. This function exists to avoid doing

--- a/src/codegen/strength_reduce.rs
+++ b/src/codegen/strength_reduce.rs
@@ -1605,7 +1605,8 @@ fn test_highest_bit() {
 
 #[test]
 fn expresson_known_bits() {
-    use crate::{parser::pt::Loc, Target};
+    use crate::Target;
+    use solang_parser::pt::Loc;
 
     let ns = Namespace::new(Target::default_substrate());
     let loc = Loc::Codegen;

--- a/src/codegen/subexpression_elimination/available_variable.rs
+++ b/src/codegen/subexpression_elimination/available_variable.rs
@@ -1,5 +1,5 @@
-use crate::parser::pt::Loc;
-use crate::parser::pt::OptionalCodeLocation;
+use solang_parser::pt::Loc;
+use solang_parser::pt::OptionalCodeLocation;
 
 /// This struct manages expressions assigned to an existing variable.
 #[derive(Clone)]

--- a/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
+++ b/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
@@ -3,11 +3,11 @@ use crate::codegen::{
     vartable::{Storage, Variable},
     ControlFlowGraph, Expression, Instr,
 };
-use crate::parser::pt::OptionalCodeLocation;
-use crate::parser::pt::{Identifier, Loc};
 use crate::sema::ast::RetrieveType;
 use crate::sema::ast::{Namespace, Type};
 use bitflags::bitflags;
+use solang_parser::pt::OptionalCodeLocation;
+use solang_parser::pt::{Identifier, Loc};
 use std::collections::{HashMap, VecDeque};
 
 #[derive(Clone)]

--- a/src/codegen/subexpression_elimination/tests.rs
+++ b/src/codegen/subexpression_elimination/tests.rs
@@ -4,9 +4,9 @@ use crate::codegen::cfg::Instr;
 use crate::codegen::subexpression_elimination::common_subexpression_tracker::CommonSubExpressionTracker;
 use crate::codegen::subexpression_elimination::{AvailableExpression, AvailableExpressionSet};
 use crate::codegen::Expression;
-use crate::parser::pt::Loc;
 use crate::sema::ast::{StringLocation, Type};
 use num_bigint::{BigInt, Sign};
+use solang_parser::pt::Loc;
 
 #[test]
 fn add_variable_function_arg() {

--- a/src/codegen/undefined_variable.rs
+++ b/src/codegen/undefined_variable.rs
@@ -2,10 +2,10 @@ use crate::ast::Type;
 use crate::codegen::cfg::{ASTFunction, ControlFlowGraph, Instr};
 use crate::codegen::reaching_definitions::{apply_transfers, VarDefs};
 use crate::codegen::{Builtin, Expression};
-use crate::parser::pt::{Loc, StorageLocation};
 use crate::sema::ast::{Diagnostic, ErrorType, Level, Namespace, Note};
 use crate::sema::symtable;
 use solang_parser::pt::CodeLocation;
+use solang_parser::pt::{Loc, StorageLocation};
 use std::collections::HashMap;
 
 /// We use this struct in expression.recurse function to provide all the

--- a/src/codegen/vartable.rs
+++ b/src/codegen/vartable.rs
@@ -1,11 +1,8 @@
+use crate::sema::{ast::Type, symtable::Symtable};
 use indexmap::IndexMap;
 use num_bigint::BigInt;
+use solang_parser::pt;
 use std::collections::BTreeSet;
-
-use crate::{
-    parser::pt,
-    sema::{ast::Type, symtable::Symtable},
-};
 
 #[derive(Clone)]
 pub struct Variable {

--- a/src/emit/ewasm.rs
+++ b/src/emit/ewasm.rs
@@ -1,7 +1,7 @@
 use crate::codegen;
 use crate::codegen::cfg::HashTy;
-use crate::parser::pt;
 use crate::sema::ast;
+use solang_parser::pt;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::str;

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -1,9 +1,9 @@
 use crate::codegen::{Builtin, Expression};
-use crate::parser::pt;
 use crate::sema::ast::RetrieveType;
 use crate::sema::ast::{
     BuiltinStruct, CallTy, Contract, FormatArg, Namespace, Parameter, StringLocation, Type,
 };
+use solang_parser::pt;
 use std::convert::TryFrom;
 use std::fmt;
 use std::str;

--- a/src/emit/solana.rs
+++ b/src/emit/solana.rs
@@ -1,7 +1,7 @@
 use crate::codegen::cfg::HashTy;
-use crate::parser::pt;
 use crate::sema::ast;
 use crate::{codegen, Target};
+use solang_parser::pt;
 use std::collections::HashMap;
 use std::str;
 

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -1,6 +1,5 @@
 use crate::codegen;
 use crate::codegen::cfg::HashTy;
-use crate::parser::pt;
 use crate::sema::ast;
 use inkwell::context::Context;
 use inkwell::module::{Linkage, Module};
@@ -12,6 +11,7 @@ use inkwell::AddressSpace;
 use inkwell::IntPredicate;
 use inkwell::OptimizationLevel;
 use num_traits::ToPrimitive;
+use solang_parser::pt;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -1,5 +1,5 @@
-use crate::parser::pt::Loc;
 use crate::sema::ast;
+use solang_parser::pt::Loc;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ pub mod emit;
 pub mod file_resolver;
 #[cfg(feature = "llvm")]
 pub mod linker;
-pub use solang_parser as parser;
 // In Sema, we use result unit for returning early
 // when code-misparses. The error will be added to the namespace diagnostics, no need to have anything but unit
 // as error.

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1,14 +1,14 @@
 use super::symtable::Symtable;
 use crate::codegen::cfg::ControlFlowGraph;
 use crate::diagnostics::Diagnostics;
-pub use crate::parser::diagnostics::*;
-use crate::parser::pt;
-use crate::parser::pt::{CodeLocation, OptionalCodeLocation};
 use crate::sema::yul::ast::{InlineAssembly, YulFunction};
 use crate::sema::Recurse;
 use crate::{codegen, Target};
 use num_bigint::BigInt;
 use num_rational::BigRational;
+pub use solang_parser::diagnostics::*;
+use solang_parser::pt;
+use solang_parser::pt::{CodeLocation, OptionalCodeLocation};
 use std::sync::Arc;
 use std::{
     collections::{BTreeMap, HashMap},

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -5,13 +5,13 @@ use super::ast::{
 use super::eval::eval_const_number;
 use super::expression::{args_sanity_check, expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
 use crate::sema::ast::RetrieveType;
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::One;
 use once_cell::sync::Lazy;
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 use std::path::PathBuf;
 
 pub struct Prototype {

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -1,7 +1,7 @@
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
 use num_bigint::BigInt;
 use num_traits::Zero;
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::TryInto;
 use tiny_keccak::{Hasher, Keccak};

--- a/src/sema/diagnostics.rs
+++ b/src/sema/diagnostics.rs
@@ -1,9 +1,9 @@
 use super::ast::{Diagnostic, Level, Namespace};
 use crate::file_resolver::FileResolver;
-use crate::parser::pt::Loc;
 use codespan_reporting::{diagnostic, files, term};
 use itertools::Itertools;
 use serde::Serialize;
+use solang_parser::pt::Loc;
 use std::{
     collections::HashMap,
     slice::Iter,

--- a/src/sema/eval.rs
+++ b/src/sema/eval.rs
@@ -6,8 +6,8 @@ use num_traits::ToPrimitive;
 use num_traits::Zero;
 
 use super::ast::{Diagnostic, Expression, Namespace};
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 
 /// Resolve an expression where a compile-time constant is expected
 pub fn eval_const_number(

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -10,8 +10,6 @@ use super::eval::eval_const_rational;
 use super::format::string_format;
 use super::{symtable::Symtable, using};
 use crate::ast::RetrieveType;
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
 use crate::sema::unused_variable::{
     assigned_variable, check_function_call, check_var_usage_expression, used_variable,
 };
@@ -20,6 +18,8 @@ use base58::{FromBase58, FromBase58Error};
 use num_bigint::{BigInt, Sign};
 use num_rational::BigRational;
 use num_traits::{FromPrimitive, Num, One, Pow, ToPrimitive, Zero};
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 use solang_parser::pt::Loc;
 use std::{
     cmp,

--- a/src/sema/file.rs
+++ b/src/sema/file.rs
@@ -1,5 +1,5 @@
 use super::ast::{File, Namespace};
-use crate::parser::pt::Loc;
+use solang_parser::pt::Loc;
 use std::{fmt, path};
 
 impl File {

--- a/src/sema/format.rs
+++ b/src/sema/format.rs
@@ -1,9 +1,9 @@
 use super::ast::{Diagnostic, Expression, FormatArg, Namespace, Type};
 use super::expression::{expression, ExprContext, ResolveTo};
 use super::symtable::Symtable;
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
 use crate::sema::ast::RetrieveType;
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 
 use std::iter::Peekable;
 use std::slice::Iter;

--- a/src/sema/functions.rs
+++ b/src/sema/functions.rs
@@ -3,10 +3,10 @@ use super::ast::{
 };
 use super::contracts::is_base;
 use super::tags::{resolve_tags, DocComment};
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
-use crate::parser::pt::OptionalCodeLocation;
 use crate::Target;
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
+use solang_parser::pt::OptionalCodeLocation;
 
 /// Resolve function declaration in a contract
 pub fn contract_function(

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -6,9 +6,9 @@ use self::{
     variables::variable_decl,
 };
 use crate::file_resolver::{FileResolver, ResolvedFile};
-use crate::parser::{parse, pt};
 use crate::sema::unused_variable::{check_unused_events, check_unused_namespace_variables};
 use num_bigint::BigInt;
+use solang_parser::{parse, pt};
 use std::ffi::OsStr;
 
 mod address;

--- a/src/sema/mutability.rs
+++ b/src/sema/mutability.rs
@@ -2,10 +2,10 @@ use super::ast::{
     Builtin, DestructureField, Diagnostic, Expression, Function, Mutability, Namespace, Statement,
     Type,
 };
-use crate::parser::pt;
 use crate::sema::ast::RetrieveType;
 use crate::sema::yul::ast::{YulExpression, YulStatement};
 use crate::sema::Recurse;
+use solang_parser::pt;
 
 /// check state mutability
 pub fn mutability(file_no: usize, ns: &mut Namespace) {

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -8,14 +8,14 @@ use super::{
     symtable::Symtable,
     visit_bases, ArrayDimension,
 };
-use crate::parser::{
-    pt,
-    pt::{CodeLocation, OptionalCodeLocation},
-};
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::Signed;
 use num_traits::Zero;
+use solang_parser::{
+    pt,
+    pt::{CodeLocation, OptionalCodeLocation},
+};
 use std::collections::HashMap;
 
 impl Namespace {

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -6,15 +6,15 @@ use super::expression::{
     new, ExprContext, ResolveTo,
 };
 use super::symtable::{LoopScopes, Symtable};
-use crate::parser::pt;
-use crate::parser::pt::CatchClause;
-use crate::parser::pt::CodeLocation;
-use crate::parser::pt::OptionalCodeLocation;
 use crate::sema::builtin;
 use crate::sema::symtable::{VariableInitializer, VariableUsage};
 use crate::sema::unused_variable::{assigned_variable, check_function_call, used_variable};
 use crate::sema::yul::resolve_inline_assembly;
 use crate::sema::Recurse;
+use solang_parser::pt;
+use solang_parser::pt::CatchClause;
+use solang_parser::pt::CodeLocation;
+use solang_parser::pt::OptionalCodeLocation;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 

--- a/src/sema/symtable.rs
+++ b/src/sema/symtable.rs
@@ -5,8 +5,8 @@ use std::str;
 use std::sync::Arc;
 
 use super::ast::{Diagnostic, Namespace, Type};
-use crate::parser::pt;
 use crate::sema::ast::Expression;
+use solang_parser::pt;
 
 #[derive(Clone, Debug)]
 pub struct Variable {

--- a/src/sema/tags.rs
+++ b/src/sema/tags.rs
@@ -1,5 +1,5 @@
 use super::ast::{Diagnostic, Namespace, Parameter, Tag};
-use crate::parser::pt;
+use solang_parser::pt;
 use std::fmt::Write;
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -8,10 +8,10 @@ use super::{
     tags::{parse_doccomments, DocComment},
     SOLANA_SPARSE_ARRAY_SIZE,
 };
-use crate::parser::{pt, pt::CodeLocation};
 use crate::Target;
 use num_bigint::BigInt;
 use num_traits::{One, Zero};
+use solang_parser::{pt, pt::CodeLocation};
 use std::{collections::HashMap, fmt::Write, ops::Mul};
 
 /// List the types which should be resolved later

--- a/src/sema/unused_variable.rs
+++ b/src/sema/unused_variable.rs
@@ -1,8 +1,8 @@
 use crate::ast::EventDecl;
-use crate::parser::pt::{ContractTy, Loc};
 use crate::sema::ast::{Builtin, CallArgs, Diagnostic, Expression, Namespace};
 use crate::sema::symtable::{Symtable, VariableUsage};
 use crate::sema::{ast, contracts::visit_bases, symtable};
+use solang_parser::pt::{ContractTy, Loc};
 
 /// Mark variables as assigned, either in the symbol table (for local variables) or in the
 /// Namespace (for storage variables)

--- a/src/sema/using.rs
+++ b/src/sema/using.rs
@@ -3,8 +3,8 @@ use super::{
     expression::{expression, function_returns, function_type, ExprContext, ResolveTo},
     symtable::Symtable,
 };
-use crate::parser::pt;
-use crate::parser::pt::CodeLocation;
+use solang_parser::pt;
+use solang_parser::pt::CodeLocation;
 use std::collections::HashSet;
 
 /// Resolve a using declaration in either file scope or contract scope

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -9,7 +9,7 @@ use super::{
     symtable::{VariableInitializer, VariableUsage},
     tags::{parse_doccomments, resolve_tags, DocComment},
 };
-use crate::parser::pt::{self, CodeLocation, OptionalCodeLocation};
+use solang_parser::pt::{self, CodeLocation, OptionalCodeLocation};
 
 pub struct DelayedResolveInitializer<'a> {
     var_no: usize,


### PR DESCRIPTION
No reason re-export.

We're exporting far too much right now. This is just a simple start.

See https://docs.rs/solang/latest/solang/ for example