### PR TITLE
Update installation instructions for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,20 @@ some caveats due to differences in the underlying blockchain.
 Solang is under active development right now, and has
 [extensive documentation](https://solang.readthedocs.io/en/latest/).
 
+
+## Installation
+
+Solang is available as a Brew cask for MacOS, with the following command:
+
+```
+brew install hyperledger-labs/solang/solang
+```
+
+For other operating systems, please check the [installation guide](https://solang.readthedocs.io/en/latest/installing.html).
+
 ## Simple example
 
-First build [Solang](https://solang.readthedocs.io/en/latest/installing.html)
-or use the container, then write the following to flipper.sol:
+After installing the compiler, write the following to flipper.sol:
 
 ```solidity
 contract flipper {

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -16,3 +16,5 @@
 - `cargo publish`
 - Release new version of vscode plugin if needed
 - Mention release in Discord (Solana, Hyperledger) and Hyperledger /dev/weekly
+- Update the version number and the MacOS binaries' sha256 hash in `Casks/solang.rb` under
+  the repository `hyperledger-labs/homebrew-solang`.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -3,6 +3,17 @@ Installing Solang
 
 The Solang compiler is a single binary. It can be installed in different ways.
 
+
+Download from Brew
+------------------
+
+Solang is available on Brew via a private tap. Currently, this works only for MacOS systems, both Intel and Apple Silicon.
+To install Solang via Brew, run the following command:
+
+.. code-block:: text
+
+    brew install hyperledger-labs/solang/solang
+
 Download release binaries
 -------------------------
 


### PR DESCRIPTION
This PR adds the new installation instructions for MacOS on our documentation and our readme file. It also adds a new item to the release checklist to remind us of updating the cask file at each new release.