### PR TITLE
Make --generate-debug-info hidden

### DIFF
--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -6,13 +6,13 @@ use clap::{
 };
 use itertools::Itertools;
 use num_traits::cast::ToPrimitive;
-use serde::Serialize;
 use solang::{
     abi,
     codegen::{codegen, OptimizationLevel, Options},
     emit::Generate,
     file_resolver::FileResolver,
-    sema::{ast::Namespace, diagnostics},
+    sema::ast::Namespace,
+    standard_json::{EwasmContract, JsonContract, JsonResult},
     Target,
 };
 use std::{
@@ -25,29 +25,6 @@ use std::{
 
 mod doc;
 mod languageserver;
-
-#[derive(Serialize)]
-pub struct EwasmContract {
-    pub wasm: String,
-}
-
-#[derive(Serialize)]
-pub struct JsonContract {
-    abi: Vec<abi::ethereum::ABI>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    ewasm: Option<EwasmContract>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    minimum_space: Option<u32>,
-}
-
-#[derive(Serialize)]
-pub struct JsonResult {
-    pub errors: Vec<diagnostics::OutputJson>,
-    pub target: String,
-    #[serde(skip_serializing_if = "String::is_empty")]
-    pub program: String,
-    pub contracts: HashMap<String, HashMap<String, JsonContract>>,
-}
 
 fn main() {
     let matches = Command::new("solang")

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -138,6 +138,7 @@ fn main() {
                         .short('m')
                         .long("importmap")
                         .takes_value(true)
+                        .value_parser(ValueParser::new(parse_import_map))
                         .action(ArgAction::Append),
                 )
                 .arg(
@@ -238,6 +239,7 @@ fn main() {
                         .short('m')
                         .long("importmap")
                         .takes_value(true)
+                        .value_parser(ValueParser::new(parse_import_map))
                         .action(ArgAction::Append),
                 ),
         )
@@ -283,6 +285,7 @@ fn main() {
                         .short('m')
                         .long("importmap")
                         .takes_value(true)
+                        .value_parser(ValueParser::new(parse_import_map))
                         .action(ArgAction::Append),
                 ),
         )
@@ -878,19 +881,22 @@ fn imports_arg(matches: &ArgMatches) -> FileResolver {
         }
     }
 
-    if let Some(maps) = matches.get_many::<String>("IMPORTMAP") {
-        for p in maps {
-            if let Some((map, path)) = p.split_once('=') {
-                if let Err(e) = resolver.add_import_map(OsString::from(map), PathBuf::from(path)) {
-                    eprintln!("error: import path '{}': {}", path, e);
-                    std::process::exit(1);
-                }
-            } else {
-                eprintln!("error: import map '{}': contains no '='", p);
+    if let Some(maps) = matches.get_many::<(String, String)>("IMPORTMAP") {
+        for (map, path) in maps {
+            if let Err(e) = resolver.add_import_map(OsString::from(map), PathBuf::from(path)) {
+                eprintln!("error: import path '{}': {}", path, e);
                 std::process::exit(1);
             }
         }
     }
 
     resolver
+}
+
+fn parse_import_map(map: &str) -> Result<(String, String), String> {
+    if let Some((var, value)) = map.split_once('=') {
+        Ok((var.to_owned(), value.to_owned()))
+    } else {
+        Err("contains no '='".to_owned())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod emit;
 pub mod file_resolver;
 #[cfg(feature = "llvm")]
 mod linker;
+pub mod standard_json;
+
 // In Sema, we use result unit for returning early
 // when code-misparses. The error will be added to the namespace diagnostics, no need to have anything but unit
 // as error.

--- a/src/sema/diagnostics.rs
+++ b/src/sema/diagnostics.rs
@@ -2,9 +2,9 @@
 
 use super::ast::{Diagnostic, ErrorType, Level, Namespace};
 use crate::file_resolver::FileResolver;
+use crate::standard_json::{LocJson, OutputJson};
 use codespan_reporting::{diagnostic, files, term};
 use itertools::Itertools;
-use serde::Serialize;
 use solang_parser::pt::Loc;
 use std::{
     collections::HashMap,
@@ -278,25 +278,6 @@ impl Namespace {
 
         (files, file_id)
     }
-}
-
-#[derive(Serialize)]
-pub struct LocJson {
-    pub file: String,
-    pub start: usize,
-    pub end: usize,
-}
-
-#[derive(Serialize)]
-#[allow(non_snake_case)]
-pub struct OutputJson {
-    pub sourceLocation: Option<LocJson>,
-    #[serde(rename = "type")]
-    pub ty: String,
-    pub component: String,
-    pub severity: String,
-    pub message: String,
-    pub formattedMessage: String,
 }
 
 pub struct RawBuffer {

--- a/src/standard_json.rs
+++ b/src/standard_json.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines the json format for `solang compile --standard-json`.
+
+use crate::abi::ethereum::ABI;
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Serialize)]
+pub struct EwasmContract {
+    pub wasm: String,
+}
+
+#[derive(Serialize)]
+pub struct JsonContract {
+    pub abi: Vec<ABI>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ewasm: Option<EwasmContract>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum_space: Option<u32>,
+}
+
+#[derive(Serialize)]
+pub struct JsonResult {
+    pub errors: Vec<OutputJson>,
+    pub target: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub program: String,
+    pub contracts: HashMap<String, HashMap<String, JsonContract>>,
+}
+
+#[derive(Serialize)]
+pub struct LocJson {
+    pub file: String,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Serialize)]
+#[allow(non_snake_case)]
+pub struct OutputJson {
+    pub sourceLocation: Option<LocJson>,
+    #[serde(rename = "type")]
+    pub ty: String,
+    pub component: String,
+    pub severity: String,
+    pub message: String,
+    pub formattedMessage: String,
+}


### PR DESCRIPTION
This feature is incomplete and does not have any users yet. For example, there is a debugging endpoint for Solana in the works, but this is not finished yet. Also, this will be useful for static analysis, which requires debug information for higher-level type information.