### PR TITLE
Build multiarch containers on linux-arm64, and only on main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,8 @@ jobs:
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-linux-arm64.tar.xz ./llvm13.0/
+      # compression takes a long time on linux-arm64, use multithreaded compression
+    - run: tar cf ./llvm13.0-linux-arm64.tar.xz -I 'xz -T 0' ./llvm13.0/
     - name: Upload llvm
       uses: svenstaro/upload-release-action@v2
       with:
@@ -243,8 +244,7 @@ jobs:
 
   container-multiarch:
     name: Multiarch Container Image
-    runs-on: macos-arm
-    needs: [mac-arm, mac-intel]
+    runs-on: linux-arm64
     if: ${{ github.repository_owner == 'hyperledger-labs' }}
     steps:
     - name: Checkout sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,22 +181,18 @@ jobs:
 
   image-multiarch:
     name: Multiarch Container Image
-    runs-on: macos-arm
-    needs: [mac-arm, mac-intel]
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    runs-on: linux-arm64
+    # Don't run this on pull requests, it takes 28 minutes and only has one runner
+    if: ${{ github.repository_owner == 'hyperledger-labs' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
       with:
         # Make sure "git describe --tags" works for solang --version
         fetch-depth: 0
-    - run: echo "::set-output name=push::--push"
-      id: push
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     - run: |
         echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-        docker buildx build . \
-          ${{steps.push.outputs.push}} \
+        docker buildx build . --push \
           -t ghcr.io/${GITHUB_REPOSITORY}:latest \
           --platform linux/arm64,linux/amd64 \
           --label org.opencontainers.image.description="Solidity Compiler for Solana, Substrate, and ewasm version $(git describe --tags)"
@@ -204,7 +200,7 @@ jobs:
   image:
     name: Container Image
     runs-on: ubuntu-20.04
-    if: ${{ github.repository_owner != 'hyperledger-labs' }}
+    if: ${{ github.repository_owner != 'hyperledger-labs' || github.ref != 'refs/heads/main' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2


### PR DESCRIPTION
The multiarch container build on macos is failing often, try on
linux-arm64 in stead.

Signed-off-by: Sean Young <sean@mess.org>