### PR TITLE
Update seal debug message

### DIFF
--- a/integration/substrate/UniswapV2ERC20.sol
+++ b/integration/substrate/UniswapV2ERC20.sol
@@ -35,7 +35,8 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
     }
 
     function _mint(address to, uint value) internal {
-        print("_mint {} {}".format(to, value));
+        // Disabled for now, see #911
+        // print("_mint {} {}".format(to, value));
         totalSupply = totalSupply.add(value);
         balanceOf[to] = balanceOf[to].add(value);
         emit Transfer(address(0), to, value);

--- a/integration/substrate/balances.sol
+++ b/integration/substrate/balances.sol
@@ -14,6 +14,7 @@ contract balances {
 	function pay_me() public payable {
 		uint128 v = msg.value;
 
-		print("Thank you very much for {}".format(v));
+		// Disabled for now, see #911
+		// print("Thank you very much for {}".format(v));
 	}
 }

--- a/integration/substrate/issue666.sol
+++ b/integration/substrate/issue666.sol
@@ -1,6 +1,7 @@
 contract Flip {
     function flip () pure public {
-	print("flip");
+	// Disabled for now, see #911
+	//print("flip");
     }
 }
 

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -89,7 +89,7 @@ impl SubstrateTarget {
             "seal_hash_blake2_128",
             "seal_hash_blake2_256",
             "seal_return",
-            "seal_println",
+            "seal_debug_message",
             "seal_instantiate",
             "seal_call",
             "seal_value_transferred",
@@ -301,7 +301,7 @@ impl SubstrateTarget {
         );
 
         binary.module.add_function(
-            "seal_println",
+            "seal_debug_message",
             binary.context.void_type().fn_type(
                 &[
                     u8_ptr,  // string_ptr
@@ -3391,7 +3391,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
 
     fn print(&self, binary: &Binary, string_ptr: PointerValue, string_len: IntValue) {
         binary.builder.build_call(
-            binary.module.get_function("seal_println").unwrap(),
+            binary.module.get_function("seal_debug_message").unwrap(),
             &[string_ptr.into(), string_len.into()],
             "",
         );

--- a/src/emit/substrate.rs
+++ b/src/emit/substrate.rs
@@ -302,7 +302,7 @@ impl SubstrateTarget {
 
         binary.module.add_function(
             "seal_debug_message",
-            binary.context.void_type().fn_type(
+            binary.context.i32_type().fn_type(
                 &[
                     u8_ptr,  // string_ptr
                     u32_val, // string_len


### PR DESCRIPTION
The `seal_println` runtime function was superseded by `seal_debug_message` in Substrate v3.0. This PR makes the `print("...")` builtin work again for current Substrate versions.
