### PR TITLE
Improve the `contributing` section in our docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,11 +24,12 @@ Code contributions are submitted via
 
 Please fork this repository and make desired changes inside a dedicated branch on your fork.
 Prior to opening a pull request for your branch, make sure that the code in your branch
-- does compile without any warnings (run ``cargo build --workspace``)
-- does not produce any clippy lints (run ``cargo clippy --workspace``)
-- does pass all unit tests (run ``cargo test --workspace``)
-- has no merge conflicts with the ``main`` branch
-- is correctly formatted (run ``cargo fmt --all`` if your IDE does not do that automatically)
+
+* does compile without any warnings (run ``cargo build --workspace``)
+* does not produce any clippy lints (run ``cargo clippy --workspace``)
+* does pass all unit tests (run ``cargo test --workspace``)
+* has no merge conflicts with the ``main`` branch
+* is correctly formatted (run ``cargo fmt --all`` if your IDE does not do that automatically)
 
 Target Specific
 ---------------


### PR DESCRIPTION
Lately, we had a bunch of people opening pull requests where the code did not even compile. But I also realized that the the `contributing` section in our docs could be better on that.