### PR TITLE
Ensure that parenthesis are added to the parse tree

### DIFF
--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -388,6 +388,7 @@ pub enum Expression {
         Option<Box<Expression>>,
         Option<Box<Expression>>,
     ),
+    Parenthesis(Loc, Box<Expression>),
     MemberAccess(Loc, Box<Expression>, Identifier),
     FunctionCall(Loc, Box<Expression>, Vec<Expression>),
     FunctionCallBlock(Loc, Box<Expression>, Box<Statement>),
@@ -451,6 +452,7 @@ impl CodeLocation for Expression {
             Expression::PostIncrement(loc, _)
             | Expression::PostDecrement(loc, _)
             | Expression::New(loc, _)
+            | Expression::Parenthesis(loc, _)
             | Expression::ArraySubscript(loc, ..)
             | Expression::ArraySlice(loc, ..)
             | Expression::MemberAccess(loc, ..)
@@ -518,6 +520,16 @@ impl Display for Expression {
             Expression::Variable(id) => write!(f, "{}", id.name),
             Expression::MemberAccess(_, e, id) => write!(f, "{}.{}", e, id.name),
             _ => unimplemented!(),
+        }
+    }
+}
+
+impl Expression {
+    pub fn remove_parenthesis(&self) -> &Expression {
+        if let Expression::Parenthesis(_, expr) = self {
+            expr
+        } else {
+            self
         }
     }
 }

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -460,7 +460,7 @@ NoFunctionTyPrecedence0: Expression = {
         if a.len() == 1 {
             if let Some(Parameter{ ty, storage: None, name: None, .. }) = &a[0].1 {
                 // this means "(" Expression ")"
-                return ty.clone();
+                return Expression::Parenthesis(ty.loc(), Box::new(ty.clone()));
             }
         }
 

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1086,7 +1086,7 @@ pub fn resolve_namespace_call(
                     context.file_no,
                     context.contract_no,
                     false,
-                    &args[1],
+                    args[1].remove_parenthesis(),
                     diagnostics,
                 )?;
 


### PR DESCRIPTION
forge fmt uses the solang-parser crate for formatting solidity code.
However, currently parenthesis are not added to the parse tree, which
makes reconstructing the source text difficult.

This means that the parse tree for `(1 + 2) * 3` contains an explicit
node for the parenthesis around the expression `1 + 2`.

See https://discord.com/channels/900503503162724452/975868842125455390/990812142049566770

Signed-off-by: Sean Young <sean@mess.org>