### PR TITLE
Update roadmap for Substrate target

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Here is a brief description of what we envision for the next versions.
 | Parse and resolve inline assembly          | Completed   |
 | Generate code for inline assembly          | Completed   |
 | Support Solana's Program Derived Addresses | In Progress |
+| Support latest Substrate production target | In Progress |
 
 
 ### V0.3
@@ -165,6 +166,8 @@ Here is a brief description of what we envision for the next versions.
 | Improvements in overflow checking          | In progress |
 | Call Solidity from Solana's Rust contracts | Not started |
 | Improve parser resilience                  | Not started |
+| Improve developer experience for Substrate | Not started |
+| Tooling for calls between ink! <> solidity | Not started |
 
 
 ### V0.4
@@ -174,6 +177,8 @@ Here is a brief description of what we envision for the next versions.
 | Improve management over optimization passes        | Not started |
 | Specify values as "1 sol" and "1e9 lamports"       | In progress |
 | Adopt single static assignment for code generation | Not started |
+| Support openzeppelin on Substrate target           | Not started |
+| Provide Solidity -> Substrate porting guide        | Not started |
 
 
 


### PR DESCRIPTION
@athei we are reworking the solang roadmap. I mapped  the milestones from the solang Bounty Proposal into the roadmap as follows:
- V0.2: Includes Milestones 1, 2, 3, 4, 6
- V0.3: Includes Milestones 5, 7, 8, 9
- V0.4: Includes Milestones 10, 11

Of course nothing will be set in stone here. What do you think?

Signed-off-by: Cyrill Leutwiler <bigcyrill@hotmail.com>