### PR TITLE
add shell completions for cli app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 parity-wasm = "0.45"
 clap = "3.2"
+clap_complete = "3.2"
 hex = "0.4"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde_json = "1.0"

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -11,6 +11,14 @@ The following targets are supported right now:
 `Parity Substrate <https://substrate.io/>`_, and
 `Ethereum ewasm <https://github.com/ewasm/design>`_.
 
+Solang supports auto-completion for multiple shells. Use ``solang shell-complete --help`` to 
+learn whether your favorite shell is supported. If so, evaluate the output of 
+``solang shell-complete <SHELL>`` in order to activate it. Example installation with ``bash``:
+
+.. code-block:: bash
+
+	  echo 'source <(solang shell-complete bash)' >> ~/.bashrc
+
 
 Compiler Usage
 ______________


### PR DESCRIPTION
This PR adds a `shell-complete` sub-command, allowing users to autocomplete our CLI with the TAB key (this pretty much defuses the issue of typing full length sub-commands out all the time). As a bonus It also shows remaining options when there is nothing to complete yet.