### PR TITLE
Dirty tracker should track all variables up to point where it is created

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -958,7 +958,6 @@ fn expr_or(
     opt: &Options,
 ) -> Expression {
     let l = expression(left, cfg, contract_no, func, ns, vartab, opt);
-    vartab.new_dirty_tracker(ns.next_id);
     let pos = vartab.temp(
         &pt::Identifier {
             name: "or".to_owned(),
@@ -966,6 +965,7 @@ fn expr_or(
         },
         &Type::Bool,
     );
+    vartab.new_dirty_tracker();
     let right_side = cfg.new_basic_block("or_right_side".to_string());
     let end_or = cfg.new_basic_block("or_end".to_string());
     cfg.add(
@@ -996,9 +996,7 @@ fn expr_or(
     );
     cfg.add(vartab, Instr::Branch { block: end_or });
     cfg.set_basic_block(end_or);
-    let mut phis = vartab.pop_dirty_tracker();
-    phis.insert(pos);
-    cfg.set_phis(end_or, phis);
+    cfg.set_phis(end_or, vartab.pop_dirty_tracker());
     Expression::Variable(*loc, Type::Bool, pos)
 }
 
@@ -1014,7 +1012,6 @@ fn and(
     opt: &Options,
 ) -> Expression {
     let l = expression(left, cfg, contract_no, func, ns, vartab, opt);
-    vartab.new_dirty_tracker(ns.next_id);
     let pos = vartab.temp(
         &pt::Identifier {
             name: "and".to_owned(),
@@ -1022,6 +1019,7 @@ fn and(
         },
         &Type::Bool,
     );
+    vartab.new_dirty_tracker();
     let right_side = cfg.new_basic_block("and_right_side".to_string());
     let end_and = cfg.new_basic_block("and_end".to_string());
     cfg.add(
@@ -1052,9 +1050,7 @@ fn and(
     );
     cfg.add(vartab, Instr::Branch { block: end_and });
     cfg.set_basic_block(end_and);
-    let mut phis = vartab.pop_dirty_tracker();
-    phis.insert(pos);
-    cfg.set_phis(end_and, phis);
+    cfg.set_phis(end_and, vartab.pop_dirty_tracker());
     Expression::Variable(*loc, Type::Bool, pos)
 }
 
@@ -1798,8 +1794,6 @@ fn ternary(
 ) -> Expression {
     let cond = expression(cond, cfg, contract_no, func, ns, vartab, opt);
 
-    vartab.new_dirty_tracker(ns.next_id);
-
     let pos = vartab.temp(
         &pt::Identifier {
             name: "ternary_result".to_owned(),
@@ -1807,6 +1801,8 @@ fn ternary(
         },
         ty,
     );
+
+    vartab.new_dirty_tracker();
 
     let left_block = cfg.new_basic_block("left_value".to_string());
     let right_block = cfg.new_basic_block("right_value".to_string());
@@ -1853,9 +1849,7 @@ fn ternary(
 
     cfg.set_basic_block(done_block);
 
-    let mut phis = vartab.pop_dirty_tracker();
-    phis.insert(pos);
-    cfg.set_phis(done_block, phis);
+    cfg.set_phis(done_block, vartab.pop_dirty_tracker());
 
     Expression::Variable(*loc, ty.clone(), pos)
 }

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -195,7 +195,7 @@ pub(crate) fn statement(
 
             cfg.set_basic_block(body);
 
-            vartab.new_dirty_tracker(ns.next_id);
+            vartab.new_dirty_tracker();
             loops.new_scope(end, cond);
 
             let mut body_reachable = true;
@@ -263,7 +263,7 @@ pub(crate) fn statement(
 
             cfg.set_basic_block(body);
 
-            vartab.new_dirty_tracker(ns.next_id);
+            vartab.new_dirty_tracker();
             loops.new_scope(end, cond);
 
             let mut body_reachable = true;
@@ -335,7 +335,7 @@ pub(crate) fn statement(
                 },
             );
 
-            vartab.new_dirty_tracker(ns.next_id);
+            vartab.new_dirty_tracker();
 
             let mut body_reachable = true;
 
@@ -443,7 +443,7 @@ pub(crate) fn statement(
             // continue goes to next
             loops.new_scope(end_block, next_block);
 
-            vartab.new_dirty_tracker(ns.next_id);
+            vartab.new_dirty_tracker();
 
             let mut body_reachable = true;
 
@@ -662,7 +662,7 @@ fn if_then(
 
     cfg.set_basic_block(then);
 
-    vartab.new_dirty_tracker(ns.next_id);
+    vartab.new_dirty_tracker();
 
     let mut reachable = true;
 
@@ -725,7 +725,7 @@ fn if_then_else(
     // then
     cfg.set_basic_block(then);
 
-    vartab.new_dirty_tracker(ns.next_id);
+    vartab.new_dirty_tracker();
 
     let mut then_reachable = true;
 
@@ -809,7 +809,7 @@ fn returns(
                 },
             );
 
-            vartab.new_dirty_tracker(ns.next_id);
+            vartab.new_dirty_tracker();
 
             cfg.set_basic_block(left_block);
             returns(left, cfg, contract_no, func, ns, vartab, opt);
@@ -882,7 +882,7 @@ fn destructure(
             },
         );
 
-        vartab.new_dirty_tracker(ns.next_id);
+        vartab.new_dirty_tracker();
 
         cfg.set_basic_block(left_block);
 
@@ -1218,7 +1218,7 @@ fn try_catch(
         _ => unreachable!(),
     }
 
-    vartab.new_dirty_tracker(ns.next_id);
+    vartab.new_dirty_tracker();
 
     let mut finally_reachable = true;
 

--- a/src/codegen/vartable.rs
+++ b/src/codegen/vartable.rs
@@ -161,9 +161,11 @@ impl Vartable {
         }
     }
 
-    pub fn new_dirty_tracker(&mut self, lim: usize) {
+    /// Track dirty variables for phi instructions.
+    /// Any variable created after this command will not be considered dirty.
+    pub fn new_dirty_tracker(&mut self) {
         self.dirty.push(DirtyTracker {
-            lim,
+            lim: self.next_id,
             set: BTreeSet::new(),
         });
     }

--- a/src/codegen/yul/statements.rs
+++ b/src/codegen/yul/statements.rs
@@ -340,7 +340,7 @@ fn process_if_block(
     );
 
     cfg.set_basic_block(then);
-    vartab.new_dirty_tracker(ns.next_id);
+    vartab.new_dirty_tracker();
 
     for stmt in &block.body {
         statement(stmt, contract_no, loops, ns, cfg, vartab, early_return, opt);
@@ -413,7 +413,7 @@ fn process_for_block(
 
     cfg.set_basic_block(body_block);
     loops.new_scope(end_block, next_block);
-    vartab.new_dirty_tracker(ns.next_id);
+    vartab.new_dirty_tracker();
 
     for stmt in &execution_block.body {
         statement(stmt, contract_no, loops, ns, cfg, vartab, early_return, opt);


### PR DESCRIPTION
Our `Vartable` tracks variables that need Phi instructions when generating LLVM IR. The way it was designed, our dirty tracker was only considering variables whose number was less than `ns.next_id`, ignoring temporaries created during code generation. This leads to an incorrect management of Phi instructions.

By considering the limit for dirty tracker as the `vartable.next_id`, we account for all variables created up to the point where we create a new dirty tracker. This allows us to remove the manual insertion of temporaries to the phis set.