### PR TITLE
Make lexer public

### DIFF
--- a/solang-parser/src/lib.rs
+++ b/solang-parser/src/lib.rs
@@ -7,7 +7,7 @@ use lalrpop_util::ParseError;
 
 pub mod diagnostics;
 pub mod doccomment;
-mod lexer;
+pub mod lexer;
 pub mod pt;
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
Exposing the lexer API would be useful for things like syntax highlighting. Plus its implemented clean as is to be exposed directly :hugs: 