### PR TITLE
Support length for storage strings

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -356,7 +356,7 @@ pub fn expression(
                     .unwrap();
                     expression(&ast_expr, cfg, contract_no, func, ns, vartab, opt)
                 }
-                Type::DynamicBytes => Expression::StorageArrayLength {
+                Type::DynamicBytes | Type::String => Expression::StorageArrayLength {
                     loc: *loc,
                     ty: ty.clone(),
                     array: Box::new(array),

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -4638,7 +4638,7 @@ fn member_access(
                     });
                 }
             }
-            Type::Bytes(_) | Type::DynamicBytes => {
+            Type::Bytes(_) | Type::DynamicBytes | Type::String => {
                 if id.name == "length" {
                     let elem_ty = expr.ty().storage_array_elem().deref_into();
 

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -971,7 +971,7 @@ impl Type {
     pub fn storage_array_elem(&self) -> Self {
         match self {
             Type::Mapping(_, v) => Type::StorageRef(false, v.clone()),
-            Type::DynamicBytes => Type::Bytes(1),
+            Type::DynamicBytes | Type::String => Type::Bytes(1),
             Type::Array(ty, dim) if dim.len() > 1 => Type::StorageRef(
                 false,
                 Box::new(Type::Array(ty.clone(), dim[..dim.len() - 1].to_vec())),

--- a/tests/solana_tests/mod.rs
+++ b/tests/solana_tests/mod.rs
@@ -20,6 +20,7 @@ mod returns;
 mod signature_verify;
 mod simple;
 mod storage;
+mod strings;
 mod unused_variable_elimination;
 mod using;
 mod vector_to_slice;

--- a/tests/solana_tests/strings.rs
+++ b/tests/solana_tests/strings.rs
@@ -1,0 +1,32 @@
+use crate::build_solidity;
+use ethabi::ethereum_types::U256;
+use ethabi::Token;
+
+#[test]
+fn storage_string_length() {
+    let mut vm = build_solidity(
+        r#"
+    contract Testing {
+        string st;
+        function setString(string input) public {
+            st = input;
+        }
+
+        function getLength() public view returns (uint32) {
+            return st.length;
+        }
+    }
+    "#,
+    );
+    vm.constructor("Testing", &[]);
+
+    let _ = vm.function(
+        "setString",
+        &[Token::String("coffee_tastes_good".to_string())],
+        &[],
+        None,
+    );
+    let returns = vm.function("getLength", &[], &[], None);
+
+    assert_eq!(returns[0], Token::Uint(U256::from(18)));
+}


### PR DESCRIPTION
Add support for retrieving the length of a string saved in storage. I implemented this to help me debug an issue with Borsh Encoding.

Solc does not support this.