### PR TITLE
solang version information missing when built outside of git

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -47,8 +47,13 @@ fn main() {
         .args(&["describe", "--tags"])
         .output()
         .unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    let solang_version = if output.stdout.is_empty() {
+        format!("v{}", env!("CARGO_PKG_VERSION"))
+    } else {
+        String::from_utf8(output.stdout).unwrap()
+    };
+
+    println!("cargo:rustc-env=SOLANG_VERSION={}", solang_version);
 
     // Make sure we have an 8MiB stack on Windows. Windows defaults to a 1MB
     // stack, which is not big enough for debug builds

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -1139,7 +1139,10 @@ impl LanguageServer for SolangServer {
         self.client
             .log_message(
                 MessageType::INFO,
-                format!("solang language server {} initialized", env!("GIT_HASH")),
+                format!(
+                    "solang language server {} initialized",
+                    env!("SOLANG_VERSION")
+                ),
             )
             .await;
     }

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -48,7 +48,7 @@ pub struct JsonResult {
 
 fn main() {
     let matches = Command::new("solang")
-        .version(&*format!("version {}", env!("GIT_HASH")))
+        .version(&*format!("version {}", env!("SOLANG_VERSION")))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .arg(
@@ -235,7 +235,7 @@ fn main() {
     };
 
     if verbose {
-        eprintln!("info: Solang version {}", env!("GIT_HASH"));
+        eprintln!("info: Solang version {}", env!("SOLANG_VERSION"));
     }
 
     let math_overflow_check = matches.contains_id("MATHOVERFLOW");


### PR DESCRIPTION
The build.rs uses `git describe --tags` to get the version for `solang
--version`. When built outside of git, use the crate version.

This affects the brew build of solang.

Signed-off-by: Sean Young <sean@mess.org>