### PR TITLE
Improve yul tests coverage

### DIFF
--- a/tests/codegen_testcases/yul/ewasm_builtin.sol
+++ b/tests/codegen_testcases/yul/ewasm_builtin.sol
@@ -44,6 +44,9 @@ contract Testing {
             // CHECK: ty:uint256 %m = (zext uint256 (builtin GasLimit ()))
             let m := gaslimit()
 
+            // CHECK: ty:uint256 %n = (zext uint256 (builtin ExtCodeSize (address((trunc uint160 %b)))))
+            let n := extcodesize(b)
+
             // CHECK: assert-failure
             invalid()
         }


### PR DESCRIPTION
PR #891 introduced a new Yul builtin, but it did not include code generation tests for it, decreasing our code coverage. Code generation tests should test all possible code paths.

This PR includes `extcodesize` to the code generation tests.