### PR TITLE
Create 'writeString' and 'writeBytes'

### DIFF
--- a/docs/language/builtins.rst
+++ b/docs/language/builtins.rst
@@ -555,6 +555,19 @@ writeAddress(address value, uint32 offset)
 
 Write an ``address`` to the specified offset.
 
+writeString(string value, uint32 offset)
+++++++++++++++++++++++++++++++++++++++++++++
+
+Write the characters of a ``string`` to the specified offset. This function does not
+write the length of the string to the buffer.
+
+writeBytes(bytes value, uint32 offset)
+++++++++++++++++++++++++++++++++++++++++++
+
+Write the bytes of a Solidity dynamic bytes type ``bytes`` to the specified offset.
+This function does not write the length of the byte array to the buffer.
+
+
 Miscellaneous
 _____________
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1268,6 +1268,7 @@ pub enum Builtin {
     WriteUint64LE,
     WriteUint128LE,
     WriteUint256LE,
+    WriteBytes,
 }
 
 impl From<&ast::Builtin> for Builtin {
@@ -1327,6 +1328,7 @@ impl From<&ast::Builtin> for Builtin {
             ast::Builtin::WriteUint64LE => Builtin::WriteUint64LE,
             ast::Builtin::WriteUint128LE => Builtin::WriteUint128LE,
             ast::Builtin::WriteUint256LE => Builtin::WriteUint256LE,
+            ast::Builtin::WriteBytes | ast::Builtin::WriteString => Builtin::WriteBytes,
             _ => panic!("Builtin should not be in the cfg"),
         }
     }

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -59,6 +59,8 @@ fn test_builtin_conversion() {
         ast::Builtin::WriteUint64LE,
         ast::Builtin::WriteUint128LE,
         ast::Builtin::WriteUint256LE,
+        ast::Builtin::WriteString,
+        ast::Builtin::WriteBytes,
     ];
 
     let output: Vec<codegen::Builtin> = vec![
@@ -115,6 +117,8 @@ fn test_builtin_conversion() {
         codegen::Builtin::WriteUint64LE,
         codegen::Builtin::WriteUint128LE,
         codegen::Builtin::WriteUint256LE,
+        codegen::Builtin::WriteBytes,
+        codegen::Builtin::WriteBytes,
     ];
 
     for (i, item) in input.iter().enumerate() {

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1165,6 +1165,8 @@ pub enum Builtin {
     WriteUint128LE,
     WriteUint256LE,
     WriteAddress,
+    WriteString,
+    WriteBytes,
     Accounts,
     UserTypeWrap,
     UserTypeUnwrap,

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -537,7 +537,7 @@ static BUILTIN_VARIABLE: Lazy<[Prototype; 16]> = Lazy::new(|| {
 });
 
 // A list of all Solidity builtins methods
-static BUILTIN_METHODS: Lazy<[Prototype; 25]> = Lazy::new(|| {
+static BUILTIN_METHODS: Lazy<[Prototype; 27]> = Lazy::new(|| {
     [
         Prototype {
             builtin: Builtin::ReadInt8,
@@ -812,6 +812,28 @@ static BUILTIN_METHODS: Lazy<[Prototype; 25]> = Lazy::new(|| {
             ret: vec![],
             target: vec![],
             doc: "Writes an address to the specified offset",
+            constant: false,
+        },
+        Prototype {
+            builtin: Builtin::WriteString,
+            namespace: None,
+            method: Some(Type::DynamicBytes),
+            name: "writeString",
+            params: vec![Type::String, Type::Uint(32)],
+            ret: vec![],
+            target: vec![],
+            doc: "Write the contents of a string (without its length) to the specified offset",
+            constant: false,
+        },
+        Prototype {
+            builtin: Builtin::WriteBytes,
+            namespace: None,
+            method: Some(Type::DynamicBytes),
+            name: "writeBytes",
+            params: vec![Type::DynamicBytes, Type::Uint(32)],
+            ret: vec![],
+            target: vec![],
+            doc: "Write the contents of a bytes array (without its length) to the specified offset",
             constant: false,
         },
     ]


### PR DESCRIPTION
This PR creates `writeStringData` and `writeBytesData` functions that write only the contents of strings and bytes arrays into a buffer. They are useful for using bincode when creating a library for System Instructions on Solana.

For arrays (strings and bytes included) bincode encodes lengths in `u64`, so borsh encoding cannot be used for this case.