### PR TITLE
Refactor size_of function

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -2678,7 +2678,7 @@ fn array_subscript(
 
                 if ty.array_length().is_some() {
                     // fixed length array
-                    let elem_size = elem_ty.deref_any().size_of(ns);
+                    let elem_size = elem_ty.deref_any().solana_storage_size(ns);
 
                     Expression::Add(
                         *loc,

--- a/src/emit/solana.rs
+++ b/src/emit/solana.rs
@@ -801,7 +801,7 @@ impl SolanaTarget {
                     self.storage_array_length(binary, function, slot, elem_ty, ns)
                 };
 
-                let elem_size = elem_ty.size_of(ns).to_u64().unwrap();
+                let elem_size = elem_ty.solana_storage_size(ns).to_u64().unwrap();
 
                 // loop over the array
                 let mut builder = LoopBuilder::new(binary, function);
@@ -1832,7 +1832,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             let elem_size = binary
                 .context
                 .i32_type()
-                .const_int(elem_ty.size_of(ns).to_u64().unwrap(), false);
+                .const_int(elem_ty.solana_storage_size(ns).to_u64().unwrap(), false);
 
             binary.builder.build_int_add(
                 offset,
@@ -2287,7 +2287,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     dest = binary.vector_new(length, elem_size, None);
                 };
 
-                let elem_size = elem_ty.size_of(ns).to_u64().unwrap();
+                let elem_size = elem_ty.solana_storage_size(ns).to_u64().unwrap();
 
                 // loop over the array
                 let mut builder = LoopBuilder::new(binary, function);
@@ -2502,7 +2502,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 let member_size = binary
                     .context
                     .i32_type()
-                    .const_int(elem_ty.size_of(ns).to_u64().unwrap(), false);
+                    .const_int(elem_ty.solana_storage_size(ns).to_u64().unwrap(), false);
                 let new_length = binary
                     .builder
                     .build_int_mul(length, member_size, "new_length");
@@ -2557,7 +2557,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .into_int_value();
             }
 
-            let elem_size = elem_ty.size_of(ns).to_u64().unwrap();
+            let elem_size = elem_ty.solana_storage_size(ns).to_u64().unwrap();
 
             // loop over the array
             let mut builder = LoopBuilder::new(binary, function);


### PR DESCRIPTION
The function `Type::size_of` is currently only used for calculation how much size a type occupies in storage. We do not utilize it to estimate the size of an item in the memory. This PR updates the function's name to properly represent what it returns and updates its description to encourage proper usage.