### PR TITLE
Replace curly quotes with ascii single quote

### DIFF
--- a/docs/language/types.rst
+++ b/docs/language/types.rst
@@ -51,7 +51,7 @@ The largest value an ``uint8`` can hold is (2 :superscript:`8`) - 1 = 255. So, t
 
 .. code-block:: none
 
-    literal 300 is too large to fit into type ‘uint8’
+    literal 300 is too large to fit into type 'uint8'
 
 .. tip::
 

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -814,7 +814,7 @@ fn resolve_declarations<'a>(
             ns.diagnostics.push(ast::Diagnostic::error_with_notes(
                     *loc,
                     format!(
-                        "contract should be marked ‘abstract contract’ since it has {} functions with no body",
+                        "contract should be marked 'abstract contract' since it has {} functions with no body",
                         notes.len()
                     ),
                     notes,

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -6292,7 +6292,7 @@ fn method_call_pos_args(
                 diagnostics.push(Diagnostic::error(
                     *loc,
                     format!(
-                        "method '{}' available on type ‘address payable’ not 'address'",
+                        "method '{}' available on type 'address payable' not 'address'",
                         func.name,
                     ),
                 ));
@@ -6406,7 +6406,7 @@ fn method_call_pos_args(
                 _ => {
                     diagnostics.push(Diagnostic::error(
                         args.loc(),
-                        format!("‘{}’ is not fixed length type", args_ty.to_string(ns),),
+                        format!("'{}' is not fixed length type", args_ty.to_string(ns),),
                     ));
 
                     return Err(());
@@ -6958,7 +6958,7 @@ pub fn collect_call_args<'a>(
             _ => {
                 diagnostics.push(Diagnostic::error(
                     block.loc(),
-                    "code block found where list of call arguments expected, like ‘{gas: 5000}’"
+                    "code block found where list of call arguments expected, like '{gas: 5000}'"
                         .to_string(),
                 ));
                 return Err(());
@@ -7139,7 +7139,7 @@ fn parse_call_args(
                     diagnostics.push(Diagnostic::error(
                         arg.loc,
                         format!(
-                            "‘accounts’ not permitted for external calls or constructors on {}",
+                            "'accounts' not permitted for external calls or constructors on {}",
                             ns.target
                         ),
                     ));
@@ -7169,7 +7169,7 @@ fn parse_call_args(
                     diagnostics.push(Diagnostic::error(
                         arg.loc,
                         format!(
-                            "‘accounts’ takes array of AccountMeta, not ‘{}’",
+                            "'accounts' takes array of AccountMeta, not '{}'",
                             expr_ty.to_string(ns)
                         ),
                     ));

--- a/src/sema/functions.rs
+++ b/src/sema/functions.rs
@@ -559,7 +559,7 @@ pub fn contract_function(
             if func.ty == pt::FunctionTy::Fallback {
                 ns.diagnostics.push(Diagnostic::error(
                     func.loc,
-                    format!("{} function must not be declare payable, use ‘receive() external payable’ instead", func.ty),
+                    format!("{} function must not be declare payable, use 'receive() external payable' instead", func.ty),
                 ));
                 return None;
             }
@@ -822,7 +822,7 @@ pub fn resolve_params(
                     if ty.contains_internal_function(ns) {
                         diagnostics.push(Diagnostic::error(
                         p.ty.loc(),
-                        "parameter of type ‘function internal’ not allowed public or external functions".to_string(),
+                        "parameter of type 'function internal' not allowed public or external functions".to_string(),
                     ));
                         success = false;
                     }
@@ -927,7 +927,7 @@ pub fn resolve_returns(
                     if ty.contains_internal_function(ns) {
                         diagnostics.push(Diagnostic::error(
                         r.ty.loc(),
-                        "return type ‘function internal’ not allowed in public or external functions"
+                        "return type 'function internal' not allowed in public or external functions"
                             .to_string(),
                     ));
                         success = false;

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -1004,7 +1004,7 @@ impl Namespace {
                     if !casting {
                         diagnostics.push(Diagnostic::decl_error(
                             id.loc(),
-                            "'payable' cannot be used for type declarations, only casting. use ‘address payable’"
+                            "'payable' cannot be used for type declarations, only casting. use 'address payable'"
                                 .to_string(),
                         ));
                         return Err(());

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -2085,7 +2085,7 @@ fn try_catch(
                         diagnostics.push(Diagnostic::error(
                             param.ty.loc(),
                             format!(
-                                "catch can only take ‘bytes memory’, not '{}'",
+                                "catch can only take 'bytes memory', not '{}'",
                                 catch_ty.to_string(ns)
                             ),
                         ));
@@ -2154,7 +2154,7 @@ fn try_catch(
                     ns.diagnostics.push(Diagnostic::error(
                         param.ty.loc(),
                         format!(
-                            "catch Error(...) can only take ‘string memory’, not '{}'",
+                            "catch Error(...) can only take 'string memory', not '{}'",
                             error_ty.to_string(ns)
                         ),
                     ));

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -175,7 +175,7 @@ fn type_decl(
     ) {
         ns.diagnostics.push(Diagnostic::error(
             def.ty.loc(),
-            format!("’{}’ is not an elementary value type", ty.to_string(ns)),
+            format!("'{}' is not an elementary value type", ty.to_string(ns)),
         ));
         return;
     }

--- a/tests/contract_testcases/solana/type_decl_broken.dot
+++ b/tests/contract_testcases/solana/type_decl_broken.dot
@@ -4,7 +4,7 @@ strict digraph "tests/contract_testcases/solana/type_decl_broken.sol" {
 	GlobalFoo_4 [label="name:GlobalFoo ty:address payable\ntests/contract_testcases/solana/type_decl_broken.sol:1:1-34"]
 	Value [label="name:Value ty:uint128\ncontract: c\ntests/contract_testcases/solana/type_decl_broken.sol:9:2-23"]
 	contract [label="contract c\ntests/contract_testcases/solana/type_decl_broken.sol:2:1-19:2"]
-	diagnostic [label="’int256[2]’ is not an elementary value type\nlevel Error\ntests/contract_testcases/solana/type_decl_broken.sol:5:14-20"]
+	diagnostic [label="'int256[2]' is not an elementary value type\nlevel Error\ntests/contract_testcases/solana/type_decl_broken.sol:5:14-20"]
 	diagnostic_11 [label="foo is already defined as a struct\nlevel Error\ntests/contract_testcases/solana/type_decl_broken.sol:6:7-10"]
 	note [label="location of previous definition\ntests/contract_testcases/solana/type_decl_broken.sol:4:9-12"]
 	diagnostic_13 [label="GlobalFoo is already defined as an user type\nlevel Warning\ntests/contract_testcases/solana/type_decl_broken.sol:7:9-18"]

--- a/tests/contract_testcases/substrate/calls/payable_functions_02.dot
+++ b/tests/contract_testcases/substrate/calls/payable_functions_02.dot
@@ -1,7 +1,7 @@
 strict digraph "tests/contract_testcases/substrate/calls/payable_functions_02.sol" {
 	contract [label="contract c\ntests/contract_testcases/substrate/calls/payable_functions_02.sol:2:9-6:10"]
 	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/calls/payable_functions_02.sol:2:9-6:10"]
-	diagnostic_5 [label="fallback function must not be declare payable, use ‘receive() external payable’ instead\nlevel Error\ntests/contract_testcases/substrate/calls/payable_functions_02.sol:3:13-40"]
+	diagnostic_5 [label="fallback function must not be declare payable, use 'receive() external payable' instead\nlevel Error\ntests/contract_testcases/substrate/calls/payable_functions_02.sol:3:13-40"]
 	contracts -> contract
 	diagnostics -> diagnostic [label="Debug"]
 	diagnostics -> diagnostic_5 [label="Error"]

--- a/tests/contract_testcases/substrate/calls/try_catch_external_calls_02.dot
+++ b/tests/contract_testcases/substrate/calls/try_catch_external_calls_02.dot
@@ -9,7 +9,7 @@ strict digraph "tests/contract_testcases/substrate/calls/try_catch_external_call
 	number_literal [label="int32 literal: 102\ntests/contract_testcases/substrate/calls/try_catch_external_calls_02.sol:17:25-28"]
 	bool_literal [label="bool literal: true\ntests/contract_testcases/substrate/calls/try_catch_external_calls_02.sol:17:30-34"]
 	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/calls/try_catch_external_calls_02.sol:2:9-13:10"]
-	diagnostic_12 [label="catch can only take ‘bytes memory’, not 'string'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_02.sol:8:26-32"]
+	diagnostic_12 [label="catch can only take 'bytes memory', not 'string'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_02.sol:8:26-32"]
 	diagnostic_13 [label="found contract 'other'\nlevel Debug\ntests/contract_testcases/substrate/calls/try_catch_external_calls_02.sol:15:9-19:10"]
 	contracts -> contract
 	contract -> test [label="function"]

--- a/tests/contract_testcases/substrate/calls/try_catch_external_calls_03.dot
+++ b/tests/contract_testcases/substrate/calls/try_catch_external_calls_03.dot
@@ -11,7 +11,7 @@ strict digraph "tests/contract_testcases/substrate/calls/try_catch_external_call
 	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/calls/try_catch_external_calls_03.sol:2:9-13:10"]
 	diagnostic_12 [label="x is already declared\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_03.sol:6:45-46"]
 	note [label="location of previous declaration\ntests/contract_testcases/substrate/calls/try_catch_external_calls_03.sol:5:23-24"]
-	diagnostic_14 [label="catch can only take ‘bytes memory’, not 'string'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_03.sol:8:26-32"]
+	diagnostic_14 [label="catch can only take 'bytes memory', not 'string'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_03.sol:8:26-32"]
 	diagnostic_15 [label="found contract 'other'\nlevel Debug\ntests/contract_testcases/substrate/calls/try_catch_external_calls_03.sol:15:9-19:10"]
 	contracts -> contract
 	contract -> test [label="function"]

--- a/tests/contract_testcases/substrate/calls/try_catch_external_calls_05.dot
+++ b/tests/contract_testcases/substrate/calls/try_catch_external_calls_05.dot
@@ -9,9 +9,9 @@ strict digraph "tests/contract_testcases/substrate/calls/try_catch_external_call
 	number_literal [label="int32 literal: 102\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:21:25-28"]
 	bool_literal [label="bool literal: true\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:21:30-34"]
 	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:2:9-17:10"]
-	diagnostic_12 [label="catch Error(...) can only take ‘string memory’, not 'bytes'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:8:31-36"]
+	diagnostic_12 [label="catch Error(...) can only take 'string memory', not 'bytes'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:8:31-36"]
 	diagnostic_13 [label="catch Panic(...) can only take 'uint256', not 'uint128'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:10:31-38"]
-	diagnostic_14 [label="catch can only take ‘bytes memory’, not 'string'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:12:26-32"]
+	diagnostic_14 [label="catch can only take 'bytes memory', not 'string'\nlevel Error\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:12:26-32"]
 	diagnostic_15 [label="found contract 'other'\nlevel Debug\ntests/contract_testcases/substrate/calls/try_catch_external_calls_05.sol:19:9-23:10"]
 	contracts -> contract
 	contract -> test [label="function"]

--- a/tests/contract_testcases/substrate/function_types/decls_06.dot
+++ b/tests/contract_testcases/substrate/function_types/decls_06.dot
@@ -1,7 +1,7 @@
 strict digraph "tests/contract_testcases/substrate/function_types/decls_06.sol" {
 	contract [label="contract test\ntests/contract_testcases/substrate/function_types/decls_06.sol:1:1-4:10"]
 	diagnostic [label="found contract 'test'\nlevel Debug\ntests/contract_testcases/substrate/function_types/decls_06.sol:1:1-4:10"]
-	diagnostic_5 [label="parameter of type ‘function internal’ not allowed public or external functions\nlevel Error\ntests/contract_testcases/substrate/function_types/decls_06.sol:2:26-72"]
+	diagnostic_5 [label="parameter of type 'function internal' not allowed public or external functions\nlevel Error\ntests/contract_testcases/substrate/function_types/decls_06.sol:2:26-72"]
 	contracts -> contract
 	diagnostics -> diagnostic [label="Debug"]
 	diagnostics -> diagnostic_5 [label="Error"]

--- a/tests/contract_testcases/substrate/function_types/decls_07.dot
+++ b/tests/contract_testcases/substrate/function_types/decls_07.dot
@@ -1,7 +1,7 @@
 strict digraph "tests/contract_testcases/substrate/function_types/decls_07.sol" {
 	contract [label="contract test\ntests/contract_testcases/substrate/function_types/decls_07.sol:1:1-4:10"]
 	diagnostic [label="found contract 'test'\nlevel Debug\ntests/contract_testcases/substrate/function_types/decls_07.sol:1:1-4:10"]
-	diagnostic_5 [label="return type ‘function internal’ not allowed in public or external functions\nlevel Error\ntests/contract_testcases/substrate/function_types/decls_07.sol:2:44-90"]
+	diagnostic_5 [label="return type 'function internal' not allowed in public or external functions\nlevel Error\ntests/contract_testcases/substrate/function_types/decls_07.sol:2:44-90"]
 	contracts -> contract
 	diagnostics -> diagnostic [label="Debug"]
 	diagnostics -> diagnostic_5 [label="Error"]

--- a/tests/contract_testcases/substrate/functions/payable_03.dot
+++ b/tests/contract_testcases/substrate/functions/payable_03.dot
@@ -4,7 +4,7 @@ strict digraph "tests/contract_testcases/substrate/functions/payable_03.sol" {
 	number_literal [label="int32 literal: 0\ntests/contract_testcases/substrate/functions/payable_03.sol:5:23-24"]
 	diagnostic [label="pragma 'solidity' is ignored\nlevel Debug\ntests/contract_testcases/substrate/functions/payable_03.sol:2:9-26"]
 	diagnostic_7 [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/functions/payable_03.sol:4:9-10:10"]
-	diagnostic_8 [label="fallback function must not be declare payable, use ‘receive() external payable’ instead\nlevel Error\ntests/contract_testcases/substrate/functions/payable_03.sol:7:13-40"]
+	diagnostic_8 [label="fallback function must not be declare payable, use 'receive() external payable' instead\nlevel Error\ntests/contract_testcases/substrate/functions/payable_03.sol:7:13-40"]
 	contracts -> contract
 	contract -> var [label="variable"]
 	var -> number_literal [label="initializer"]

--- a/tests/contract_testcases/substrate/inheritance/test_virtual_02.dot
+++ b/tests/contract_testcases/substrate/inheritance/test_virtual_02.dot
@@ -2,7 +2,7 @@ strict digraph "tests/contract_testcases/substrate/inheritance/test_virtual_02.s
 	contract [label="contract c\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:2:9-5:10"]
 	test [label="function test\ncontract: c\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:3:13-43\nsignature test()\nvisibility public\nmutability nonpayable\nvirtual"]
 	test2 [label="function test2\ncontract: c\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:4:13-44\nsignature test2()\nvisibility public\nmutability nonpayable\nvirtual"]
-	diagnostic [label="contract should be marked ‘abstract contract’ since it has 2 functions with no body\nlevel Error\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:2:9-17"]
+	diagnostic [label="contract should be marked 'abstract contract' since it has 2 functions with no body\nlevel Error\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:2:9-17"]
 	note [label="location of function 'test' with no body\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:3:13-43"]
 	note_7 [label="location of function 'test2' with no body\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:4:13-44"]
 	diagnostic_8 [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/inheritance/test_virtual_02.sol:2:9-5:10"]

--- a/tests/contract_testcases/substrate/primitives/address_payable_type_06.dot
+++ b/tests/contract_testcases/substrate/primitives/address_payable_type_06.dot
@@ -1,7 +1,7 @@
 strict digraph "tests/contract_testcases/substrate/primitives/address_payable_type_06.sol" {
 	contract [label="contract c\ntests/contract_testcases/substrate/primitives/address_payable_type_06.sol:2:9-6:10"]
 	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/primitives/address_payable_type_06.sol:2:9-6:10"]
-	diagnostic_5 [label="'payable' cannot be used for type declarations, only casting. use ‘address payable’\nlevel Error\ntests/contract_testcases/substrate/primitives/address_payable_type_06.sol:3:27-34"]
+	diagnostic_5 [label="'payable' cannot be used for type declarations, only casting. use 'address payable'\nlevel Error\ntests/contract_testcases/substrate/primitives/address_payable_type_06.sol:3:27-34"]
 	contracts -> contract
 	diagnostics -> diagnostic [label="Debug"]
 	diagnostics -> diagnostic_5 [label="Error"]

--- a/tests/contract_testcases/substrate/value/external_call_value_05.dot
+++ b/tests/contract_testcases/substrate/value/external_call_value_05.dot
@@ -9,7 +9,7 @@ strict digraph "tests/contract_testcases/substrate/value/external_call_value_05.
 	var_decl [label="variable decl contract a f\ntests/contract_testcases/substrate/value/external_call_value_05.sol:12:17-30"]
 	constructor [label="constructor contract a\ntests/contract_testcases/substrate/value/external_call_value_05.sol:12:23-30"]
 	diagnostic [label="found contract 'a'\nlevel Debug\ntests/contract_testcases/substrate/value/external_call_value_05.sol:2:9-6:10"]
-	diagnostic_12 [label="code block found where list of call arguments expected, like ‘{gas: 5000}’\nlevel Error\ntests/contract_testcases/substrate/value/external_call_value_05.sol:4:33-45"]
+	diagnostic_12 [label="code block found where list of call arguments expected, like '{gas: 5000}'\nlevel Error\ntests/contract_testcases/substrate/value/external_call_value_05.sol:4:33-45"]
 	diagnostic_13 [label="found contract 'b'\nlevel Debug\ntests/contract_testcases/substrate/value/external_call_value_05.sol:8:9-14:10"]
 	contracts -> contract
 	contract -> test [label="function"]


### PR DESCRIPTION
We use ascii quotes in diagnostics, these ones were missed.

Signed-off-by: Sean Young <sean@mess.org>