### PR TITLE
Do not build clang for the release library

### DIFF
--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -28,7 +28,7 @@ jobs:
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
-        -DLLVM_ENABLE_PROJECTS='clang;lld'
+        -DLLVM_ENABLE_PROJECTS='lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
       working-directory: ./llvm-project/
@@ -55,7 +55,7 @@ jobs:
     - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
-        -DLLVM_ENABLE_PROJECTS='clang;lld'
+        -DLLVM_ENABLE_PROJECTS='lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
       working-directory: ./llvm-project/
@@ -84,7 +84,7 @@ jobs:
 #      uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
-        -DLLVM_ENABLE_PROJECTS='clang;lld'
+        -DLLVM_ENABLE_PROJECTS='lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
       working-directory: ./llvm-project/
@@ -114,7 +114,7 @@ jobs:
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
-        -DLLVM_ENABLE_PROJECTS='clang;lld'
+        -DLLVM_ENABLE_PROJECTS='lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
       working-directory: ./llvm-project/
@@ -151,7 +151,7 @@ jobs:
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
-        '-DLLVM_ENABLE_PROJECTS=clang;lld'
+        '-DLLVM_ENABLE_PROJECTS=lld'
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=C:/llvm13.0 llvm
       working-directory: C:\llvm-project
     - run: cmake --build . --target install


### PR DESCRIPTION
There is no need to build clang for the release LLVM binaries. We can compile and run Solang without clang. I was able to reduce the Linux x86 LLVM tarball from 305 MB to 170 MB.