### PR TITLE
Fix load of vector of strings from storage on Solana

### DIFF
--- a/src/emit/solana.rs
+++ b/src/emit/solana.rs
@@ -2263,11 +2263,9 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                         .i32_type()
                         .const_int(dim[0].as_ref().unwrap().to_u64().unwrap(), false);
                 } else {
+                    let llvm_elem_ty = binary.llvm_field_ty(elem_ty, ns);
                     let elem_size = binary.builder.build_int_truncate(
-                        binary
-                            .context
-                            .i32_type()
-                            .const_int(elem_ty.size_of(ns).to_u64().unwrap(), false),
+                        llvm_elem_ty.size_of().unwrap(),
                         binary.context.i32_type(),
                         "size_of",
                     );

--- a/tests/solana_tests/strings.rs
+++ b/tests/solana_tests/strings.rs
@@ -30,3 +30,41 @@ fn storage_string_length() {
 
     assert_eq!(returns[0], Token::Uint(U256::from(18)));
 }
+
+#[test]
+fn load_string_vector() {
+    let mut vm = build_solidity(
+        r#"
+    contract Testing {
+        string[] string_vec;
+        function testLength() public returns (uint32, uint32, uint32) {
+            string_vec.push("tea");
+            string_vec.push("coffe");
+            string_vec.push("sixsix");
+            string[] memory rr = string_vec;
+            return (rr[0].length, rr[1].length, rr[2].length);
+        }
+
+        function getString(uint32 index) public view returns (string memory) {
+            string[] memory rr = string_vec;
+            return rr[index];
+        }
+    }
+      "#,
+    );
+
+    vm.constructor("Testing", &[]);
+    let returns = vm.function("testLength", &[], &[], None);
+    assert_eq!(returns[0], Token::Uint(U256::from(3)));
+    assert_eq!(returns[1], Token::Uint(U256::from(5)));
+    assert_eq!(returns[2], Token::Uint(U256::from(6)));
+
+    let returns = vm.function("getString", &[Token::Uint(U256::from(0))], &[], None);
+    assert_eq!(returns[0], Token::String("tea".to_string()));
+
+    let returns = vm.function("getString", &[Token::Uint(U256::from(1))], &[], None);
+    assert_eq!(returns[0], Token::String("coffe".to_string()));
+
+    let returns = vm.function("getString", &[Token::Uint(U256::from(2))], &[], None);
+    assert_eq!(returns[0], Token::String("sixsix".to_string()));
+}


### PR DESCRIPTION
Loading a vector of strings from storage was not working correctly. When we accessed the first element of the loaded array, we would get the wrong length, and consequently the wrong string. This PR fixes this problem.