### PR TITLE
Parse tree should specify if string literal was unicode"foo"

### DIFF
--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -482,7 +482,7 @@ Unit: Unit = {
 
 StringLiteral: StringLiteral = {
     <l:@L> <s:string> <r:@R> => {
-        StringLiteral{ loc: Loc::File(file_no, l, r), string: s.to_string() }
+        StringLiteral{ loc: Loc::File(file_no, l, r), string: s.1.to_string() }
     }
 }
 
@@ -971,7 +971,7 @@ extern {
 
     enum Token<'input> {
         identifier => Token::Identifier(<&'input str>),
-        string => Token::StringLiteral(<&'input str>),
+        string => Token::StringLiteral(<bool>, <&'input str>),
         hexstring => Token::HexLiteral(<&'input str>),
         address => Token::AddressLiteral(<&'input str>),
         number => Token::Number(<&'input str>, <&'input str>),


### PR DESCRIPTION
When trying to re-create the original source code from the parse tree,
we should know whether the string was `unicode"foo"` or simply `"foo"`.

Signed-off-by: Sean Young <sean@mess.org>