### PR TITLE
Bump solang-parser version for crate publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.8"
 once_cell = "1.10"
-solang-parser = { path = "solang-parser", version = "0.1.16" }
+solang-parser = { path = "solang-parser", version = "0.1.17" }
 codespan-reporting = "0.11"
 phf = "0.10.1"
 rust-lapper = "1.0"

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger-labs/solang"
 documentation = "https://solang.readthedocs.io/"


### PR DESCRIPTION
Foundry would like a new version