### PR TITLE
Fix mapping inside struct

### DIFF
--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -834,7 +834,7 @@ impl<'a> Binary<'a> {
                         false,
                     )
                     .as_basic_type_enum(),
-                Type::Mapping(..) => unreachable!(),
+                Type::Mapping(..) => self.llvm_type(&ns.storage_type(), ns),
                 Type::Ref(r) => self
                     .llvm_type(r, ns)
                     .ptr_type(AddressSpace::Generic)


### PR DESCRIPTION
Solang crashes when we try to access a mapping that is a member of a struct. There was a bug during code generation, in which we were not considering that struct members can be mappings. This PR should fix a problem raised in #785.