### PR TITLE
Fix vscode extension build

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -96,13 +96,19 @@
 		"@types/node": "^12.12.0",
 		"@types/node-fetch": "^2.5.8",
 		"@types/semver": "^7.3.8",
-		"@types/vscode": "^1.43.0",
+		"@types/vscode": "^1.43.0 <1.69.0",
 		"@typescript-eslint/eslint-plugin": "^4.15.0",
 		"@typescript-eslint/parser": "^4.15.0",
 		"eslint": ">=7.0.0",
 		"glob": "^7.1.6",
 		"mocha": "^7.1.2",
 		"typescript": "^3.8.3",
-		"vscode-test": "^1.3.0"
+		"@vscode/test-electron": "^1.6.2"
+	},
+	"__metadata": {
+		"id": "3134b20d-911a-4418-a461-3f2380f4a1c2",
+		"publisherDisplayName": "solang.io",
+		"publisherId": "6c1a8c6d-5493-4493-81d2-e899244f0def",
+		"isPreReleaseVersion": false
 	}
 }

--- a/vscode/src/test/runTest.ts
+++ b/vscode/src/test/runTest.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { runTests } from 'vscode-test';
+import { runTests } from '@vscode/test-electron';
 
 async function main() {
   try {


### PR DESCRIPTION
Looks like @types/vscode 1.69.0 is broken. Do not use this version.

vscode-test has been renamed to @vscode/test-electron, update this too.

Signed-off-by: Sean Young <sean@mess.org>