### PR TITLE
Rename `binary` to `bin`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,3 @@
 too-many-arguments-threshold = 13
 cognitive-complexity-threshold = 37
+disallowed-names = ["binary"]

--- a/src/emit/expression.rs
+++ b/src/emit/expression.rs
@@ -2170,7 +2170,7 @@ pub(super) fn expression<'a, T: TargetRuntime<'a> + ?Sized>(
 
 pub(super) fn compare_address<'a, T: TargetRuntime<'a> + ?Sized>(
     target: &T,
-    binary: &Binary<'a>,
+    bin: &Binary<'a>,
     left: &Expression,
     right: &Expression,
     op: inkwell::IntPredicate,
@@ -2178,24 +2178,23 @@ pub(super) fn compare_address<'a, T: TargetRuntime<'a> + ?Sized>(
     function: FunctionValue<'a>,
     ns: &Namespace,
 ) -> IntValue<'a> {
-    let l = expression(target, binary, left, vartab, function, ns).into_array_value();
-    let r = expression(target, binary, right, vartab, function, ns).into_array_value();
+    let l = expression(target, bin, left, vartab, function, ns).into_array_value();
+    let r = expression(target, bin, right, vartab, function, ns).into_array_value();
 
-    let left = binary.build_alloca(function, binary.address_type(ns), "left");
-    let right = binary.build_alloca(function, binary.address_type(ns), "right");
+    let left = bin.build_alloca(function, bin.address_type(ns), "left");
+    let right = bin.build_alloca(function, bin.address_type(ns), "right");
 
-    binary.builder.build_store(left, l).unwrap();
-    binary.builder.build_store(right, r).unwrap();
+    bin.builder.build_store(left, l).unwrap();
+    bin.builder.build_store(right, r).unwrap();
 
-    let res = binary
+    let res = bin
         .builder
         .build_call(
-            binary.module.get_function("__memcmp_ord").unwrap(),
+            bin.module.get_function("__memcmp_ord").unwrap(),
             &[
                 left.into(),
                 right.into(),
-                binary
-                    .context
+                bin.context
                     .i32_type()
                     .const_int(ns.address_length as u64, false)
                     .into(),
@@ -2208,9 +2207,8 @@ pub(super) fn compare_address<'a, T: TargetRuntime<'a> + ?Sized>(
         .unwrap()
         .into_int_value();
 
-    binary
-        .builder
-        .build_int_compare(op, res, binary.context.i32_type().const_zero(), "")
+    bin.builder
+        .build_int_compare(op, res, bin.context.i32_type().const_zero(), "")
         .unwrap()
 }
 

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -80,7 +80,7 @@ pub trait TargetRuntime<'a> {
 
     fn storage_load(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         ty: &ast::Type,
         slot: &mut IntValue<'a>,
         function: FunctionValue<'a>,
@@ -91,7 +91,7 @@ pub trait TargetRuntime<'a> {
     /// Recursively store a type to storage
     fn storage_store(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         ty: &ast::Type,
         existing: bool,
         slot: &mut IntValue<'a>,
@@ -229,7 +229,7 @@ pub trait TargetRuntime<'a> {
 
     fn builtin_function(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue<'a>,
         builtin_func: &Function,
         args: &[BasicMetadataValueEnum<'a>],
@@ -293,10 +293,10 @@ pub trait TargetRuntime<'a> {
     fn return_data<'b>(&self, bin: &Binary<'b>, function: FunctionValue<'b>) -> PointerValue<'b>;
 
     /// Return the value we received
-    fn value_transferred<'b>(&self, binary: &Binary<'b>, ns: &Namespace) -> IntValue<'b>;
+    fn value_transferred<'b>(&self, bin: &Binary<'b>, ns: &Namespace) -> IntValue<'b>;
 
     /// Terminate execution, destroy bin and send remaining funds to addr
-    fn selfdestruct<'b>(&self, binary: &Binary<'b>, addr: ArrayValue<'b>, ns: &Namespace);
+    fn selfdestruct<'b>(&self, bin: &Binary<'b>, addr: ArrayValue<'b>, ns: &Namespace);
 
     /// Crypto Hash
     fn hash<'b>(
@@ -321,7 +321,7 @@ pub trait TargetRuntime<'a> {
     /// Return ABI encoded data
     fn return_abi_data<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         data: PointerValue<'b>,
         data_len: BasicValueEnum<'b>,
     );
@@ -385,8 +385,8 @@ impl ast::Contract {
         self.code
             .get_or_init(move || {
                 let context = inkwell::context::Context::create();
-                let binary = self.binary(ns, &context, opt, contract_no);
-                binary.code(Generate::Linked).expect("llvm build")
+                let bin = self.binary(ns, &context, opt, contract_no);
+                bin.code(Generate::Linked).expect("llvm build")
             })
             .to_vec()
     }

--- a/src/emit/solana/mod.rs
+++ b/src/emit/solana/mod.rs
@@ -34,7 +34,7 @@ impl SolanaTarget {
     ) -> Binary<'a> {
         let mut target = SolanaTarget();
         let filename = ns.files[contract.loc.file_no()].file_name();
-        let mut binary = Binary::new(
+        let mut bin = Binary::new(
             context,
             Target::Solana,
             &contract.id.name,
@@ -44,35 +44,34 @@ impl SolanaTarget {
             None,
         );
 
-        binary
-            .return_values
+        bin.return_values
             .insert(ReturnCode::Success, context.i64_type().const_zero());
-        binary.return_values.insert(
+        bin.return_values.insert(
             ReturnCode::FunctionSelectorInvalid,
             context.i64_type().const_int(2u64 << 32, false),
         );
-        binary.return_values.insert(
+        bin.return_values.insert(
             ReturnCode::AbiEncodingInvalid,
             context.i64_type().const_int(2u64 << 32, false),
         );
-        binary.return_values.insert(
+        bin.return_values.insert(
             ReturnCode::InvalidProgramId,
             context.i64_type().const_int(7u64 << 32, false),
         );
-        binary.return_values.insert(
+        bin.return_values.insert(
             ReturnCode::InvalidDataError,
             context.i64_type().const_int(2, false),
         );
-        binary.return_values.insert(
+        bin.return_values.insert(
             ReturnCode::AccountDataTooSmall,
             context.i64_type().const_int(5u64 << 32, false),
         );
         // externals
-        target.declare_externals(&mut binary, ns);
+        target.declare_externals(&mut bin, ns);
 
-        emit_functions(&mut target, &mut binary, contract, ns);
+        emit_functions(&mut target, &mut bin, contract, ns);
 
-        binary.internalize(&[
+        bin.internalize(&[
             "entrypoint",
             "sol_log_",
             "sol_log_pubkey",
@@ -87,26 +86,26 @@ impl SolanaTarget {
             "sol_log_data",
         ]);
 
-        binary
+        bin
     }
 
-    fn declare_externals(&self, binary: &mut Binary, ns: &ast::Namespace) {
-        let void_ty = binary.context.void_type();
-        let u8_ptr = binary.context.i8_type().ptr_type(AddressSpace::default());
-        let u64_ty = binary.context.i64_type();
-        let u32_ty = binary.context.i32_type();
-        let address = binary.address_type(ns).ptr_type(AddressSpace::default());
-        let seeds = binary.llvm_type(
+    fn declare_externals(&self, bin: &mut Binary, ns: &ast::Namespace) {
+        let void_ty = bin.context.void_type();
+        let u8_ptr = bin.context.i8_type().ptr_type(AddressSpace::default());
+        let u64_ty = bin.context.i64_type();
+        let u32_ty = bin.context.i32_type();
+        let address = bin.address_type(ns).ptr_type(AddressSpace::default());
+        let seeds = bin.llvm_type(
             &Type::Ref(Box::new(Type::Slice(Box::new(Type::Bytes(1))))),
             ns,
         );
 
-        let sol_bytes = binary
+        let sol_bytes = bin
             .context
             .struct_type(&[u8_ptr.into(), u64_ty.into()], false)
             .ptr_type(AddressSpace::default());
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_log_",
             void_ty.fn_type(&[u8_ptr.into(), u64_ty.into()], false),
             None,
@@ -115,7 +114,7 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_log_64_",
             void_ty.fn_type(
                 &[
@@ -133,7 +132,7 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_sha256",
             void_ty.fn_type(&[sol_bytes.into(), u32_ty.into(), u8_ptr.into()], false),
             None,
@@ -142,7 +141,7 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_keccak256",
             void_ty.fn_type(&[sol_bytes.into(), u32_ty.into(), u8_ptr.into()], false),
             None,
@@ -151,7 +150,7 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_set_return_data",
             void_ty.fn_type(&[u8_ptr.into(), u64_ty.into()], false),
             None,
@@ -160,7 +159,7 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_get_return_data",
             u64_ty.fn_type(&[u8_ptr.into(), u64_ty.into(), u8_ptr.into()], false),
             None,
@@ -169,11 +168,11 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let fields = binary.context.opaque_struct_type("SolLogDataField");
+        let fields = bin.context.opaque_struct_type("SolLogDataField");
 
         fields.set_body(&[u8_ptr.into(), u64_ty.into()], false);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_log_data",
             void_ty.fn_type(
                 &[
@@ -188,7 +187,7 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_create_program_address",
             u64_ty.fn_type(
                 &[seeds.into(), u64_ty.into(), address.into(), address.into()],
@@ -200,7 +199,7 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_try_find_program_address",
             u64_ty.fn_type(
                 &[
@@ -218,24 +217,22 @@ impl SolanaTarget {
             .as_global_value()
             .set_unnamed_address(UnnamedAddress::Local);
 
-        let function = binary.module.add_function(
+        let function = bin.module.add_function(
             "sol_invoke_signed_c",
             u64_ty.fn_type(
                 &[
                     u8_ptr.into(),
-                    binary
-                        .module
+                    bin.module
                         .get_struct_type("struct.SolAccountInfo")
                         .unwrap()
                         .ptr_type(AddressSpace::default())
                         .into(),
-                    binary.context.i32_type().into(),
-                    binary
-                        .context
+                    bin.context.i32_type().into(),
+                    bin.context
                         .i8_type()
                         .ptr_type(AddressSpace::default())
                         .into(),
-                    binary.context.i32_type().into(),
+                    bin.context.i32_type().into(),
                 ],
                 false,
             ),
@@ -247,22 +244,18 @@ impl SolanaTarget {
     }
 
     /// Returns the SolAccountInfo of the executing binary
-    fn contract_storage_account<'b>(&self, binary: &Binary<'b>) -> PointerValue<'b> {
-        let parameters = self.sol_parameters(binary);
+    fn contract_storage_account<'b>(&self, bin: &Binary<'b>) -> PointerValue<'b> {
+        let parameters = self.sol_parameters(bin);
 
         unsafe {
-            binary
-                .builder
+            bin.builder
                 .build_gep(
-                    binary
-                        .module
-                        .get_struct_type("struct.SolParameters")
-                        .unwrap(),
+                    bin.module.get_struct_type("struct.SolParameters").unwrap(),
                     parameters,
                     &[
-                        binary.context.i32_type().const_int(0, false),
-                        binary.context.i32_type().const_int(0, false),
-                        binary.context.i32_type().const_int(0, false),
+                        bin.context.i32_type().const_int(0, false),
+                        bin.context.i32_type().const_int(0, false),
+                        bin.context.i32_type().const_int(0, false),
                     ],
                     "account",
                 )
@@ -271,9 +264,8 @@ impl SolanaTarget {
     }
 
     /// Get the pointer to SolParameters
-    fn sol_parameters<'b>(&self, binary: &Binary<'b>) -> PointerValue<'b> {
-        binary
-            .builder
+    fn sol_parameters<'b>(&self, bin: &Binary<'b>) -> PointerValue<'b> {
+        bin.builder
             .get_insert_block()
             .unwrap()
             .get_parent()
@@ -284,27 +276,22 @@ impl SolanaTarget {
     }
 
     /// Returns the account data of the executing binary
-    fn contract_storage_data<'b>(&self, binary: &Binary<'b>) -> PointerValue<'b> {
-        let parameters = self.sol_parameters(binary);
+    fn contract_storage_data<'b>(&self, bin: &Binary<'b>) -> PointerValue<'b> {
+        let parameters = self.sol_parameters(bin);
 
-        binary
-            .builder
+        bin.builder
             .build_load(
-                binary.context.i8_type().ptr_type(AddressSpace::default()),
+                bin.context.i8_type().ptr_type(AddressSpace::default()),
                 unsafe {
-                    binary
-                        .builder
+                    bin.builder
                         .build_gep(
-                            binary
-                                .module
-                                .get_struct_type("struct.SolParameters")
-                                .unwrap(),
+                            bin.module.get_struct_type("struct.SolParameters").unwrap(),
                             parameters,
                             &[
-                                binary.context.i32_type().const_int(0, false),
-                                binary.context.i32_type().const_int(0, false),
-                                binary.context.i32_type().const_int(0, false),
-                                binary.context.i32_type().const_int(3, false),
+                                bin.context.i32_type().const_int(0, false),
+                                bin.context.i32_type().const_int(0, false),
+                                bin.context.i32_type().const_int(0, false),
+                                bin.context.i32_type().const_int(3, false),
                             ],
                             "data",
                         )
@@ -319,7 +306,7 @@ impl SolanaTarget {
     /// Free binary storage and zero out
     fn storage_free<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         ty: &ast::Type,
         data: PointerValue<'b>,
         slot: IntValue<'b>,
@@ -334,32 +321,30 @@ impl SolanaTarget {
 
         // the slot is simply the offset after the magic
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[slot], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[slot], "data")
                 .unwrap()
         };
 
         if *ty == ast::Type::String || *ty == ast::Type::DynamicBytes {
-            let offset = binary
+            let offset = bin
                 .builder
-                .build_load(binary.context.i32_type(), member, "offset")
+                .build_load(bin.context.i32_type(), member, "offset")
                 .unwrap()
                 .into_int_value();
 
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function("account_data_free").unwrap(),
+                    bin.module.get_function("account_data_free").unwrap(),
                     &[data.into(), offset.into()],
                     "",
                 )
                 .unwrap();
 
             // account_data_alloc will return 0 if the string is length 0
-            let new_offset = binary.context.i32_type().const_zero();
+            let new_offset = bin.context.i32_type().const_zero();
 
-            binary.builder.build_store(member, new_offset).unwrap();
+            bin.builder.build_store(member, new_offset).unwrap();
         } else if let ast::Type::Array(elem_ty, dim) = ty {
             // delete the existing storage
             let mut elem_slot = slot;
@@ -367,39 +352,38 @@ impl SolanaTarget {
 
             if elem_ty.is_dynamic(ns) || zero {
                 let length = if let Some(ast::ArrayLength::Fixed(length)) = dim.last() {
-                    binary
-                        .context
+                    bin.context
                         .i32_type()
                         .const_int(length.to_u64().unwrap(), false)
                 } else {
-                    elem_slot = binary
+                    elem_slot = bin
                         .builder
-                        .build_load(binary.context.i32_type(), member, "offset")
+                        .build_load(bin.context.i32_type(), member, "offset")
                         .unwrap()
                         .into_int_value();
 
                     free_array = Some(elem_slot);
 
-                    self.storage_array_length(binary, function, slot, elem_ty, ns)
+                    self.storage_array_length(bin, function, slot, elem_ty, ns)
                 };
 
                 let elem_size = elem_ty.solana_storage_size(ns).to_u64().unwrap();
 
                 // loop over the array
-                let mut builder = LoopBuilder::new(binary, function);
+                let mut builder = LoopBuilder::new(bin, function);
 
                 // we need a phi for the offset
                 let offset_phi =
-                    builder.add_loop_phi(binary, "offset", slot.get_type(), elem_slot.into());
+                    builder.add_loop_phi(bin, "offset", slot.get_type(), elem_slot.into());
 
-                let _ = builder.over(binary, binary.context.i32_type().const_zero(), length);
+                let _ = builder.over(bin, bin.context.i32_type().const_zero(), length);
 
                 let offset_val = offset_phi.into_int_value();
 
                 let elem_ty = ty.array_deref();
 
                 self.storage_free(
-                    binary,
+                    bin,
                     elem_ty.deref_any(),
                     data,
                     offset_val,
@@ -408,28 +392,27 @@ impl SolanaTarget {
                     ns,
                 );
 
-                let offset_val = binary
+                let offset_val = bin
                     .builder
                     .build_int_add(
                         offset_val,
-                        binary.context.i32_type().const_int(elem_size, false),
+                        bin.context.i32_type().const_int(elem_size, false),
                         "new_offset",
                     )
                     .unwrap();
 
                 // set the offset for the next iteration of the loop
-                builder.set_loop_phi_value(binary, "offset", offset_val.into());
+                builder.set_loop_phi_value(bin, "offset", offset_val.into());
 
                 // done
-                builder.finish(binary);
+                builder.finish(bin);
             }
 
             // if the array was dynamic, free the array itself
             if let Some(offset) = free_array {
-                binary
-                    .builder
+                bin.builder
                     .build_call(
-                        binary.module.get_function("account_data_free").unwrap(),
+                        bin.module.get_function("account_data_free").unwrap(),
                         &[data.into(), offset.into()],
                         "",
                     )
@@ -437,9 +420,9 @@ impl SolanaTarget {
 
                 if zero {
                     // account_data_alloc will return 0 if the string is length 0
-                    let new_offset = binary.context.i32_type().const_zero();
+                    let new_offset = bin.context.i32_type().const_zero();
 
-                    binary.builder.build_store(member, new_offset).unwrap();
+                    bin.builder.build_store(member, new_offset).unwrap();
                 }
             }
         } else if let ast::Type::Struct(struct_ty) = ty {
@@ -448,29 +431,27 @@ impl SolanaTarget {
                     .to_u64()
                     .unwrap();
 
-                let offset = binary
+                let offset = bin
                     .builder
                     .build_int_add(
                         slot,
-                        binary.context.i32_type().const_int(field_offset, false),
+                        bin.context.i32_type().const_int(field_offset, false),
                         "field_offset",
                     )
                     .unwrap();
 
-                self.storage_free(binary, &field.ty, data, offset, function, zero, ns);
+                self.storage_free(bin, &field.ty, data, offset, function, zero, ns);
             }
         } else if matches!(ty, Type::Address(_) | Type::Contract(_)) {
-            let ty = binary.llvm_type(ty, ns);
+            let ty = bin.llvm_type(ty, ns);
 
-            binary
-                .builder
+            bin.builder
                 .build_store(member, ty.into_array_type().const_zero())
                 .unwrap();
         } else {
-            let ty = binary.llvm_type(ty, ns);
+            let ty = bin.llvm_type(ty, ns);
 
-            binary
-                .builder
+            bin.builder
                 .build_store(member, ty.into_int_type().const_zero())
                 .unwrap();
         }
@@ -479,7 +460,7 @@ impl SolanaTarget {
     /// An entry in a sparse array or mapping
     fn sparse_entry<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         key_ty: &ast::Type,
         value_ty: &ast::Type,
         ns: &ast::Namespace,
@@ -488,21 +469,20 @@ impl SolanaTarget {
             key_ty,
             ast::Type::String | ast::Type::DynamicBytes | ast::Type::Mapping(..)
         ) {
-            binary.context.i32_type().into()
+            bin.context.i32_type().into()
         } else {
-            binary.llvm_type(key_ty, ns)
+            bin.llvm_type(key_ty, ns)
         };
 
-        binary
-            .context
+        bin.context
             .struct_type(
                 &[
-                    key,                              // key
-                    binary.context.i32_type().into(), // next field
+                    key,                           // key
+                    bin.context.i32_type().into(), // next field
                     if value_ty.is_mapping() {
-                        binary.context.i32_type().into()
+                        bin.context.i32_type().into()
                     } else {
-                        binary.llvm_type(value_ty, ns) // value
+                        bin.llvm_type(value_ty, ns) // value
                     },
                 ],
                 false,
@@ -513,7 +493,7 @@ impl SolanaTarget {
     /// Generate sparse lookup
     fn sparse_lookup_function<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         key_ty: &ast::Type,
         value_ty: &ast::Type,
         ns: &ast::Namespace,
@@ -524,31 +504,30 @@ impl SolanaTarget {
             value_ty.to_llvm_string(ns)
         );
 
-        if let Some(function) = binary.module.get_function(&function_name) {
+        if let Some(function) = bin.module.get_function(&function_name) {
             return function;
         }
 
         // The function takes an offset (of the mapping or sparse array), the key which
         // is the index, and it should return an offset.
-        let function_ty = binary.function_type(
+        let function_ty = bin.function_type(
             &[ast::Type::Uint(32), key_ty.clone()],
             &[ast::Type::Uint(32)],
             ns,
         );
 
         let function =
-            binary
-                .module
+            bin.module
                 .add_function(&function_name, function_ty, Some(Linkage::Internal));
 
-        let entry = binary.context.append_basic_block(function, "entry");
+        let entry = bin.context.append_basic_block(function, "entry");
 
-        binary.builder.position_at_end(entry);
+        bin.builder.position_at_end(entry);
 
         let offset = function.get_nth_param(0).unwrap().into_int_value();
         let key = function.get_nth_param(1).unwrap();
 
-        let entry_ty = self.sparse_entry(binary, key_ty, value_ty, ns);
+        let entry_ty = self.sparse_entry(bin, key_ty, value_ty, ns);
         let value_offset = unsafe {
             entry_ty
                 .ptr_type(AddressSpace::default())
@@ -556,30 +535,28 @@ impl SolanaTarget {
                 .const_gep(
                     entry_ty.as_basic_type_enum(),
                     &[
-                        binary.context.i32_type().const_zero(),
-                        binary.context.i32_type().const_int(2, false),
+                        bin.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_int(2, false),
                     ],
                 )
-                .const_to_int(binary.context.i32_type())
+                .const_to_int(bin.context.i32_type())
         };
 
-        let data = self.contract_storage_data(binary);
+        let data = self.contract_storage_data(bin);
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[offset], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[offset], "data")
         }
         .unwrap();
 
-        let address = binary.build_alloca(function, binary.address_type(ns), "address");
+        let address = bin.build_alloca(function, bin.address_type(ns), "address");
 
         // calculate the correct bucket. We have an prime number of
         let bucket = if matches!(key_ty, ast::Type::String | ast::Type::DynamicBytes) {
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function("vector_hash").unwrap(),
+                    bin.module.get_function("vector_hash").unwrap(),
                     &[key.into()],
                     "hash",
                 )
@@ -589,12 +566,11 @@ impl SolanaTarget {
                 .unwrap()
                 .into_int_value()
         } else if matches!(key_ty, ast::Type::Contract(_) | ast::Type::Address(_)) {
-            binary.builder.build_store(address, key).unwrap();
+            bin.builder.build_store(address, key).unwrap();
 
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function("address_hash").unwrap(),
+                    bin.module.get_function("address_hash").unwrap(),
                     &[address.into()],
                     "hash",
                 )
@@ -604,15 +580,14 @@ impl SolanaTarget {
                 .unwrap()
                 .into_int_value()
         } else if key_ty.bits(ns) > 64 {
-            binary
-                .builder
-                .build_int_truncate(key.into_int_value(), binary.context.i64_type(), "")
+            bin.builder
+                .build_int_truncate(key.into_int_value(), bin.context.i64_type(), "")
                 .unwrap()
         } else {
             key.into_int_value()
         };
 
-        let bucket = binary
+        let bucket = bin
             .builder
             .build_int_unsigned_rem(
                 bucket,
@@ -624,34 +599,28 @@ impl SolanaTarget {
             .unwrap();
 
         let first_offset_ptr = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i32_type(), member, &[bucket], "bucket_list")
+            bin.builder
+                .build_gep(bin.context.i32_type(), member, &[bucket], "bucket_list")
         }
         .unwrap();
 
         // we should now loop until offset is zero or we found it
-        let loop_entry = binary.context.append_basic_block(function, "loop_entry");
-        let end_of_bucket = binary.context.append_basic_block(function, "end_of_bucket");
-        let examine_bucket = binary
-            .context
-            .append_basic_block(function, "examine_bucket");
-        let found_entry = binary.context.append_basic_block(function, "found_entry");
-        let next_entry = binary.context.append_basic_block(function, "next_entry");
+        let loop_entry = bin.context.append_basic_block(function, "loop_entry");
+        let end_of_bucket = bin.context.append_basic_block(function, "end_of_bucket");
+        let examine_bucket = bin.context.append_basic_block(function, "examine_bucket");
+        let found_entry = bin.context.append_basic_block(function, "found_entry");
+        let next_entry = bin.context.append_basic_block(function, "next_entry");
 
         // let's enter the loop
-        binary
-            .builder
-            .build_unconditional_branch(loop_entry)
-            .unwrap();
+        bin.builder.build_unconditional_branch(loop_entry).unwrap();
 
-        binary.builder.position_at_end(loop_entry);
+        bin.builder.position_at_end(loop_entry);
 
         // we are walking the bucket list via the offset ptr
-        let offset_ptr_phi = binary
+        let offset_ptr_phi = bin
             .builder
             .build_phi(
-                binary.context.i32_type().ptr_type(AddressSpace::default()),
+                bin.context.i32_type().ptr_type(AddressSpace::default()),
                 "offset_ptr",
             )
             .unwrap();
@@ -659,17 +628,17 @@ impl SolanaTarget {
         offset_ptr_phi.add_incoming(&[(&first_offset_ptr, entry)]);
 
         // load the offset and check for zero (end of bucket list)
-        let offset = binary
+        let offset = bin
             .builder
             .build_load(
-                binary.context.i32_type(),
+                bin.context.i32_type(),
                 offset_ptr_phi.as_basic_value().into_pointer_value(),
                 "offset",
             )
             .unwrap()
             .into_int_value();
 
-        let is_offset_zero = binary
+        let is_offset_zero = bin
             .builder
             .build_int_compare(
                 IntPredicate::EQ,
@@ -679,30 +648,27 @@ impl SolanaTarget {
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(is_offset_zero, end_of_bucket, examine_bucket)
             .unwrap();
 
-        binary.builder.position_at_end(examine_bucket);
+        bin.builder.position_at_end(examine_bucket);
 
         // let's compare the key in this entry to the key we are looking for
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[offset], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[offset], "data")
         }
         .unwrap();
 
         let ptr = unsafe {
-            binary
-                .builder
+            bin.builder
                 .build_gep(
                     entry_ty,
                     member,
                     &[
-                        binary.context.i32_type().const_zero(),
-                        binary.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_zero(),
                     ],
                     "key_ptr",
                 )
@@ -710,27 +676,26 @@ impl SolanaTarget {
         };
 
         let matches = if matches!(key_ty, ast::Type::String | ast::Type::DynamicBytes) {
-            let entry_key = binary
+            let entry_key = bin
                 .builder
-                .build_load(binary.context.i32_type(), ptr, "key")
+                .build_load(bin.context.i32_type(), ptr, "key")
                 .unwrap();
 
             // entry_key is an offset
             let entry_data = unsafe {
-                binary
-                    .builder
+                bin.builder
                     .build_gep(
-                        binary.context.i8_type(),
+                        bin.context.i8_type(),
                         data,
                         &[entry_key.into_int_value()],
                         "data",
                     )
                     .unwrap()
             };
-            let entry_length = binary
+            let entry_length = bin
                 .builder
                 .build_call(
-                    binary.module.get_function("account_data_len").unwrap(),
+                    bin.module.get_function("account_data_len").unwrap(),
                     &[data.into(), entry_key.into()],
                     "length",
                 )
@@ -740,15 +705,14 @@ impl SolanaTarget {
                 .unwrap()
                 .into_int_value();
 
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function("__memcmp").unwrap(),
+                    bin.module.get_function("__memcmp").unwrap(),
                     &[
                         entry_data.into(),
                         entry_length.into(),
-                        binary.vector_bytes(key).into(),
-                        binary.vector_len(key).into(),
+                        bin.vector_bytes(key).into(),
+                        bin.vector_len(key).into(),
                     ],
                     "",
                 )
@@ -758,10 +722,9 @@ impl SolanaTarget {
                 .unwrap()
                 .into_int_value()
         } else if matches!(key_ty, ast::Type::Address(_) | ast::Type::Contract(_)) {
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function("address_equal").unwrap(),
+                    bin.module.get_function("address_equal").unwrap(),
                     &[address.into(), ptr.into()],
                     "",
                 )
@@ -771,13 +734,12 @@ impl SolanaTarget {
                 .unwrap()
                 .into_int_value()
         } else {
-            let entry_key = binary
+            let entry_key = bin
                 .builder
-                .build_load(binary.llvm_type(key_ty, ns), ptr, "key")
+                .build_load(bin.llvm_type(key_ty, ns), ptr, "key")
                 .unwrap();
 
-            binary
-                .builder
+            bin.builder
                 .build_int_compare(
                     IntPredicate::EQ,
                     key.into_int_value(),
@@ -787,61 +749,54 @@ impl SolanaTarget {
                 .unwrap()
         };
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(matches, found_entry, next_entry)
             .unwrap();
 
-        binary.builder.position_at_end(found_entry);
+        bin.builder.position_at_end(found_entry);
 
         let ret_offset = function.get_nth_param(2).unwrap().into_pointer_value();
 
-        binary
-            .builder
+        bin.builder
             .build_store(
                 ret_offset,
-                binary
-                    .builder
+                bin.builder
                     .build_int_add(offset, value_offset, "value_offset")
                     .unwrap(),
             )
             .unwrap();
 
-        binary
-            .builder
-            .build_return(Some(&binary.context.i64_type().const_zero()))
+        bin.builder
+            .build_return(Some(&bin.context.i64_type().const_zero()))
             .unwrap();
 
-        binary.builder.position_at_end(next_entry);
+        bin.builder.position_at_end(next_entry);
 
-        let offset_ptr = binary
+        let offset_ptr = bin
             .builder
             .build_struct_gep(entry_ty, member, 1, "offset_ptr")
             .unwrap();
 
         offset_ptr_phi.add_incoming(&[(&offset_ptr, next_entry)]);
 
-        binary
-            .builder
-            .build_unconditional_branch(loop_entry)
-            .unwrap();
+        bin.builder.build_unconditional_branch(loop_entry).unwrap();
 
         let offset_ptr = offset_ptr_phi.as_basic_value().into_pointer_value();
 
-        binary.builder.position_at_end(end_of_bucket);
+        bin.builder.position_at_end(end_of_bucket);
 
         let entry_length = entry_ty
             .size_of()
             .unwrap()
-            .const_cast(binary.context.i32_type(), false);
+            .const_cast(bin.context.i32_type(), false);
 
-        let account = self.contract_storage_account(binary);
+        let account = self.contract_storage_account(bin);
 
         // account_data_alloc will return offset = 0 if the string is length 0
-        let rc = binary
+        let rc = bin
             .builder
             .build_call(
-                binary.module.get_function("account_data_alloc").unwrap(),
+                bin.module.get_function("account_data_alloc").unwrap(),
                 &[account.into(), entry_length.into(), offset_ptr.into()],
                 "rc",
             )
@@ -851,65 +806,57 @@ impl SolanaTarget {
             .unwrap()
             .into_int_value();
 
-        let is_rc_zero = binary
+        let is_rc_zero = bin
             .builder
             .build_int_compare(
                 IntPredicate::EQ,
                 rc,
-                binary.context.i64_type().const_zero(),
+                bin.context.i64_type().const_zero(),
                 "is_rc_zero",
             )
             .unwrap();
 
-        let rc_not_zero = binary.context.append_basic_block(function, "rc_not_zero");
-        let rc_zero = binary.context.append_basic_block(function, "rc_zero");
+        let rc_not_zero = bin.context.append_basic_block(function, "rc_not_zero");
+        let rc_zero = bin.context.append_basic_block(function, "rc_zero");
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(is_rc_zero, rc_zero, rc_not_zero)
             .unwrap();
 
-        binary.builder.position_at_end(rc_not_zero);
+        bin.builder.position_at_end(rc_not_zero);
 
-        self.return_code(binary, rc);
+        self.return_code(bin, rc);
 
-        binary.builder.position_at_end(rc_zero);
+        bin.builder.position_at_end(rc_zero);
 
-        let offset = binary
+        let offset = bin
             .builder
-            .build_load(binary.context.i32_type(), offset_ptr, "new_offset")
+            .build_load(bin.context.i32_type(), offset_ptr, "new_offset")
             .unwrap()
             .into_int_value();
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[offset], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[offset], "data")
                 .unwrap()
         };
 
         // Clear memory. The length argument to __bzero8 is in lengths of 8 bytes. We round up to the nearest
         // 8 byte, since account_data_alloc also rounds up to the nearest 8 byte when allocating.
-        let length = binary
+        let length = bin
             .builder
             .build_int_unsigned_div(
-                binary
-                    .builder
-                    .build_int_add(
-                        entry_length,
-                        binary.context.i32_type().const_int(7, false),
-                        "",
-                    )
+                bin.builder
+                    .build_int_add(entry_length, bin.context.i32_type().const_int(7, false), "")
                     .unwrap(),
-                binary.context.i32_type().const_int(8, false),
+                bin.context.i32_type().const_int(8, false),
                 "length_div_8",
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("__bzero8").unwrap(),
+                bin.module.get_function("__bzero8").unwrap(),
                 &[member.into(), length.into()],
                 "zeroed",
             )
@@ -917,17 +864,17 @@ impl SolanaTarget {
 
         // set key
         if matches!(key_ty, ast::Type::String | ast::Type::DynamicBytes) {
-            let new_string_length = binary.vector_len(key);
-            let offset_ptr = binary
+            let new_string_length = bin.vector_len(key);
+            let offset_ptr = bin
                 .builder
                 .build_struct_gep(entry_ty, member, 0, "key_ptr")
                 .unwrap();
 
             // account_data_alloc will return offset = 0 if the string is length 0
-            let rc = binary
+            let rc = bin
                 .builder
                 .build_call(
-                    binary.module.get_function("account_data_alloc").unwrap(),
+                    bin.module.get_function("account_data_alloc").unwrap(),
                     &[account.into(), new_string_length.into(), offset_ptr.into()],
                     "alloc",
                 )
@@ -937,55 +884,50 @@ impl SolanaTarget {
                 .unwrap()
                 .into_int_value();
 
-            let is_rc_zero = binary
+            let is_rc_zero = bin
                 .builder
                 .build_int_compare(
                     IntPredicate::EQ,
                     rc,
-                    binary.context.i64_type().const_zero(),
+                    bin.context.i64_type().const_zero(),
                     "is_rc_zero",
                 )
                 .unwrap();
 
-            let rc_not_zero = binary.context.append_basic_block(function, "rc_not_zero");
-            let rc_zero = binary.context.append_basic_block(function, "rc_zero");
-            let memcpy = binary.context.append_basic_block(function, "memcpy");
+            let rc_not_zero = bin.context.append_basic_block(function, "rc_not_zero");
+            let rc_zero = bin.context.append_basic_block(function, "rc_zero");
+            let memcpy = bin.context.append_basic_block(function, "memcpy");
 
-            binary
-                .builder
+            bin.builder
                 .build_conditional_branch(is_rc_zero, rc_zero, rc_not_zero)
                 .unwrap();
 
-            binary.builder.position_at_end(rc_not_zero);
+            bin.builder.position_at_end(rc_not_zero);
 
-            self.return_code(
-                binary,
-                binary.context.i64_type().const_int(5u64 << 32, false),
-            );
+            self.return_code(bin, bin.context.i64_type().const_int(5u64 << 32, false));
 
-            binary.builder.position_at_end(rc_zero);
+            bin.builder.position_at_end(rc_zero);
 
-            let new_offset = binary
+            let new_offset = bin
                 .builder
-                .build_load(binary.context.i32_type(), offset_ptr, "new_offset")
+                .build_load(bin.context.i32_type(), offset_ptr, "new_offset")
                 .unwrap();
 
-            binary.builder.build_unconditional_branch(memcpy).unwrap();
+            bin.builder.build_unconditional_branch(memcpy).unwrap();
 
-            binary.builder.position_at_end(memcpy);
+            bin.builder.position_at_end(memcpy);
 
-            let offset_phi = binary
+            let offset_phi = bin
                 .builder
-                .build_phi(binary.context.i32_type(), "offset")
+                .build_phi(bin.context.i32_type(), "offset")
                 .unwrap();
 
             offset_phi.add_incoming(&[(&new_offset, rc_zero), (&offset, entry)]);
 
             let dest_string_data = unsafe {
-                binary
-                    .builder
+                bin.builder
                     .build_gep(
-                        binary.context.i8_type(),
+                        bin.context.i8_type(),
                         data,
                         &[offset_phi.as_basic_value().into_int_value()],
                         "dest_string_data",
@@ -993,43 +935,39 @@ impl SolanaTarget {
                     .unwrap()
             };
 
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function("__memcpy").unwrap(),
+                    bin.module.get_function("__memcpy").unwrap(),
                     &[
                         dest_string_data.into(),
-                        binary.vector_bytes(key).into(),
+                        bin.vector_bytes(key).into(),
                         new_string_length.into(),
                     ],
                     "copied",
                 )
                 .unwrap();
         } else {
-            let key_ptr = binary
+            let key_ptr = bin
                 .builder
                 .build_struct_gep(entry_ty, member, 0, "key_ptr")
                 .unwrap();
 
-            binary.builder.build_store(key_ptr, key).unwrap();
+            bin.builder.build_store(key_ptr, key).unwrap();
         };
 
         let ret_offset = function.get_nth_param(2).unwrap().into_pointer_value();
 
-        binary
-            .builder
+        bin.builder
             .build_store(
                 ret_offset,
-                binary
-                    .builder
+                bin.builder
                     .build_int_add(offset, value_offset, "value_offset")
                     .unwrap(),
             )
             .unwrap();
 
-        binary
-            .builder
-            .build_return(Some(&binary.context.i64_type().const_zero()))
+        bin.builder
+            .build_return(Some(&bin.context.i64_type().const_zero()))
             .unwrap();
 
         function
@@ -1038,7 +976,7 @@ impl SolanaTarget {
     /// Do a lookup/subscript in a sparse array or mapping; this will call a function
     fn sparse_lookup<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         function: FunctionValue<'b>,
         key_ty: &ast::Type,
         value_ty: &ast::Type,
@@ -1046,17 +984,17 @@ impl SolanaTarget {
         index: BasicValueEnum<'b>,
         ns: &ast::Namespace,
     ) -> IntValue<'b> {
-        let offset = binary.build_alloca(function, binary.context.i32_type(), "offset");
+        let offset = bin.build_alloca(function, bin.context.i32_type(), "offset");
 
-        let current_block = binary.builder.get_insert_block().unwrap();
+        let current_block = bin.builder.get_insert_block().unwrap();
 
-        let lookup = self.sparse_lookup_function(binary, key_ty, value_ty, ns);
+        let lookup = self.sparse_lookup_function(bin, key_ty, value_ty, ns);
 
-        binary.builder.position_at_end(current_block);
+        bin.builder.position_at_end(current_block);
 
-        let parameters = self.sol_parameters(binary);
+        let parameters = self.sol_parameters(bin);
 
-        let rc = binary
+        let rc = bin
             .builder
             .build_call(
                 lookup,
@@ -1070,7 +1008,7 @@ impl SolanaTarget {
             .into_int_value();
 
         // either load the result from offset or return failure
-        let is_rc_zero = binary
+        let is_rc_zero = bin
             .builder
             .build_int_compare(
                 IntPredicate::EQ,
@@ -1080,23 +1018,21 @@ impl SolanaTarget {
             )
             .unwrap();
 
-        let rc_not_zero = binary.context.append_basic_block(function, "rc_not_zero");
-        let rc_zero = binary.context.append_basic_block(function, "rc_zero");
+        let rc_not_zero = bin.context.append_basic_block(function, "rc_not_zero");
+        let rc_zero = bin.context.append_basic_block(function, "rc_zero");
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(is_rc_zero, rc_zero, rc_not_zero)
             .unwrap();
 
-        binary.builder.position_at_end(rc_not_zero);
+        bin.builder.position_at_end(rc_not_zero);
 
-        self.return_code(binary, rc);
+        self.return_code(bin, rc);
 
-        binary.builder.position_at_end(rc_zero);
+        bin.builder.position_at_end(rc_zero);
 
-        binary
-            .builder
-            .build_load(binary.context.i32_type(), offset, "offset")
+        bin.builder
+            .build_load(bin.context.i32_type(), offset, "offset")
             .unwrap()
             .into_int_value()
     }
@@ -1104,28 +1040,24 @@ impl SolanaTarget {
     /// AccountInfo struct member
     fn account_info_member<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         function: FunctionValue<'b>,
         account_info: PointerValue<'b>,
         member: usize,
         ns: &ast::Namespace,
     ) -> BasicValueEnum<'b> {
-        let account_info_ty = binary
-            .module
-            .get_struct_type("struct.SolAccountInfo")
-            .unwrap();
+        let account_info_ty = bin.module.get_struct_type("struct.SolAccountInfo").unwrap();
 
         let gep_no = match member.cmp(&2) {
             Ordering::Less => member as u32,
             Ordering::Greater => (member + 1) as u32,
             Ordering::Equal => {
                 // The data field is transformed into a slice, so we do not return it directly.
-                let data_len = binary
+                let data_len = bin
                     .builder
                     .build_load(
-                        binary.context.i64_type(),
-                        binary
-                            .builder
+                        bin.context.i64_type(),
+                        bin.builder
                             .build_struct_gep(account_info_ty, account_info, 2, "data_len")
                             .unwrap(),
                         "data_len",
@@ -1133,50 +1065,48 @@ impl SolanaTarget {
                     .unwrap()
                     .into_int_value();
 
-                let data = binary
+                let data = bin
                     .builder
                     .build_load(
-                        binary.context.i8_type().ptr_type(AddressSpace::default()),
-                        binary
-                            .builder
+                        bin.context.i8_type().ptr_type(AddressSpace::default()),
+                        bin.builder
                             .build_struct_gep(account_info_ty, account_info, 3, "data")
                             .unwrap(),
                         "data",
                     )
                     .unwrap();
 
-                let slice_alloca = binary.build_alloca(
+                let slice_alloca = bin.build_alloca(
                     function,
-                    binary.llvm_type(&ast::Type::Slice(Box::new(Type::Bytes(1))), ns),
+                    bin.llvm_type(&ast::Type::Slice(Box::new(Type::Bytes(1))), ns),
                     "slice_alloca",
                 );
-                let data_elem = binary
+                let data_elem = bin
                     .builder
                     .build_struct_gep(
-                        binary.llvm_type(&ast::Type::Slice(Box::new(Type::Bytes(1))), ns),
+                        bin.llvm_type(&ast::Type::Slice(Box::new(Type::Bytes(1))), ns),
                         slice_alloca,
                         0,
                         "data",
                     )
                     .unwrap();
-                binary.builder.build_store(data_elem, data).unwrap();
-                let data_len_elem = binary
+                bin.builder.build_store(data_elem, data).unwrap();
+                let data_len_elem = bin
                     .builder
                     .build_struct_gep(
-                        binary.llvm_type(&ast::Type::Slice(Box::new(Type::Bytes(1))), ns),
+                        bin.llvm_type(&ast::Type::Slice(Box::new(Type::Bytes(1))), ns),
                         slice_alloca,
                         1,
                         "data_len",
                     )
                     .unwrap();
-                binary.builder.build_store(data_len_elem, data_len).unwrap();
+                bin.builder.build_store(data_len_elem, data_len).unwrap();
 
                 return slice_alloca.as_basic_value_enum();
             }
         };
 
-        binary
-            .builder
+        bin.builder
             .build_struct_gep(
                 account_info_ty,
                 account_info,
@@ -1190,135 +1120,112 @@ impl SolanaTarget {
     /// Construct the LLVM-IR to call 'sol_invoke_signed_c'.
     fn build_invoke_signed_c<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         function: FunctionValue<'b>,
         payload: PointerValue<'b>,
         payload_len: IntValue<'b>,
         contract_args: ContractArgs<'b>,
         ns: &Namespace,
     ) {
-        let instruction_ty: BasicTypeEnum = binary
+        let instruction_ty: BasicTypeEnum = bin
             .context
             .struct_type(
                 &[
-                    binary
-                        .module
+                    bin.module
                         .get_struct_type("struct.SolPubkey")
                         .unwrap()
                         .ptr_type(AddressSpace::default())
                         .as_basic_type_enum(),
-                    binary
-                        .llvm_type(&Type::Struct(StructType::AccountMeta), ns)
+                    bin.llvm_type(&Type::Struct(StructType::AccountMeta), ns)
                         .ptr_type(AddressSpace::default())
                         .as_basic_type_enum(),
-                    binary.context.i64_type().as_basic_type_enum(),
-                    binary
-                        .context
+                    bin.context.i64_type().as_basic_type_enum(),
+                    bin.context
                         .i8_type()
                         .ptr_type(AddressSpace::default())
                         .as_basic_type_enum(),
-                    binary.context.i64_type().as_basic_type_enum(),
+                    bin.context.i64_type().as_basic_type_enum(),
                 ],
                 false,
             )
             .as_basic_type_enum();
 
-        let instruction = binary.build_alloca(function, instruction_ty, "instruction");
+        let instruction = bin.build_alloca(function, instruction_ty, "instruction");
 
-        binary
-            .builder
+        bin.builder
             .build_store(
-                binary
-                    .builder
+                bin.builder
                     .build_struct_gep(instruction_ty, instruction, 0, "program_id")
                     .unwrap(),
                 contract_args.program_id.unwrap(),
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_store(
-                binary
-                    .builder
+                bin.builder
                     .build_struct_gep(instruction_ty, instruction, 1, "accounts")
                     .unwrap(),
                 contract_args.accounts.unwrap().0,
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_store(
-                binary
-                    .builder
+                bin.builder
                     .build_struct_gep(instruction_ty, instruction, 2, "accounts_len")
                     .unwrap(),
-                binary
-                    .builder
+                bin.builder
                     .build_int_z_extend(
                         contract_args.accounts.unwrap().1,
-                        binary.context.i64_type(),
+                        bin.context.i64_type(),
                         "accounts_len",
                     )
                     .unwrap(),
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_store(
-                binary
-                    .builder
+                bin.builder
                     .build_struct_gep(instruction_ty, instruction, 3, "data")
                     .unwrap(),
                 payload,
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_store(
-                binary
-                    .builder
+                bin.builder
                     .build_struct_gep(instruction_ty, instruction, 4, "data_len")
                     .unwrap(),
-                binary
-                    .builder
-                    .build_int_z_extend(payload_len, binary.context.i64_type(), "payload_len")
+                bin.builder
+                    .build_int_z_extend(payload_len, bin.context.i64_type(), "payload_len")
                     .unwrap(),
             )
             .unwrap();
 
-        let parameters = self.sol_parameters(binary);
+        let parameters = self.sol_parameters(bin);
 
-        let account_infos = binary
+        let account_infos = bin
             .builder
             .build_struct_gep(
-                binary
-                    .module
-                    .get_struct_type("struct.SolParameters")
-                    .unwrap(),
+                bin.module.get_struct_type("struct.SolParameters").unwrap(),
                 parameters,
                 0,
                 "ka",
             )
             .unwrap();
 
-        let account_infos_len = binary
+        let account_infos_len = bin
             .builder
             .build_int_truncate(
-                binary
-                    .builder
+                bin.builder
                     .build_load(
-                        binary.context.i64_type(),
-                        binary
-                            .builder
+                        bin.context.i64_type(),
+                        bin.builder
                             .build_struct_gep(
-                                binary
-                                    .module
-                                    .get_struct_type("struct.SolParameters")
-                                    .unwrap(),
+                                bin.module.get_struct_type("struct.SolParameters").unwrap(),
                                 parameters,
                                 1,
                                 "ka_num",
@@ -1328,18 +1235,17 @@ impl SolanaTarget {
                     )
                     .unwrap()
                     .into_int_value(),
-                binary.context.i32_type(),
+                bin.context.i32_type(),
                 "ka_num",
             )
             .unwrap();
 
-        let external_call = binary.module.get_function("sol_invoke_signed_c").unwrap();
+        let external_call = bin.module.get_function("sol_invoke_signed_c").unwrap();
 
         let (signer_seeds, signer_seeds_len) = if let Some((seeds, len)) = contract_args.seeds {
             (
                 seeds,
-                binary
-                    .builder
+                bin.builder
                     .build_int_cast(
                         len,
                         external_call.get_type().get_param_types()[4].into_int_type(),
@@ -1358,8 +1264,7 @@ impl SolanaTarget {
             )
         };
 
-        binary
-            .builder
+        bin.builder
             .build_call(
                 external_call,
                 &[

--- a/src/emit/solana/target.rs
+++ b/src/emit/solana/target.rs
@@ -21,21 +21,21 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     /// Solana does not use slot based-storage so override
     fn storage_delete(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         ty: &ast::Type,
         slot: &mut IntValue<'a>,
         function: FunctionValue<'a>,
         ns: &ast::Namespace,
     ) {
         // binary storage is in 2nd account
-        let data = self.contract_storage_data(binary);
+        let data = self.contract_storage_data(bin);
 
-        self.storage_free(binary, ty, data, *slot, function, true, ns);
+        self.storage_free(bin, ty, data, *slot, function, true, ns);
     }
 
     fn set_storage_extfunc(
         &self,
-        _binary: &Binary,
+        _bin: &Binary,
         _function: FunctionValue,
         _slot: PointerValue,
         _dest: PointerValue,
@@ -45,7 +45,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     }
     fn get_storage_extfunc(
         &self,
-        _binary: &Binary<'a>,
+        _bin: &Binary<'a>,
         _function: FunctionValue,
         _slot: PointerValue<'a>,
         _ns: &ast::Namespace,
@@ -55,7 +55,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
     fn set_storage_string(
         &self,
-        _binary: &Binary<'a>,
+        _bin: &Binary<'a>,
         _function: FunctionValue<'a>,
         _slot: PointerValue<'a>,
         _dest: BasicValueEnum<'a>,
@@ -66,7 +66,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
     fn get_storage_string(
         &self,
-        _binary: &Binary<'a>,
+        _bin: &Binary<'a>,
         _function: FunctionValue,
         _slot: PointerValue<'a>,
     ) -> PointerValue<'a> {
@@ -76,32 +76,31 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
     fn get_storage_bytes_subscript(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue,
         slot: IntValue<'a>,
         index: IntValue<'a>,
         loc: Loc,
         ns: &Namespace,
     ) -> IntValue<'a> {
-        let data = self.contract_storage_data(binary);
+        let data = self.contract_storage_data(bin);
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[slot], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[slot], "data")
                 .unwrap()
         };
 
-        let offset = binary
+        let offset = bin
             .builder
-            .build_load(binary.context.i32_type(), member, "offset")
+            .build_load(bin.context.i32_type(), member, "offset")
             .unwrap()
             .into_int_value();
 
-        let length = binary
+        let length = bin
             .builder
             .build_call(
-                binary.module.get_function("account_data_len").unwrap(),
+                bin.module.get_function("account_data_len").unwrap(),
                 &[data.into(), offset.into()],
                 "length",
             )
@@ -112,61 +111,54 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .into_int_value();
 
         // do bounds check on index
-        let in_range = binary
+        let in_range = bin
             .builder
             .build_int_compare(IntPredicate::ULT, index, length, "index_in_range")
             .unwrap();
 
-        let get_block = binary.context.append_basic_block(function, "in_range");
-        let bang_block = binary.context.append_basic_block(function, "bang_block");
+        let get_block = bin.context.append_basic_block(function, "in_range");
+        let bang_block = bin.context.append_basic_block(function, "bang_block");
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(in_range, get_block, bang_block)
             .unwrap();
 
-        binary.builder.position_at_end(bang_block);
+        bin.builder.position_at_end(bang_block);
 
-        binary.log_runtime_error(
+        bin.log_runtime_error(
             self,
             "storage array index out of bounds".to_string(),
             Some(loc),
             ns,
         );
         self.assert_failure(
-            binary,
-            binary
-                .context
+            bin,
+            bin.context
                 .i8_type()
                 .ptr_type(AddressSpace::default())
                 .const_null(),
-            binary.context.i32_type().const_zero(),
+            bin.context.i32_type().const_zero(),
         );
 
-        binary.builder.position_at_end(get_block);
+        bin.builder.position_at_end(get_block);
 
-        let offset = binary
-            .builder
-            .build_int_add(offset, index, "offset")
-            .unwrap();
+        let offset = bin.builder.build_int_add(offset, index, "offset").unwrap();
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[offset], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[offset], "data")
                 .unwrap()
         };
 
-        binary
-            .builder
-            .build_load(binary.context.i8_type(), member, "val")
+        bin.builder
+            .build_load(bin.context.i8_type(), member, "val")
             .unwrap()
             .into_int_value()
     }
 
     fn set_storage_bytes_subscript(
         &self,
-        binary: &Binary,
+        bin: &Binary,
         function: FunctionValue,
         slot: IntValue,
         index: IntValue,
@@ -174,25 +166,24 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         ns: &Namespace,
         loc: Loc,
     ) {
-        let data = self.contract_storage_data(binary);
+        let data = self.contract_storage_data(bin);
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[slot], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[slot], "data")
                 .unwrap()
         };
 
-        let offset = binary
+        let offset = bin
             .builder
-            .build_load(binary.context.i32_type(), member, "offset")
+            .build_load(bin.context.i32_type(), member, "offset")
             .unwrap()
             .into_int_value();
 
-        let length = binary
+        let length = bin
             .builder
             .build_call(
-                binary.module.get_function("account_data_len").unwrap(),
+                bin.module.get_function("account_data_len").unwrap(),
                 &[data.into(), offset.into()],
                 "length",
             )
@@ -203,97 +194,87 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .into_int_value();
 
         // do bounds check on index
-        let in_range = binary
+        let in_range = bin
             .builder
             .build_int_compare(IntPredicate::ULT, index, length, "index_in_range")
             .unwrap();
 
-        let set_block = binary.context.append_basic_block(function, "in_range");
-        let bang_block = binary.context.append_basic_block(function, "bang_block");
+        let set_block = bin.context.append_basic_block(function, "in_range");
+        let bang_block = bin.context.append_basic_block(function, "bang_block");
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(in_range, set_block, bang_block)
             .unwrap();
 
-        binary.builder.position_at_end(bang_block);
-        binary.log_runtime_error(
+        bin.builder.position_at_end(bang_block);
+        bin.log_runtime_error(
             self,
             "storage index out of bounds".to_string(),
             Some(loc),
             ns,
         );
         self.assert_failure(
-            binary,
-            binary
-                .context
+            bin,
+            bin.context
                 .i8_type()
                 .ptr_type(AddressSpace::default())
                 .const_null(),
-            binary.context.i32_type().const_zero(),
+            bin.context.i32_type().const_zero(),
         );
 
-        binary.builder.position_at_end(set_block);
+        bin.builder.position_at_end(set_block);
 
-        let offset = binary
-            .builder
-            .build_int_add(offset, index, "offset")
-            .unwrap();
+        let offset = bin.builder.build_int_add(offset, index, "offset").unwrap();
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[offset], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[offset], "data")
                 .unwrap()
         };
 
-        binary.builder.build_store(member, val).unwrap();
+        bin.builder.build_store(member, val).unwrap();
     }
 
     fn storage_subscript(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue<'a>,
         ty: &ast::Type,
         slot: IntValue<'a>,
         index: BasicValueEnum<'a>,
         ns: &ast::Namespace,
     ) -> IntValue<'a> {
-        let account = self.contract_storage_account(binary);
+        let account = self.contract_storage_account(bin);
 
         if let ast::Type::Mapping(ast::Mapping { key, value, .. }) = ty.deref_any() {
-            self.sparse_lookup(binary, function, key, value, slot, index, ns)
+            self.sparse_lookup(bin, function, key, value, slot, index, ns)
         } else if ty.is_sparse_solana(ns) {
             // sparse array
             let elem_ty = ty.storage_array_elem().deref_into();
 
             let key = ast::Type::Uint(256);
 
-            self.sparse_lookup(binary, function, &key, &elem_ty, slot, index, ns)
+            self.sparse_lookup(bin, function, &key, &elem_ty, slot, index, ns)
         } else {
             // 3rd member of account is data pointer
             let data = unsafe {
-                binary
-                    .builder
+                bin.builder
                     .build_gep(
-                        binary
-                            .module
-                            .get_struct_type("struct.SolAccountInfo")
-                            .unwrap(),
+                        bin.module.get_struct_type("struct.SolAccountInfo").unwrap(),
                         account,
                         &[
-                            binary.context.i32_type().const_zero(),
-                            binary.context.i32_type().const_int(3, false),
+                            bin.context.i32_type().const_zero(),
+                            bin.context.i32_type().const_int(3, false),
                         ],
                         "data",
                     )
                     .unwrap()
             };
 
-            let data = binary
+            let data = bin
                 .builder
                 .build_load(
-                    binary.context.i8_type().ptr_type(AddressSpace::default()),
+                    bin.context.i8_type().ptr_type(AddressSpace::default()),
                     data,
                     "data",
                 )
@@ -301,31 +282,28 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 .into_pointer_value();
 
             let member = unsafe {
-                binary
-                    .builder
-                    .build_gep(binary.context.i8_type(), data, &[slot], "data")
+                bin.builder
+                    .build_gep(bin.context.i8_type(), data, &[slot], "data")
                     .unwrap()
             };
 
-            let offset = binary
+            let offset = bin
                 .builder
-                .build_load(binary.context.i32_type(), member, "offset")
+                .build_load(bin.context.i32_type(), member, "offset")
                 .unwrap()
                 .into_int_value();
 
             let elem_ty = ty.storage_array_elem().deref_into();
 
-            let elem_size = binary
+            let elem_size = bin
                 .context
                 .i32_type()
                 .const_int(elem_ty.solana_storage_size(ns).to_u64().unwrap(), false);
 
-            binary
-                .builder
+            bin.builder
                 .build_int_add(
                     offset,
-                    binary
-                        .builder
+                    bin.builder
                         .build_int_mul(index.into_int_value(), elem_size, "")
                         .unwrap(),
                     "",
@@ -336,33 +314,32 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
     fn storage_push(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue<'a>,
         ty: &ast::Type,
         slot: IntValue<'a>,
         val: Option<BasicValueEnum<'a>>,
         ns: &ast::Namespace,
     ) -> BasicValueEnum<'a> {
-        let data = self.contract_storage_data(binary);
-        let account = self.contract_storage_account(binary);
+        let data = self.contract_storage_data(bin);
+        let account = self.contract_storage_account(bin);
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[slot], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[slot], "data")
                 .unwrap()
         };
 
-        let offset = binary
+        let offset = bin
             .builder
-            .build_load(binary.context.i32_type(), member, "offset")
+            .build_load(bin.context.i32_type(), member, "offset")
             .unwrap()
             .into_int_value();
 
-        let length = binary
+        let length = bin
             .builder
             .build_call(
-                binary.module.get_function("account_data_len").unwrap(),
+                bin.module.get_function("account_data_len").unwrap(),
                 &[data.into(), offset.into()],
                 "length",
             )
@@ -372,19 +349,19 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .unwrap()
             .into_int_value();
 
-        let member_size = binary
+        let member_size = bin
             .context
             .i32_type()
             .const_int(ty.storage_slots(ns).to_u64().unwrap(), false);
-        let new_length = binary
+        let new_length = bin
             .builder
             .build_int_add(length, member_size, "new_length")
             .unwrap();
 
-        let rc = binary
+        let rc = bin
             .builder
             .build_call(
-                binary.module.get_function("account_data_realloc").unwrap(),
+                bin.module.get_function("account_data_realloc").unwrap(),
                 &[
                     account.into(),
                     offset.into(),
@@ -399,39 +376,34 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .unwrap()
             .into_int_value();
 
-        let is_rc_zero = binary
+        let is_rc_zero = bin
             .builder
             .build_int_compare(
                 IntPredicate::EQ,
                 rc,
-                binary.context.i64_type().const_zero(),
+                bin.context.i64_type().const_zero(),
                 "is_rc_zero",
             )
             .unwrap();
 
-        let rc_not_zero = binary.context.append_basic_block(function, "rc_not_zero");
-        let rc_zero = binary.context.append_basic_block(function, "rc_zero");
+        let rc_not_zero = bin.context.append_basic_block(function, "rc_not_zero");
+        let rc_zero = bin.context.append_basic_block(function, "rc_zero");
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(is_rc_zero, rc_zero, rc_not_zero)
             .unwrap();
 
-        binary.builder.position_at_end(rc_not_zero);
+        bin.builder.position_at_end(rc_not_zero);
 
-        self.return_code(
-            binary,
-            binary.context.i64_type().const_int(5u64 << 32, false),
-        );
+        self.return_code(bin, bin.context.i64_type().const_int(5u64 << 32, false));
 
-        binary.builder.position_at_end(rc_zero);
+        bin.builder.position_at_end(rc_zero);
 
-        let mut new_offset = binary
+        let mut new_offset = bin
             .builder
             .build_int_add(
-                binary
-                    .builder
-                    .build_load(binary.context.i32_type(), member, "offset")
+                bin.builder
+                    .build_load(bin.context.i32_type(), member, "offset")
                     .unwrap()
                     .into_int_value(),
                 length,
@@ -440,7 +412,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .unwrap();
 
         if let Some(val) = val {
-            self.storage_store(binary, ty, false, &mut new_offset, val, function, ns, &None);
+            self.storage_store(bin, ty, false, &mut new_offset, val, function, ns, &None);
         }
 
         if ty.is_reference_type(ns) {
@@ -454,7 +426,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
     fn storage_pop(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue<'a>,
         ty: &ast::Type,
         slot: IntValue<'a>,
@@ -462,26 +434,25 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         ns: &ast::Namespace,
         loc: Loc,
     ) -> Option<BasicValueEnum<'a>> {
-        let data = self.contract_storage_data(binary);
-        let account = self.contract_storage_account(binary);
+        let data = self.contract_storage_data(bin);
+        let account = self.contract_storage_account(bin);
 
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[slot], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[slot], "data")
                 .unwrap()
         };
 
-        let offset = binary
+        let offset = bin
             .builder
-            .build_load(binary.context.i32_type(), member, "offset")
+            .build_load(bin.context.i32_type(), member, "offset")
             .unwrap()
             .into_int_value();
 
-        let length = binary
+        let length = bin
             .builder
             .build_call(
-                binary.module.get_function("account_data_len").unwrap(),
+                bin.module.get_function("account_data_len").unwrap(),
                 &[data.into(), offset.into()],
                 "length",
             )
@@ -492,72 +463,66 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .into_int_value();
 
         // do bounds check on index
-        let in_range = binary
+        let in_range = bin
             .builder
             .build_int_compare(
                 IntPredicate::NE,
-                binary.context.i32_type().const_zero(),
+                bin.context.i32_type().const_zero(),
                 length,
                 "index_in_range",
             )
             .unwrap();
 
-        let bang_block = binary.context.append_basic_block(function, "bang_block");
-        let retrieve_block = binary.context.append_basic_block(function, "in_range");
+        let bang_block = bin.context.append_basic_block(function, "bang_block");
+        let retrieve_block = bin.context.append_basic_block(function, "in_range");
 
-        binary
-            .builder
+        bin.builder
             .build_conditional_branch(in_range, retrieve_block, bang_block)
             .unwrap();
 
-        binary.builder.position_at_end(bang_block);
-        binary.log_runtime_error(
+        bin.builder.position_at_end(bang_block);
+        bin.log_runtime_error(
             self,
             "pop from empty storage array".to_string(),
             Some(loc),
             ns,
         );
         self.assert_failure(
-            binary,
-            binary
-                .context
+            bin,
+            bin.context
                 .i8_type()
                 .ptr_type(AddressSpace::default())
                 .const_null(),
-            binary.context.i32_type().const_zero(),
+            bin.context.i32_type().const_zero(),
         );
 
-        binary.builder.position_at_end(retrieve_block);
+        bin.builder.position_at_end(retrieve_block);
 
-        let member_size = binary
+        let member_size = bin
             .context
             .i32_type()
             .const_int(ty.storage_slots(ns).to_u64().unwrap(), false);
 
-        let new_length = binary
+        let new_length = bin
             .builder
             .build_int_sub(length, member_size, "new_length")
             .unwrap();
 
-        let mut old_elem_offset = binary
-            .builder
-            .build_int_add(offset, new_length, "")
-            .unwrap();
+        let mut old_elem_offset = bin.builder.build_int_add(offset, new_length, "").unwrap();
 
         let val = if load {
-            Some(self.storage_load(binary, ty, &mut old_elem_offset, function, ns, &None))
+            Some(self.storage_load(bin, ty, &mut old_elem_offset, function, ns, &None))
         } else {
             None
         };
 
         // delete existing storage -- pointers need to be freed
-        self.storage_free(binary, ty, data, old_elem_offset, function, false, ns);
+        self.storage_free(bin, ty, data, old_elem_offset, function, false, ns);
 
         // we can assume pointer will stay the same after realloc to smaller size
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("account_data_realloc").unwrap(),
+                bin.module.get_function("account_data_realloc").unwrap(),
                 &[
                     account.into(),
                     offset.into(),
@@ -573,37 +538,36 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
     fn storage_array_length(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         _function: FunctionValue,
         slot: IntValue<'a>,
         elem_ty: &ast::Type,
         ns: &ast::Namespace,
     ) -> IntValue<'a> {
-        let data = self.contract_storage_data(binary);
+        let data = self.contract_storage_data(bin);
 
         // the slot is simply the offset after the magic
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[slot], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[slot], "data")
                 .unwrap()
         };
 
-        let offset = binary
+        let offset = bin
             .builder
-            .build_load(binary.context.i32_type(), member, "offset")
+            .build_load(bin.context.i32_type(), member, "offset")
             .unwrap()
             .into_int_value();
 
-        let member_size = binary
+        let member_size = bin
             .context
             .i32_type()
             .const_int(elem_ty.storage_slots(ns).to_u64().unwrap(), false);
 
-        let length_bytes = binary
+        let length_bytes = bin
             .builder
             .build_call(
-                binary.module.get_function("account_data_len").unwrap(),
+                bin.module.get_function("account_data_len").unwrap(),
                 &[data.into(), offset.into()],
                 "length",
             )
@@ -613,15 +577,14 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .unwrap()
             .into_int_value();
 
-        binary
-            .builder
+        bin.builder
             .build_int_unsigned_div(length_bytes, member_size, "")
             .unwrap()
     }
 
     fn get_storage_int(
         &self,
-        _binary: &Binary<'a>,
+        _bin: &Binary<'a>,
         _function: FunctionValue,
         _slot: PointerValue<'a>,
         _ty: IntType<'a>,
@@ -634,35 +597,34 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     /// in the trait, which is for chains with 256 bit storage keys.
     fn storage_load(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         ty: &ast::Type,
         slot: &mut IntValue<'a>,
         function: FunctionValue<'a>,
         ns: &ast::Namespace,
         _storage_type: &Option<StorageType>,
     ) -> BasicValueEnum<'a> {
-        let data = self.contract_storage_data(binary);
+        let data = self.contract_storage_data(bin);
 
         // the slot is simply the offset after the magic
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[*slot], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[*slot], "data")
                 .unwrap()
         };
 
         match ty {
             ast::Type::String | ast::Type::DynamicBytes => {
-                let offset = binary
+                let offset = bin
                     .builder
-                    .build_load(binary.context.i32_type(), member, "offset")
+                    .build_load(bin.context.i32_type(), member, "offset")
                     .unwrap()
                     .into_int_value();
 
-                let string_length = binary
+                let string_length = bin
                     .builder
                     .build_call(
-                        binary.module.get_function("account_data_len").unwrap(),
+                        bin.module.get_function("account_data_len").unwrap(),
                         &[data.into(), offset.into()],
                         "free",
                     )
@@ -673,19 +635,17 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .into_int_value();
 
                 let string_data = unsafe {
-                    binary
-                        .builder
-                        .build_gep(binary.context.i8_type(), data, &[offset], "string_data")
+                    bin.builder
+                        .build_gep(bin.context.i8_type(), data, &[offset], "string_data")
                         .unwrap()
                 };
 
-                binary
-                    .builder
+                bin.builder
                     .build_call(
-                        binary.module.get_function("vector_new").unwrap(),
+                        bin.module.get_function("vector_new").unwrap(),
                         &[
                             string_length.into(),
-                            binary.context.i32_type().const_int(1, false).into(),
+                            bin.context.i32_type().const_int(1, false).into(),
                             string_data.into(),
                         ],
                         "",
@@ -696,21 +656,21 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
             }
             ast::Type::Struct(struct_ty) => {
-                let llvm_ty = binary.llvm_type(ty.deref_any(), ns);
+                let llvm_ty = bin.llvm_type(ty.deref_any(), ns);
                 // LLVMSizeOf() produces an i64
-                let size = binary
+                let size = bin
                     .builder
                     .build_int_truncate(
                         llvm_ty.size_of().unwrap(),
-                        binary.context.i32_type(),
+                        bin.context.i32_type(),
                         "size_of",
                     )
                     .unwrap();
 
-                let new = binary
+                let new = bin
                     .builder
                     .build_call(
-                        binary.module.get_function("__malloc").unwrap(),
+                        bin.module.get_function("__malloc").unwrap(),
                         &[size.into()],
                         "",
                     )
@@ -725,27 +685,25 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                         .to_u64()
                         .unwrap();
 
-                    let mut offset = binary
+                    let mut offset = bin
                         .builder
                         .build_int_add(
                             *slot,
-                            binary.context.i32_type().const_int(field_offset, false),
+                            bin.context.i32_type().const_int(field_offset, false),
                             "field_offset",
                         )
                         .unwrap();
 
-                    let val =
-                        self.storage_load(binary, &field.ty, &mut offset, function, ns, &None);
+                    let val = self.storage_load(bin, &field.ty, &mut offset, function, ns, &None);
 
                     let elem = unsafe {
-                        binary
-                            .builder
+                        bin.builder
                             .build_gep(
                                 llvm_ty,
                                 new,
                                 &[
-                                    binary.context.i32_type().const_zero(),
-                                    binary.context.i32_type().const_int(i as u64, false),
+                                    bin.context.i32_type().const_zero(),
+                                    bin.context.i32_type().const_int(i as u64, false),
                                 ],
                                 field.name_as_str(),
                             )
@@ -753,22 +711,21 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     };
 
                     let val = if field.ty.is_fixed_reference_type(ns) {
-                        let load_ty = binary.llvm_type(&field.ty, ns);
-                        binary
-                            .builder
+                        let load_ty = bin.llvm_type(&field.ty, ns);
+                        bin.builder
                             .build_load(load_ty, val.into_pointer_value(), "elem")
                             .unwrap()
                     } else {
                         val
                     };
 
-                    binary.builder.build_store(elem, val).unwrap();
+                    bin.builder.build_store(elem, val).unwrap();
                 }
 
                 new.into()
             }
             ast::Type::Array(elem_ty, dim) => {
-                let llvm_ty = binary.llvm_type(ty.deref_any(), ns);
+                let llvm_ty = bin.llvm_type(ty.deref_any(), ns);
 
                 let dest;
                 let length;
@@ -776,19 +733,19 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
                 if matches!(dim.last().unwrap(), ast::ArrayLength::Fixed(_)) {
                     // LLVMSizeOf() produces an i64 and malloc takes i32
-                    let size = binary
+                    let size = bin
                         .builder
                         .build_int_truncate(
                             llvm_ty.size_of().unwrap(),
-                            binary.context.i32_type(),
+                            bin.context.i32_type(),
                             "size_of",
                         )
                         .unwrap();
 
-                    dest = binary
+                    dest = bin
                         .builder
                         .build_call(
-                            binary.module.get_function("__malloc").unwrap(),
+                            bin.module.get_function("__malloc").unwrap(),
                             &[size.into()],
                             "",
                         )
@@ -798,7 +755,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                         .unwrap()
                         .into_pointer_value();
 
-                    length = binary.context.i32_type().const_int(
+                    length = bin.context.i32_type().const_int(
                         if let Some(ast::ArrayLength::Fixed(d)) = dim.last() {
                             d.to_u64().unwrap()
                         } else {
@@ -807,25 +764,25 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                         false,
                     );
                 } else {
-                    let llvm_elem_ty = binary.llvm_field_ty(elem_ty, ns);
-                    let elem_size = binary
+                    let llvm_elem_ty = bin.llvm_field_ty(elem_ty, ns);
+                    let elem_size = bin
                         .builder
                         .build_int_truncate(
                             llvm_elem_ty.size_of().unwrap(),
-                            binary.context.i32_type(),
+                            bin.context.i32_type(),
                             "size_of",
                         )
                         .unwrap();
 
-                    length = self.storage_array_length(binary, function, slot, elem_ty, ns);
+                    length = self.storage_array_length(bin, function, slot, elem_ty, ns);
 
-                    slot = binary
+                    slot = bin
                         .builder
-                        .build_load(binary.context.i32_type(), member, "offset")
+                        .build_load(bin.context.i32_type(), member, "offset")
                         .unwrap()
                         .into_int_value();
 
-                    dest = binary
+                    dest = bin
                         .vector_new(length, elem_size, None, elem_ty, ns)
                         .into_pointer_value();
                 };
@@ -833,22 +790,21 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 let elem_size = elem_ty.solana_storage_size(ns).to_u64().unwrap();
 
                 // loop over the array
-                let mut builder = LoopBuilder::new(binary, function);
+                let mut builder = LoopBuilder::new(bin, function);
 
                 // we need a phi for the offset
-                let offset_phi =
-                    builder.add_loop_phi(binary, "offset", slot.get_type(), slot.into());
+                let offset_phi = builder.add_loop_phi(bin, "offset", slot.get_type(), slot.into());
 
-                let index = builder.over(binary, binary.context.i32_type().const_zero(), length);
+                let index = builder.over(bin, bin.context.i32_type().const_zero(), length);
 
-                let elem = binary.array_subscript(ty.deref_any(), dest, index, ns);
+                let elem = bin.array_subscript(ty.deref_any(), dest, index, ns);
 
                 let elem_ty = ty.array_deref();
 
                 let mut offset_val = offset_phi.into_int_value();
 
                 let val = self.storage_load(
-                    binary,
+                    bin,
                     elem_ty.deref_memory(),
                     &mut offset_val,
                     function,
@@ -857,44 +813,43 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 );
 
                 let val = if elem_ty.deref_memory().is_fixed_reference_type(ns) {
-                    let load_ty = binary.llvm_type(elem_ty.deref_any(), ns);
-                    binary
-                        .builder
+                    let load_ty = bin.llvm_type(elem_ty.deref_any(), ns);
+                    bin.builder
                         .build_load(load_ty, val.into_pointer_value(), "elem")
                         .unwrap()
                 } else {
                     val
                 };
 
-                binary.builder.build_store(elem, val).unwrap();
+                bin.builder.build_store(elem, val).unwrap();
 
-                offset_val = binary
+                offset_val = bin
                     .builder
                     .build_int_add(
                         offset_val,
-                        binary.context.i32_type().const_int(elem_size, false),
+                        bin.context.i32_type().const_int(elem_size, false),
                         "new_offset",
                     )
                     .unwrap();
 
                 // set the offset for the next iteration of the loop
-                builder.set_loop_phi_value(binary, "offset", offset_val.into());
+                builder.set_loop_phi_value(bin, "offset", offset_val.into());
 
                 // done
-                builder.finish(binary);
+                builder.finish(bin);
 
                 dest.into()
             }
-            _ => binary
+            _ => bin
                 .builder
-                .build_load(binary.llvm_var_ty(ty, ns), member, "")
+                .build_load(bin.llvm_var_ty(ty, ns), member, "")
                 .unwrap(),
         }
     }
 
     fn storage_store(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         ty: &ast::Type,
         existing: bool,
         offset: &mut IntValue<'a>,
@@ -903,32 +858,31 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         ns: &ast::Namespace,
         _: &Option<StorageType>,
     ) {
-        let data = self.contract_storage_data(binary);
-        let account = self.contract_storage_account(binary);
+        let data = self.contract_storage_data(bin);
+        let account = self.contract_storage_account(bin);
 
         // the slot is simply the offset after the magic
         let member = unsafe {
-            binary
-                .builder
-                .build_gep(binary.context.i8_type(), data, &[*offset], "data")
+            bin.builder
+                .build_gep(bin.context.i8_type(), data, &[*offset], "data")
                 .unwrap()
         };
 
         if *ty == ast::Type::String || *ty == ast::Type::DynamicBytes {
-            let new_string_length = binary.vector_len(val);
+            let new_string_length = bin.vector_len(val);
 
             let offset = if existing {
-                let offset = binary
+                let offset = bin
                     .builder
-                    .build_load(binary.context.i32_type(), member, "offset")
+                    .build_load(bin.context.i32_type(), member, "offset")
                     .unwrap()
                     .into_int_value();
 
                 // get the length of the existing string in storage
-                let existing_string_length = binary
+                let existing_string_length = bin
                     .builder
                     .build_call(
-                        binary.module.get_function("account_data_len").unwrap(),
+                        bin.module.get_function("account_data_len").unwrap(),
                         &[data.into(), offset.into()],
                         "length",
                     )
@@ -939,7 +893,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .into_int_value();
 
                 // do we need to reallocate?
-                let allocation_necessary = binary
+                let allocation_necessary = bin
                     .builder
                     .build_int_compare(
                         IntPredicate::NE,
@@ -949,33 +903,31 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     )
                     .unwrap();
 
-                let entry = binary.builder.get_insert_block().unwrap();
+                let entry = bin.builder.get_insert_block().unwrap();
 
-                let realloc = binary.context.append_basic_block(function, "realloc");
-                let memcpy = binary.context.append_basic_block(function, "memcpy");
+                let realloc = bin.context.append_basic_block(function, "realloc");
+                let memcpy = bin.context.append_basic_block(function, "memcpy");
 
-                binary
-                    .builder
+                bin.builder
                     .build_conditional_branch(allocation_necessary, realloc, memcpy)
                     .unwrap();
 
-                binary.builder.position_at_end(realloc);
+                bin.builder.position_at_end(realloc);
 
                 // do not realloc since we're copying everything
-                binary
-                    .builder
+                bin.builder
                     .build_call(
-                        binary.module.get_function("account_data_free").unwrap(),
+                        bin.module.get_function("account_data_free").unwrap(),
                         &[data.into(), offset.into()],
                         "free",
                     )
                     .unwrap();
 
                 // account_data_alloc will return offset = 0 if the string is length 0
-                let rc = binary
+                let rc = bin
                     .builder
                     .build_call(
-                        binary.module.get_function("account_data_alloc").unwrap(),
+                        bin.module.get_function("account_data_alloc").unwrap(),
                         &[account.into(), new_string_length.into(), member.into()],
                         "alloc",
                     )
@@ -985,45 +937,41 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
                     .into_int_value();
 
-                let is_rc_zero = binary
+                let is_rc_zero = bin
                     .builder
                     .build_int_compare(
                         IntPredicate::EQ,
                         rc,
-                        binary.context.i64_type().const_zero(),
+                        bin.context.i64_type().const_zero(),
                         "is_rc_zero",
                     )
                     .unwrap();
 
-                let rc_not_zero = binary.context.append_basic_block(function, "rc_not_zero");
-                let rc_zero = binary.context.append_basic_block(function, "rc_zero");
+                let rc_not_zero = bin.context.append_basic_block(function, "rc_not_zero");
+                let rc_zero = bin.context.append_basic_block(function, "rc_zero");
 
-                binary
-                    .builder
+                bin.builder
                     .build_conditional_branch(is_rc_zero, rc_zero, rc_not_zero)
                     .unwrap();
 
-                binary.builder.position_at_end(rc_not_zero);
+                bin.builder.position_at_end(rc_not_zero);
 
-                self.return_code(
-                    binary,
-                    binary.context.i64_type().const_int(5u64 << 32, false),
-                );
+                self.return_code(bin, bin.context.i64_type().const_int(5u64 << 32, false));
 
-                binary.builder.position_at_end(rc_zero);
+                bin.builder.position_at_end(rc_zero);
 
-                let new_offset = binary
+                let new_offset = bin
                     .builder
-                    .build_load(binary.context.i32_type(), member, "new_offset")
+                    .build_load(bin.context.i32_type(), member, "new_offset")
                     .unwrap();
 
-                binary.builder.build_unconditional_branch(memcpy).unwrap();
+                bin.builder.build_unconditional_branch(memcpy).unwrap();
 
-                binary.builder.position_at_end(memcpy);
+                bin.builder.position_at_end(memcpy);
 
-                let offset_phi = binary
+                let offset_phi = bin
                     .builder
-                    .build_phi(binary.context.i32_type(), "offset")
+                    .build_phi(bin.context.i32_type(), "offset")
                     .unwrap();
 
                 offset_phi.add_incoming(&[(&new_offset, rc_zero), (&offset, entry)]);
@@ -1031,10 +979,10 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 offset_phi.as_basic_value().into_int_value()
             } else {
                 // account_data_alloc will return offset = 0 if the string is length 0
-                let rc = binary
+                let rc = bin
                     .builder
                     .build_call(
-                        binary.module.get_function("account_data_alloc").unwrap(),
+                        bin.module.get_function("account_data_alloc").unwrap(),
                         &[account.into(), new_string_length.into(), member.into()],
                         "alloc",
                     )
@@ -1044,59 +992,47 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
                     .into_int_value();
 
-                let is_rc_zero = binary
+                let is_rc_zero = bin
                     .builder
                     .build_int_compare(
                         IntPredicate::EQ,
                         rc,
-                        binary.context.i64_type().const_zero(),
+                        bin.context.i64_type().const_zero(),
                         "is_rc_zero",
                     )
                     .unwrap();
 
-                let rc_not_zero = binary.context.append_basic_block(function, "rc_not_zero");
-                let rc_zero = binary.context.append_basic_block(function, "rc_zero");
+                let rc_not_zero = bin.context.append_basic_block(function, "rc_not_zero");
+                let rc_zero = bin.context.append_basic_block(function, "rc_zero");
 
-                binary
-                    .builder
+                bin.builder
                     .build_conditional_branch(is_rc_zero, rc_zero, rc_not_zero)
                     .unwrap();
 
-                binary.builder.position_at_end(rc_not_zero);
+                bin.builder.position_at_end(rc_not_zero);
 
-                self.return_code(
-                    binary,
-                    binary.context.i64_type().const_int(5u64 << 32, false),
-                );
+                self.return_code(bin, bin.context.i64_type().const_int(5u64 << 32, false));
 
-                binary.builder.position_at_end(rc_zero);
+                bin.builder.position_at_end(rc_zero);
 
-                binary
-                    .builder
-                    .build_load(binary.context.i32_type(), member, "new_offset")
+                bin.builder
+                    .build_load(bin.context.i32_type(), member, "new_offset")
                     .unwrap()
                     .into_int_value()
             };
 
             let dest_string_data = unsafe {
-                binary
-                    .builder
-                    .build_gep(
-                        binary.context.i8_type(),
-                        data,
-                        &[offset],
-                        "dest_string_data",
-                    )
+                bin.builder
+                    .build_gep(bin.context.i8_type(), data, &[offset], "dest_string_data")
                     .unwrap()
             };
 
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function("__memcpy").unwrap(),
+                    bin.module.get_function("__memcpy").unwrap(),
                     &[
                         dest_string_data.into(),
-                        binary.vector_bytes(val).into(),
+                        bin.vector_bytes(val).into(),
                         new_string_length.into(),
                     ],
                     "copied",
@@ -1105,40 +1041,39 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         } else if let ast::Type::Array(elem_ty, dim) = ty {
             // make sure any pointers are freed
             if existing {
-                self.storage_free(binary, ty, data, *offset, function, false, ns);
+                self.storage_free(bin, ty, data, *offset, function, false, ns);
             }
 
             let length = if let Some(ast::ArrayLength::Fixed(length)) = dim.last() {
-                binary
-                    .context
+                bin.context
                     .i32_type()
                     .const_int(length.to_u64().unwrap(), false)
             } else {
-                binary.vector_len(val)
+                bin.vector_len(val)
             };
 
             let mut elem_slot = *offset;
 
             if Some(&ast::ArrayLength::Dynamic) == dim.last() {
                 // reallocate to the right size
-                let member_size = binary
+                let member_size = bin
                     .context
                     .i32_type()
                     .const_int(elem_ty.solana_storage_size(ns).to_u64().unwrap(), false);
-                let new_length = binary
+                let new_length = bin
                     .builder
                     .build_int_mul(length, member_size, "new_length")
                     .unwrap();
-                let offset = binary
+                let offset = bin
                     .builder
-                    .build_load(binary.context.i32_type(), member, "offset")
+                    .build_load(bin.context.i32_type(), member, "offset")
                     .unwrap()
                     .into_int_value();
 
-                let rc = binary
+                let rc = bin
                     .builder
                     .build_call(
-                        binary.module.get_function("account_data_realloc").unwrap(),
+                        bin.module.get_function("account_data_realloc").unwrap(),
                         &[
                             account.into(),
                             offset.into(),
@@ -1153,36 +1088,32 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
                     .into_int_value();
 
-                let is_rc_zero = binary
+                let is_rc_zero = bin
                     .builder
                     .build_int_compare(
                         IntPredicate::EQ,
                         rc,
-                        binary.context.i64_type().const_zero(),
+                        bin.context.i64_type().const_zero(),
                         "is_rc_zero",
                     )
                     .unwrap();
 
-                let rc_not_zero = binary.context.append_basic_block(function, "rc_not_zero");
-                let rc_zero = binary.context.append_basic_block(function, "rc_zero");
+                let rc_not_zero = bin.context.append_basic_block(function, "rc_not_zero");
+                let rc_zero = bin.context.append_basic_block(function, "rc_zero");
 
-                binary
-                    .builder
+                bin.builder
                     .build_conditional_branch(is_rc_zero, rc_zero, rc_not_zero)
                     .unwrap();
 
-                binary.builder.position_at_end(rc_not_zero);
+                bin.builder.position_at_end(rc_not_zero);
 
-                self.return_code(
-                    binary,
-                    binary.context.i64_type().const_int(5u64 << 32, false),
-                );
+                self.return_code(bin, bin.context.i64_type().const_int(5u64 << 32, false));
 
-                binary.builder.position_at_end(rc_zero);
+                bin.builder.position_at_end(rc_zero);
 
-                elem_slot = binary
+                elem_slot = bin
                     .builder
-                    .build_load(binary.context.i32_type(), member, "offset")
+                    .build_load(bin.context.i32_type(), member, "offset")
                     .unwrap()
                     .into_int_value();
             }
@@ -1190,22 +1121,22 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             let elem_size = elem_ty.solana_storage_size(ns).to_u64().unwrap();
 
             // loop over the array
-            let mut builder = LoopBuilder::new(binary, function);
+            let mut builder = LoopBuilder::new(bin, function);
 
             // we need a phi for the offset
             let offset_phi =
-                builder.add_loop_phi(binary, "offset", offset.get_type(), elem_slot.into());
+                builder.add_loop_phi(bin, "offset", offset.get_type(), elem_slot.into());
 
-            let index = builder.over(binary, binary.context.i32_type().const_zero(), length);
+            let index = builder.over(bin, bin.context.i32_type().const_zero(), length);
 
-            let elem = binary.array_subscript(ty, val.into_pointer_value(), index, ns);
+            let elem = bin.array_subscript(ty, val.into_pointer_value(), index, ns);
 
             let mut offset_val = offset_phi.into_int_value();
 
             let elem_ty = ty.array_deref();
 
             self.storage_store(
-                binary,
+                bin,
                 elem_ty.deref_any(),
                 false, // storage already freed with storage_free
                 &mut offset_val,
@@ -1213,62 +1144,57 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     elem.into()
                 } else {
                     let load_ty = if elem_ty.is_dynamic(ns) {
-                        binary
-                            .llvm_type(elem_ty.deref_memory(), ns)
+                        bin.llvm_type(elem_ty.deref_memory(), ns)
                             .ptr_type(AddressSpace::default())
                             .as_basic_type_enum()
                     } else {
-                        binary.llvm_type(elem_ty.deref_memory(), ns)
+                        bin.llvm_type(elem_ty.deref_memory(), ns)
                     };
-                    binary
-                        .builder
-                        .build_load(load_ty, elem, "array_elem")
-                        .unwrap()
+                    bin.builder.build_load(load_ty, elem, "array_elem").unwrap()
                 },
                 function,
                 ns,
                 &None,
             );
 
-            offset_val = binary
+            offset_val = bin
                 .builder
                 .build_int_add(
                     offset_val,
-                    binary.context.i32_type().const_int(elem_size, false),
+                    bin.context.i32_type().const_int(elem_size, false),
                     "new_offset",
                 )
                 .unwrap();
 
             // set the offset for the next iteration of the loop
-            builder.set_loop_phi_value(binary, "offset", offset_val.into());
+            builder.set_loop_phi_value(bin, "offset", offset_val.into());
 
             // done
-            builder.finish(binary);
+            builder.finish(bin);
         } else if let ast::Type::Struct(struct_ty) = ty {
             for (i, field) in struct_ty.definition(ns).fields.iter().enumerate() {
                 let field_offset = struct_ty.definition(ns).storage_offsets[i]
                     .to_u64()
                     .unwrap();
 
-                let mut offset = binary
+                let mut offset = bin
                     .builder
                     .build_int_add(
                         *offset,
-                        binary.context.i32_type().const_int(field_offset, false),
+                        bin.context.i32_type().const_int(field_offset, false),
                         "field_offset",
                     )
                     .unwrap();
 
-                let val_ty = binary.llvm_type(ty, ns);
+                let val_ty = bin.llvm_type(ty, ns);
                 let elem = unsafe {
-                    binary
-                        .builder
+                    bin.builder
                         .build_gep(
                             val_ty,
                             val.into_pointer_value(),
                             &[
-                                binary.context.i32_type().const_zero(),
-                                binary.context.i32_type().const_int(i as u64, false),
+                                bin.context.i32_type().const_zero(),
+                                bin.context.i32_type().const_int(i as u64, false),
                             ],
                             field.name_as_str(),
                         )
@@ -1277,11 +1203,11 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
                 // free any existing dynamic storage
                 if existing {
-                    self.storage_free(binary, &field.ty, data, offset, function, false, ns);
+                    self.storage_free(bin, &field.ty, data, offset, function, false, ns);
                 }
 
                 self.storage_store(
-                    binary,
+                    bin,
                     &field.ty,
                     existing,
                     &mut offset,
@@ -1289,15 +1215,13 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                         elem.into()
                     } else {
                         let load_ty = if field.ty.is_dynamic(ns) {
-                            binary
-                                .llvm_type(&field.ty, ns)
+                            bin.llvm_type(&field.ty, ns)
                                 .ptr_type(AddressSpace::default())
                                 .as_basic_type_enum()
                         } else {
-                            binary.llvm_type(&field.ty, ns)
+                            bin.llvm_type(&field.ty, ns)
                         };
-                        binary
-                            .builder
+                        bin.builder
                             .build_load(load_ty, elem, field.name_as_str())
                             .unwrap()
                     },
@@ -1307,13 +1231,13 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 );
             }
         } else {
-            binary.builder.build_store(member, val).unwrap();
+            bin.builder.build_store(member, val).unwrap();
         }
     }
 
     fn keccak256_hash(
         &self,
-        _binary: &Binary,
+        _bin: &Binary,
         _src: PointerValue,
         _length: IntValue,
         _dest: PointerValue,
@@ -1322,25 +1246,22 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         unreachable!();
     }
 
-    fn return_empty_abi(&self, binary: &Binary) {
+    fn return_empty_abi(&self, bin: &Binary) {
         // return 0 for success
-        binary
-            .builder
-            .build_return(Some(&binary.context.i64_type().const_int(0, false)))
+        bin.builder
+            .build_return(Some(&bin.context.i64_type().const_int(0, false)))
             .unwrap();
     }
 
-    fn assert_failure(&self, binary: &Binary, data: PointerValue, length: IntValue) {
+    fn assert_failure(&self, bin: &Binary, data: PointerValue, length: IntValue) {
         // the reason code should be null (and already printed)
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("sol_set_return_data").unwrap(),
+                bin.module.get_function("sol_set_return_data").unwrap(),
                 &[
                     data.into(),
-                    binary
-                        .builder
-                        .build_int_z_extend(length, binary.context.i64_type(), "length")
+                    bin.builder
+                        .build_int_z_extend(length, bin.context.i64_type(), "length")
                         .unwrap()
                         .into(),
                 ],
@@ -1349,24 +1270,20 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .unwrap();
 
         // return 1 for failure
-        binary
-            .builder
-            .build_return(Some(
-                &binary.context.i64_type().const_int(1u64 << 32, false),
-            ))
+        bin.builder
+            .build_return(Some(&bin.context.i64_type().const_int(1u64 << 32, false)))
             .unwrap();
     }
 
-    fn print(&self, binary: &Binary, string_ptr: PointerValue, string_len: IntValue) {
-        let string_len64 = binary
+    fn print(&self, bin: &Binary, string_ptr: PointerValue, string_len: IntValue) {
+        let string_len64 = bin
             .builder
-            .build_int_z_extend(string_len, binary.context.i64_type(), "")
+            .build_int_z_extend(string_len, bin.context.i64_type(), "")
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("sol_log_").unwrap(),
+                bin.module.get_function("sol_log_").unwrap(),
                 &[string_ptr.into(), string_len64.into()],
                 "",
             )
@@ -1376,7 +1293,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     /// Create new contract
     fn create_contract<'b>(
         &mut self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         function: FunctionValue<'b>,
         _success: Option<&mut BasicValueEnum<'b>>,
         _contract_no: usize,
@@ -1389,17 +1306,17 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     ) {
         contract_args.program_id = Some(address);
 
-        let payload = binary.vector_bytes(encoded_args);
+        let payload = bin.vector_bytes(encoded_args);
         let payload_len = encoded_args_len.into_int_value();
 
         assert!(contract_args.accounts.is_some());
         // The AccountMeta array is always present for Solana contracts
-        self.build_invoke_signed_c(binary, function, payload, payload_len, contract_args, ns);
+        self.build_invoke_signed_c(bin, function, payload, payload_len, contract_args, ns);
     }
 
     fn builtin_function(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue<'a>,
         builtin_func: &ast::Function,
         args: &[BasicMetadataValueEnum<'a>],
@@ -1410,25 +1327,24 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             first_arg_type.expect("solana does not have builtin without any parameter");
 
         if builtin_func.id.name == "create_program_address" {
-            let func = binary
+            let func = bin
                 .module
                 .get_function("sol_create_program_address")
                 .unwrap();
 
-            let seed_count = binary
+            let seed_count = bin
                 .context
                 .i64_type()
                 .const_int(first_arg_type.into_array_type().len() as u64, false);
 
             // address
-            let address = binary.build_alloca(function, binary.address_type(ns), "address");
+            let address = bin.build_alloca(function, bin.address_type(ns), "address");
 
-            binary
-                .builder
+            bin.builder
                 .build_store(address, args[1].into_array_value())
                 .unwrap();
 
-            let ret = binary
+            let ret = bin
                 .builder
                 .build_call(
                     func,
@@ -1446,25 +1362,24 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 .unwrap();
             Some(ret)
         } else if builtin_func.id.name == "try_find_program_address" {
-            let func = binary
+            let func = bin
                 .module
                 .get_function("sol_try_find_program_address")
                 .unwrap();
 
-            let seed_count = binary
+            let seed_count = bin
                 .context
                 .i64_type()
                 .const_int(first_arg_type.into_array_type().len() as u64, false);
 
             // address
-            let address = binary.build_alloca(function, binary.address_type(ns), "address");
+            let address = bin.build_alloca(function, bin.address_type(ns), "address");
 
-            binary
-                .builder
+            bin.builder
                 .build_store(address, args[1].into_array_value())
                 .unwrap();
 
-            let ret = binary
+            let ret = bin
                 .builder
                 .build_call(
                     func,
@@ -1490,7 +1405,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     /// Call external binary
     fn external_call<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         function: FunctionValue<'b>,
         _success: Option<&mut BasicValueEnum<'b>>,
         payload: PointerValue<'b>,
@@ -1505,38 +1420,33 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
         if contract_args.accounts.is_none() {
             contract_args.accounts = Some((
-                binary
-                    .context
+                bin.context
                     .i64_type()
                     .ptr_type(AddressSpace::default())
                     .const_zero(),
-                binary.context.i32_type().const_zero(),
+                bin.context.i32_type().const_zero(),
             ))
         };
 
         contract_args.program_id = Some(address.into_pointer_value());
-        self.build_invoke_signed_c(binary, function, payload, payload_len, contract_args, ns);
+        self.build_invoke_signed_c(bin, function, payload, payload_len, contract_args, ns);
     }
 
     /// Get return buffer for external call
-    fn return_data<'b>(
-        &self,
-        binary: &Binary<'b>,
-        function: FunctionValue<'b>,
-    ) -> PointerValue<'b> {
-        let null_u8_ptr = binary
+    fn return_data<'b>(&self, bin: &Binary<'b>, function: FunctionValue<'b>) -> PointerValue<'b> {
+        let null_u8_ptr = bin
             .context
             .i8_type()
             .ptr_type(AddressSpace::default())
             .const_zero();
 
-        let length_as_64 = binary
+        let length_as_64 = bin
             .builder
             .build_call(
-                binary.module.get_function("sol_get_return_data").unwrap(),
+                bin.module.get_function("sol_get_return_data").unwrap(),
                 &[
                     null_u8_ptr.into(),
-                    binary.context.i64_type().const_zero().into(),
+                    bin.context.i64_type().const_zero().into(),
                     null_u8_ptr.into(),
                 ],
                 "returndatasize",
@@ -1547,30 +1457,29 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .unwrap()
             .into_int_value();
 
-        let length = binary
+        let length = bin
             .builder
-            .build_int_truncate(length_as_64, binary.context.i32_type(), "length")
+            .build_int_truncate(length_as_64, bin.context.i32_type(), "length")
             .unwrap();
 
-        let malloc_length = binary
+        let malloc_length = bin
             .builder
             .build_int_add(
                 length,
-                binary
-                    .module
+                bin.module
                     .get_struct_type("struct.vector")
                     .unwrap()
                     .size_of()
                     .unwrap()
-                    .const_cast(binary.context.i32_type(), false),
+                    .const_cast(bin.context.i32_type(), false),
                 "size",
             )
             .unwrap();
 
-        let p = binary
+        let p = bin
             .builder
             .build_call(
-                binary.module.get_function("__malloc").unwrap(),
+                bin.module.get_function("__malloc").unwrap(),
                 &[malloc_length.into()],
                 "",
             )
@@ -1581,65 +1490,61 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             .into_pointer_value();
 
         let data_len = unsafe {
-            binary
-                .builder
+            bin.builder
                 .build_gep(
-                    binary.module.get_struct_type("struct.vector").unwrap(),
+                    bin.module.get_struct_type("struct.vector").unwrap(),
                     p,
                     &[
-                        binary.context.i32_type().const_zero(),
-                        binary.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_zero(),
                     ],
                     "data_len",
                 )
                 .unwrap()
         };
 
-        binary.builder.build_store(data_len, length).unwrap();
+        bin.builder.build_store(data_len, length).unwrap();
 
         let data_size = unsafe {
-            binary
-                .builder
+            bin.builder
                 .build_gep(
-                    binary.module.get_struct_type("struct.vector").unwrap(),
+                    bin.module.get_struct_type("struct.vector").unwrap(),
                     p,
                     &[
-                        binary.context.i32_type().const_zero(),
-                        binary.context.i32_type().const_int(1, false),
+                        bin.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_int(1, false),
                     ],
                     "data_size",
                 )
                 .unwrap()
         };
 
-        binary.builder.build_store(data_size, length).unwrap();
+        bin.builder.build_store(data_size, length).unwrap();
 
         let data = unsafe {
-            binary
-                .builder
+            bin.builder
                 .build_gep(
-                    binary.module.get_struct_type("struct.vector").unwrap(),
+                    bin.module.get_struct_type("struct.vector").unwrap(),
                     p,
                     &[
-                        binary.context.i32_type().const_zero(),
-                        binary.context.i32_type().const_int(2, false),
+                        bin.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_int(2, false),
                     ],
                     "data",
                 )
                 .unwrap()
         };
 
-        let program_id = binary.build_array_alloca(
+        let program_id = bin.build_array_alloca(
             function,
-            binary.context.i8_type(),
-            binary.context.i32_type().const_int(32, false),
+            bin.context.i8_type(),
+            bin.context.i32_type().const_int(32, false),
             "program_id",
         );
 
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("sol_get_return_data").unwrap(),
+                bin.module.get_function("sol_get_return_data").unwrap(),
                 &[data.into(), length_as_64.into(), program_id.into()],
                 "",
             )
@@ -1648,19 +1553,19 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         p
     }
 
-    fn return_code<'b>(&self, binary: &'b Binary, ret: IntValue<'b>) {
-        binary.builder.build_return(Some(&ret)).unwrap();
+    fn return_code<'b>(&self, bin: &'b Binary, ret: IntValue<'b>) {
+        bin.builder.build_return(Some(&ret)).unwrap();
     }
 
     /// Value received is not available on solana
-    fn value_transferred<'b>(&self, _binary: &Binary<'b>, _ns: &ast::Namespace) -> IntValue<'b> {
+    fn value_transferred<'b>(&self, _bin: &Binary<'b>, _ns: &ast::Namespace) -> IntValue<'b> {
         unreachable!();
     }
 
     /// Send value to address
     fn value_transfer<'b>(
         &self,
-        _binary: &Binary<'b>,
+        _bin: &Binary<'b>,
         _function: FunctionValue,
         _success: Option<&mut BasicValueEnum<'b>>,
         _address: PointerValue<'b>,
@@ -1672,83 +1577,71 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     }
 
     /// Terminate execution, destroy binary and send remaining funds to addr
-    fn selfdestruct<'b>(&self, _binary: &Binary<'b>, _addr: ArrayValue<'b>, _ns: &ast::Namespace) {
+    fn selfdestruct<'b>(&self, _bin: &Binary<'b>, _addr: ArrayValue<'b>, _ns: &ast::Namespace) {
         unimplemented!();
     }
 
     /// Emit event
     fn emit_event<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         function: FunctionValue<'b>,
         data: BasicValueEnum<'b>,
         _topics: &[BasicValueEnum<'b>],
     ) {
-        let fields = binary.build_array_alloca(
+        let fields = bin.build_array_alloca(
             function,
-            binary.module.get_struct_type("SolLogDataField").unwrap(),
-            binary.context.i32_type().const_int(1, false),
+            bin.module.get_struct_type("SolLogDataField").unwrap(),
+            bin.context.i32_type().const_int(1, false),
             "fields",
         );
 
         let field_data = unsafe {
-            binary
-                .builder
+            bin.builder
                 .build_gep(
-                    binary.module.get_struct_type("SolLogDataField").unwrap(),
+                    bin.module.get_struct_type("SolLogDataField").unwrap(),
                     fields,
                     &[
-                        binary.context.i32_type().const_zero(),
-                        binary.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_zero(),
                     ],
                     "field_data",
                 )
                 .unwrap()
         };
 
-        let bytes_pointer = binary.vector_bytes(data);
-        binary
-            .builder
-            .build_store(field_data, bytes_pointer)
-            .unwrap();
+        let bytes_pointer = bin.vector_bytes(data);
+        bin.builder.build_store(field_data, bytes_pointer).unwrap();
 
         let field_len = unsafe {
-            binary
-                .builder
+            bin.builder
                 .build_gep(
-                    binary.module.get_struct_type("SolLogDataField").unwrap(),
+                    bin.module.get_struct_type("SolLogDataField").unwrap(),
                     fields,
                     &[
-                        binary.context.i32_type().const_zero(),
-                        binary.context.i32_type().const_int(1, false),
+                        bin.context.i32_type().const_zero(),
+                        bin.context.i32_type().const_int(1, false),
                     ],
                     "data_len",
                 )
                 .unwrap()
         };
 
-        binary
-            .builder
+        bin.builder
             .build_store(
                 field_len,
-                binary
-                    .builder
-                    .build_int_z_extend(
-                        binary.vector_len(data),
-                        binary.context.i64_type(),
-                        "data_len64",
-                    )
+                bin.builder
+                    .build_int_z_extend(bin.vector_len(data), bin.context.i64_type(), "data_len64")
                     .unwrap(),
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("sol_log_data").unwrap(),
+                bin.module.get_function("sol_log_data").unwrap(),
                 &[
                     fields.into(),
-                    binary.context.i64_type().const_int(1, false).into(),
+                    bin.context.i64_type().const_int(1, false).into(),
                 ],
                 "",
             )
@@ -1758,7 +1651,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     /// builtin expressions
     fn builtin<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         expr: &codegen::Expression,
         vartab: &HashMap<usize, Variable<'b>>,
         function: FunctionValue<'b>,
@@ -1772,11 +1665,11 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 0);
 
-                let parameters = self.sol_parameters(binary);
+                let parameters = self.sol_parameters(bin);
 
-                let sol_clock = binary.module.get_function("sol_clock").unwrap();
+                let sol_clock = bin.module.get_function("sol_clock").unwrap();
 
-                let clock = binary
+                let clock = bin
                     .builder
                     .build_call(sol_clock, &[parameters.into()], "clock")
                     .unwrap()
@@ -1786,17 +1679,16 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .into_pointer_value();
 
                 // This is struct.clock_layout
-                let clock_struct = binary
+                let clock_struct = bin
                     .context
-                    .struct_type(&[binary.context.i64_type().as_basic_type_enum(); 5], false);
-                let timestamp = binary
+                    .struct_type(&[bin.context.i64_type().as_basic_type_enum(); 5], false);
+                let timestamp = bin
                     .builder
                     .build_struct_gep(clock_struct, clock, 4, "unix_timestamp")
                     .unwrap();
 
-                binary
-                    .builder
-                    .build_load(binary.context.i64_type(), timestamp, "timestamp")
+                bin.builder
+                    .build_load(bin.context.i64_type(), timestamp, "timestamp")
                     .unwrap()
             }
             codegen::Expression::Builtin {
@@ -1806,11 +1698,11 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 0);
 
-                let parameters = self.sol_parameters(binary);
+                let parameters = self.sol_parameters(bin);
 
-                let sol_clock = binary.module.get_function("sol_clock").unwrap();
+                let sol_clock = bin.module.get_function("sol_clock").unwrap();
 
-                let clock = binary
+                let clock = bin
                     .builder
                     .build_call(sol_clock, &[parameters.into()], "clock")
                     .unwrap()
@@ -1820,17 +1712,16 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .into_pointer_value();
 
                 // This is struct.clock_layout
-                let clock_struct = binary
+                let clock_struct = bin
                     .context
-                    .struct_type(&[binary.context.i64_type().as_basic_type_enum(); 5], false);
-                let slot = binary
+                    .struct_type(&[bin.context.i64_type().as_basic_type_enum(); 5], false);
+                let slot = bin
                     .builder
                     .build_struct_gep(clock_struct, clock, 0, "slot")
                     .unwrap();
 
-                binary
-                    .builder
-                    .build_load(binary.context.i64_type(), slot, "timestamp")
+                bin.builder
+                    .build_load(bin.context.i64_type(), slot, "timestamp")
                     .unwrap()
             }
             codegen::Expression::Builtin {
@@ -1840,20 +1731,15 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 0);
 
-                let parameters = self.sol_parameters(binary);
+                let parameters = self.sol_parameters(bin);
 
-                let sol_pubkey_type = binary.module.get_struct_type("struct.SolPubkey").unwrap();
-                binary
-                    .builder
+                let sol_pubkey_type = bin.module.get_struct_type("struct.SolPubkey").unwrap();
+                bin.builder
                     .build_load(
                         sol_pubkey_type.ptr_type(AddressSpace::default()),
-                        binary
-                            .builder
+                        bin.builder
                             .build_struct_gep(
-                                binary
-                                    .module
-                                    .get_struct_type("struct.SolParameters")
-                                    .unwrap(),
+                                bin.module.get_struct_type("struct.SolParameters").unwrap(),
                                 parameters,
                                 4,
                                 "program_id",
@@ -1870,19 +1756,15 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 0);
 
-                let sol_params = self.sol_parameters(binary);
+                let sol_params = self.sol_parameters(bin);
 
-                let input = binary
+                let input = bin
                     .builder
                     .build_load(
-                        binary.context.i8_type().ptr_type(AddressSpace::default()),
-                        binary
-                            .builder
+                        bin.context.i8_type().ptr_type(AddressSpace::default()),
+                        bin.builder
                             .build_struct_gep(
-                                binary
-                                    .module
-                                    .get_struct_type("struct.SolParameters")
-                                    .unwrap(),
+                                bin.module.get_struct_type("struct.SolParameters").unwrap(),
                                 sol_params,
                                 2,
                                 "input",
@@ -1893,17 +1775,13 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
                     .into_pointer_value();
 
-                let input_len = binary
+                let input_len = bin
                     .builder
                     .build_load(
-                        binary.context.i64_type(),
-                        binary
-                            .builder
+                        bin.context.i64_type(),
+                        bin.builder
                             .build_struct_gep(
-                                binary
-                                    .module
-                                    .get_struct_type("struct.SolParameters")
-                                    .unwrap(),
+                                bin.module.get_struct_type("struct.SolParameters").unwrap(),
                                 sol_params,
                                 3,
                                 "input_len",
@@ -1914,18 +1792,17 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
                     .into_int_value();
 
-                let input_len = binary
+                let input_len = bin
                     .builder
-                    .build_int_truncate(input_len, binary.context.i32_type(), "input_len")
+                    .build_int_truncate(input_len, bin.context.i32_type(), "input_len")
                     .unwrap();
 
-                binary
-                    .builder
+                bin.builder
                     .build_call(
-                        binary.module.get_function("vector_new").unwrap(),
+                        bin.module.get_function("vector_new").unwrap(),
                         &[
                             input_len.into(),
-                            binary.context.i32_type().const_int(1, false).into(),
+                            bin.context.i32_type().const_int(1, false).into(),
                             input.into(),
                         ],
                         "",
@@ -1942,19 +1819,15 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 0);
 
-                let sol_params = self.sol_parameters(binary);
+                let sol_params = self.sol_parameters(bin);
 
-                let input = binary
+                let input = bin
                     .builder
                     .build_load(
-                        binary.context.i8_type().ptr_type(AddressSpace::default()),
-                        binary
-                            .builder
+                        bin.context.i8_type().ptr_type(AddressSpace::default()),
+                        bin.builder
                             .build_struct_gep(
-                                binary
-                                    .module
-                                    .get_struct_type("struct.SolParameters")
-                                    .unwrap(),
+                                bin.module.get_struct_type("struct.SolParameters").unwrap(),
                                 sol_params,
                                 2,
                                 "input",
@@ -1965,15 +1838,14 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
                     .into_pointer_value();
 
-                let selector = binary
+                let selector = bin
                     .builder
-                    .build_load(binary.context.i64_type(), input, "selector")
+                    .build_load(bin.context.i64_type(), input, "selector")
                     .unwrap();
 
-                let bswap = binary.llvm_bswap(64);
+                let bswap = bin.llvm_bswap(64);
 
-                binary
-                    .builder
+                bin.builder
                     .build_call(bswap, &[selector.into()], "")
                     .unwrap()
                     .try_as_basic_value()
@@ -1987,22 +1859,21 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 3);
 
-                let address = binary.build_alloca(function, binary.address_type(ns), "address");
+                let address = bin.build_alloca(function, bin.address_type(ns), "address");
 
-                binary
-                    .builder
+                bin.builder
                     .build_store(
                         address,
-                        expression(self, binary, &args[0], vartab, function, ns).into_array_value(),
+                        expression(self, bin, &args[0], vartab, function, ns).into_array_value(),
                     )
                     .unwrap();
 
-                let message = expression(self, binary, &args[1], vartab, function, ns);
-                let signature = expression(self, binary, &args[2], vartab, function, ns);
-                let parameters = self.sol_parameters(binary);
-                let signature_verify = binary.module.get_function("signature_verify").unwrap();
+                let message = expression(self, bin, &args[1], vartab, function, ns);
+                let signature = expression(self, bin, &args[2], vartab, function, ns);
+                let parameters = self.sol_parameters(bin);
+                let signature_verify = bin.module.get_function("signature_verify").unwrap();
 
-                let ret = binary
+                let ret = bin
                     .builder
                     .build_call(
                         signature_verify,
@@ -2020,12 +1891,11 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                     .unwrap()
                     .into_int_value();
 
-                binary
-                    .builder
+                bin.builder
                     .build_int_compare(
                         IntPredicate::EQ,
                         ret,
-                        binary.context.i64_type().const_zero(),
+                        bin.context.i64_type().const_zero(),
                         "success",
                     )
                     .unwrap()
@@ -2038,19 +1908,16 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 0);
 
-                let parameters = self.sol_parameters(binary);
+                let parameters = self.sol_parameters(bin);
 
                 unsafe {
-                    binary.builder.build_gep(
-                        binary
-                            .module
-                            .get_struct_type("struct.SolParameters")
-                            .unwrap(),
+                    bin.builder.build_gep(
+                        bin.module.get_struct_type("struct.SolParameters").unwrap(),
                         parameters,
                         &[
-                            binary.context.i32_type().const_int(0, false),
-                            binary.context.i32_type().const_int(0, false),
-                            binary.context.i32_type().const_int(0, false),
+                            bin.context.i32_type().const_int(0, false),
+                            bin.context.i32_type().const_int(0, false),
+                            bin.context.i32_type().const_int(0, false),
                         ],
                         "accounts",
                     )
@@ -2065,38 +1932,34 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             } => {
                 assert_eq!(args.len(), 1);
 
-                let parameters = self.sol_parameters(binary);
+                let parameters = self.sol_parameters(bin);
 
-                let ka_num = binary
+                let ka_num = bin
                     .builder
                     .build_struct_gep(
-                        binary
-                            .module
-                            .get_struct_type("struct.SolParameters")
-                            .unwrap(),
+                        bin.module.get_struct_type("struct.SolParameters").unwrap(),
                         parameters,
                         1,
                         "ka_num",
                     )
                     .unwrap();
 
-                let ka_num = binary
+                let ka_num = bin
                     .builder
-                    .build_load(binary.context.i64_type(), ka_num, "ka_num")
+                    .build_load(bin.context.i64_type(), ka_num, "ka_num")
                     .unwrap()
                     .into_int_value();
 
-                binary
-                    .builder
-                    .build_int_truncate(ka_num, binary.context.i32_type(), "ka_num_32bits")
+                bin.builder
+                    .build_int_truncate(ka_num, bin.context.i32_type(), "ka_num_32bits")
                     .unwrap()
                     .into()
             }
             codegen::Expression::StructMember { expr, member, .. } => {
                 let account_info =
-                    expression(self, binary, expr, vartab, function, ns).into_pointer_value();
+                    expression(self, bin, expr, vartab, function, ns).into_pointer_value();
 
-                self.account_info_member(binary, function, account_info, *member, ns)
+                self.account_info_member(bin, function, account_info, *member, ns)
             }
             _ => unimplemented!(),
         }
@@ -2105,7 +1968,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     /// Crypto Hash
     fn hash<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         function: FunctionValue<'b>,
         hash: HashTy,
         input: PointerValue<'b>,
@@ -2119,74 +1982,66 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             _ => unreachable!(),
         };
 
-        let res = binary.build_array_alloca(
+        let res = bin.build_array_alloca(
             function,
-            binary.context.i8_type(),
-            binary.context.i32_type().const_int(hashlen, false),
+            bin.context.i8_type(),
+            bin.context.i32_type().const_int(hashlen, false),
             "res",
         );
 
         if hash == HashTy::Ripemd160 {
-            binary
-                .builder
+            bin.builder
                 .build_call(
-                    binary.module.get_function(fname).unwrap(),
+                    bin.module.get_function(fname).unwrap(),
                     &[input.into(), input_len.into(), res.into()],
                     "hash",
                 )
                 .unwrap();
         } else {
-            let u64_ty = binary.context.i64_type();
+            let u64_ty = bin.context.i64_type();
 
-            let sol_keccak256 = binary.module.get_function(fname).unwrap();
+            let sol_keccak256 = bin.module.get_function(fname).unwrap();
 
             // This is struct.SolBytes
-            let sol_bytes = binary.context.struct_type(
+            let sol_bytes = bin.context.struct_type(
                 &[
-                    binary
-                        .context
+                    bin.context
                         .i8_type()
                         .ptr_type(AddressSpace::default())
                         .as_basic_type_enum(),
-                    binary.context.i64_type().as_basic_type_enum(),
+                    bin.context.i64_type().as_basic_type_enum(),
                 ],
                 false,
             );
 
-            let array = binary.build_alloca(function, sol_bytes, "sol_bytes");
+            let array = bin.build_alloca(function, sol_bytes, "sol_bytes");
 
-            binary
-                .builder
+            bin.builder
                 .build_store(
-                    binary
-                        .builder
+                    bin.builder
                         .build_struct_gep(sol_bytes, array, 0, "input")
                         .unwrap(),
                     input,
                 )
                 .unwrap();
 
-            binary
-                .builder
+            bin.builder
                 .build_store(
-                    binary
-                        .builder
+                    bin.builder
                         .build_struct_gep(sol_bytes, array, 1, "input_len")
                         .unwrap(),
-                    binary
-                        .builder
+                    bin.builder
                         .build_int_z_extend(input_len, u64_ty, "input_len")
                         .unwrap(),
                 )
                 .unwrap();
 
-            binary
-                .builder
+            bin.builder
                 .build_call(
                     sol_keccak256,
                     &[
                         array.into(),
-                        binary.context.i32_type().const_int(1, false).into(),
+                        bin.context.i32_type().const_int(1, false).into(),
                         res.into(),
                     ],
                     "hash",
@@ -2195,29 +2050,27 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         }
 
         // bytes32 needs to reverse bytes
-        let temp = binary.build_alloca(
+        let temp = bin.build_alloca(
             function,
-            binary.llvm_type(&ast::Type::Bytes(hashlen as u8), ns),
+            bin.llvm_type(&ast::Type::Bytes(hashlen as u8), ns),
             "hash",
         );
 
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("__beNtoleN").unwrap(),
+                bin.module.get_function("__beNtoleN").unwrap(),
                 &[
                     res.into(),
                     temp.into(),
-                    binary.context.i32_type().const_int(hashlen, false).into(),
+                    bin.context.i32_type().const_int(hashlen, false).into(),
                 ],
                 "",
             )
             .unwrap();
 
-        binary
-            .builder
+        bin.builder
             .build_load(
-                binary.llvm_type(&ast::Type::Bytes(hashlen as u8), ns),
+                bin.llvm_type(&ast::Type::Bytes(hashlen as u8), ns),
                 temp,
                 "hash",
             )
@@ -2227,22 +2080,20 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
 
     fn return_abi_data<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         data: PointerValue<'b>,
         data_len: BasicValueEnum<'b>,
     ) {
-        binary
-            .builder
+        bin.builder
             .build_call(
-                binary.module.get_function("sol_set_return_data").unwrap(),
+                bin.module.get_function("sol_set_return_data").unwrap(),
                 &[data.into(), data_len.into()],
                 "",
             )
             .unwrap();
 
-        binary
-            .builder
-            .build_return(Some(&binary.return_values[&ReturnCode::Success]))
+        bin.builder
+            .build_return(Some(&bin.return_values[&ReturnCode::Success]))
             .unwrap();
     }
 }

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -126,7 +126,7 @@ impl SorobanTarget {
         contract_no: usize,
     ) -> Binary<'a> {
         let filename = ns.files[contract.loc.file_no()].file_name();
-        let mut binary = Binary::new(
+        let mut bin = Binary::new(
             context,
             ns.target,
             &contract.id.name,
@@ -137,29 +137,29 @@ impl SorobanTarget {
         );
 
         let mut export_list = Vec::new();
-        Self::declare_externals(&mut binary);
+        Self::declare_externals(&mut bin);
         Self::emit_functions_with_spec(
             contract,
-            &mut binary,
+            &mut bin,
             ns,
             context,
             contract_no,
             &mut export_list,
         );
-        binary.internalize(export_list.as_slice());
+        bin.internalize(export_list.as_slice());
 
-        Self::emit_initializer(&mut binary, ns);
+        Self::emit_initializer(&mut bin, ns);
 
-        Self::emit_env_meta_entries(context, &mut binary, opt);
+        Self::emit_env_meta_entries(context, &mut bin, opt);
 
-        binary
+        bin
     }
 
     // In Soroban, the public functions specifications is embeded in the contract binary.
     // for each function, emit both the function spec entry and the function body.
     fn emit_functions_with_spec<'a>(
         contract: &'a ast::Contract,
-        binary: &mut Binary<'a>,
+        bin: &mut Binary<'a>,
         ns: &'a ast::Namespace,
         context: &'a Context,
         _contract_no: usize,
@@ -168,7 +168,7 @@ impl SorobanTarget {
         let mut defines = Vec::new();
 
         for (cfg_no, cfg) in contract.cfg.iter().enumerate() {
-            let ftype = binary.function_type(
+            let ftype = bin.function_type(
                 &cfg.params.iter().map(|p| p.ty.clone()).collect::<Vec<_>>(),
                 &cfg.returns.iter().map(|p| p.ty.clone()).collect::<Vec<_>>(),
                 ns,
@@ -187,38 +187,37 @@ impl SorobanTarget {
                 } else {
                     &cfg.name
                 };
-                Self::emit_function_spec_entry(context, cfg, name.to_string(), binary);
+                Self::emit_function_spec_entry(context, cfg, name.to_string(), bin);
                 export_list.push(name);
                 Linkage::External
             } else {
                 Linkage::Internal
             };
 
-            let func_decl = if let Some(func) = binary.module.get_function(&cfg.name) {
+            let func_decl = if let Some(func) = bin.module.get_function(&cfg.name) {
                 // must not have a body yet
                 assert_eq!(func.get_first_basic_block(), None);
 
                 func
             } else {
-                binary.module.add_function(&cfg.name, ftype, Some(linkage))
+                bin.module.add_function(&cfg.name, ftype, Some(linkage))
             };
 
-            binary.functions.insert(cfg_no, func_decl);
+            bin.functions.insert(cfg_no, func_decl);
 
             defines.push((func_decl, cfg));
         }
 
         let init_type = context.i64_type().fn_type(&[], false);
-        binary
-            .module
+        bin.module
             .add_function("storage_initializer", init_type, None);
 
         for (func_decl, cfg) in defines {
-            emit_cfg(&mut SorobanTarget, binary, contract, cfg, func_decl, ns);
+            emit_cfg(&mut SorobanTarget, bin, contract, cfg, func_decl, ns);
         }
     }
 
-    fn emit_env_meta_entries<'a>(context: &'a Context, binary: &mut Binary<'a>, opt: &'a Options) {
+    fn emit_env_meta_entries<'a>(context: &'a Context, bin: &mut Binary<'a>, opt: &'a Options) {
         let mut meta = Limited::new(Vec::new(), Limits::none());
         let soroban_env_interface_version = opt.soroban_version;
         let soroban_env_interface_version = match soroban_env_interface_version {
@@ -231,14 +230,14 @@ impl SorobanTarget {
         ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(soroban_env_interface_version)
             .write_xdr(&mut meta)
             .expect("writing env meta interface version to xdr");
-        Self::add_custom_section(context, &binary.module, "contractenvmetav0", meta.inner);
+        Self::add_custom_section(context, &bin.module, "contractenvmetav0", meta.inner);
     }
 
     fn emit_function_spec_entry<'a>(
         context: &'a Context,
         cfg: &ControlFlowGraph,
         name: String,
-        binary: &mut Binary<'a>,
+        bin: &mut Binary<'a>,
     ) {
         if cfg.public && !cfg.is_placeholder() {
             // TODO: Emit custom type spec entries
@@ -315,7 +314,7 @@ impl SorobanTarget {
             .write_xdr(&mut spec)
             .unwrap_or_else(|_| panic!("writing spec to xdr for function {}", cfg.name));
 
-            Self::add_custom_section(context, &binary.module, "contractspecv0", spec.inner);
+            Self::add_custom_section(context, &bin.module, "contractspecv0", spec.inner);
         }
     }
 
@@ -342,7 +341,7 @@ impl SorobanTarget {
             .expect("adding spec as metadata");
     }
 
-    fn declare_externals(binary: &mut Binary) {
+    fn declare_externals(bin: &mut Binary) {
         let host_functions = [
             HostFunctions::PutContractData,
             HostFunctions::GetContractData,
@@ -374,25 +373,25 @@ impl SorobanTarget {
         ];
 
         for func in &host_functions {
-            binary.module.add_function(
+            bin.module.add_function(
                 func.name(),
-                func.function_signature(binary),
+                func.function_signature(bin),
                 Some(Linkage::External),
             );
         }
     }
 
-    fn emit_initializer(binary: &mut Binary, _ns: &ast::Namespace) {
+    fn emit_initializer(bin: &mut Binary, _ns: &ast::Namespace) {
         let mut cfg = ControlFlowGraph::new("__constructor".to_string(), ASTFunction::None);
 
         cfg.public = true;
         let void_param = ast::Parameter::new_default(ast::Type::Void);
         cfg.returns = sync::Arc::new(vec![void_param]);
 
-        Self::emit_function_spec_entry(binary.context, &cfg, "__constructor".to_string(), binary);
+        Self::emit_function_spec_entry(bin.context, &cfg, "__constructor".to_string(), bin);
 
         let function_name = CString::new(STORAGE_INITIALIZER).unwrap();
-        let mut storage_initializers = binary
+        let mut storage_initializers = bin
             .functions
             .values()
             .filter(|f: &&inkwell::values::FunctionValue| f.get_name() == function_name.as_c_str());
@@ -401,21 +400,19 @@ impl SorobanTarget {
             .expect("storage initializer is always present");
         assert!(storage_initializers.next().is_none());
 
-        let void_type = binary.context.i64_type().fn_type(&[], false);
+        let void_type = bin.context.i64_type().fn_type(&[], false);
         let constructor =
-            binary
-                .module
+            bin.module
                 .add_function("__constructor", void_type, Some(Linkage::External));
-        let entry = binary.context.append_basic_block(constructor, "entry");
+        let entry = bin.context.append_basic_block(constructor, "entry");
 
-        binary.builder.position_at_end(entry);
-        binary
-            .builder
+        bin.builder.position_at_end(entry);
+        bin.builder
             .build_call(storage_initializer, &[], "storage_initializer")
             .unwrap();
 
         // return zero
-        let zero_val = binary.context.i64_type().const_int(2, false);
-        binary.builder.build_return(Some(&zero_val)).unwrap();
+        let zero_val = bin.context.i64_type().const_int(2, false);
+        bin.builder.build_return(Some(&zero_val)).unwrap();
     }
 }

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 impl<'a> TargetRuntime<'a> for SorobanTarget {
     fn get_storage_int(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue,
         slot: PointerValue<'a>,
         ty: IntType<'a>,
@@ -39,7 +39,7 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
 
     fn storage_load(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         ty: &ast::Type,
         slot: &mut IntValue<'a>,
         function: FunctionValue<'a>,
@@ -47,19 +47,15 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
         storage_type: &Option<StorageType>,
     ) -> BasicValueEnum<'a> {
         let storage_type = storage_type_to_int(storage_type);
-        emit_context!(binary);
+        emit_context!(bin);
         let ret = call!(
             HostFunctions::GetContractData.name(),
             &[
                 slot.as_basic_value_enum()
                     .into_int_value()
-                    .const_cast(binary.context.i64_type(), false)
+                    .const_cast(bin.context.i64_type(), false)
                     .into(),
-                binary
-                    .context
-                    .i64_type()
-                    .const_int(storage_type, false)
-                    .into(),
+                bin.context.i64_type().const_int(storage_type, false).into(),
             ]
         )
         .try_as_basic_value()
@@ -73,7 +69,7 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
     /// Recursively store a type to storage
     fn storage_store(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         ty: &ast::Type,
         existing: bool,
         slot: &mut IntValue<'a>,
@@ -82,30 +78,26 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
         ns: &ast::Namespace,
         storage_type: &Option<StorageType>,
     ) {
-        emit_context!(binary);
+        emit_context!(bin);
 
         let storage_type = storage_type_to_int(storage_type);
 
-        let function_value = binary
+        let function_value = bin
             .module
             .get_function(HostFunctions::PutContractData.name())
             .unwrap();
 
-        let value = binary
+        let value = bin
             .builder
             .build_call(
                 function_value,
                 &[
                     slot.as_basic_value_enum()
                         .into_int_value()
-                        .const_cast(binary.context.i64_type(), false)
+                        .const_cast(bin.context.i64_type(), false)
                         .into(),
                     dest.into(),
-                    binary
-                        .context
-                        .i64_type()
-                        .const_int(storage_type, false)
-                        .into(),
+                    bin.context.i64_type().const_int(storage_type, false).into(),
                 ],
                 HostFunctions::PutContractData.name(),
             )
@@ -303,7 +295,7 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
 
     fn builtin_function(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         function: FunctionValue<'a>,
         builtin_func: &Function,
         args: &[BasicMetadataValueEnum<'a>],
@@ -618,12 +610,12 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
     }
 
     /// Return the value we received
-    fn value_transferred<'b>(&self, binary: &Binary<'b>, ns: &Namespace) -> IntValue<'b> {
+    fn value_transferred<'b>(&self, bin: &Binary<'b>, ns: &Namespace) -> IntValue<'b> {
         unimplemented!()
     }
 
     /// Terminate execution, destroy bin and send remaining funds to addr
-    fn selfdestruct<'b>(&self, binary: &Binary<'b>, addr: ArrayValue<'b>, ns: &Namespace) {
+    fn selfdestruct<'b>(&self, bin: &Binary<'b>, addr: ArrayValue<'b>, ns: &Namespace) {
         unimplemented!()
     }
 
@@ -654,7 +646,7 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
     /// Return ABI encoded data
     fn return_abi_data<'b>(
         &self,
-        binary: &Binary<'b>,
+        bin: &Binary<'b>,
         data: PointerValue<'b>,
         data_len: BasicValueEnum<'b>,
     ) {

--- a/src/emit/storage.rs
+++ b/src/emit/storage.rs
@@ -9,7 +9,7 @@ use inkwell::values::{ArrayValue, BasicValueEnum, FunctionValue, IntValue, Point
 pub(super) trait StorageSlot {
     fn set_storage(
         &self,
-        binary: &Binary,
+        bin: &Binary,
         slot: PointerValue,
         dest: PointerValue,
         dest_ty: BasicTypeEnum,
@@ -17,13 +17,13 @@ pub(super) trait StorageSlot {
 
     fn get_storage_address<'a>(
         &self,
-        binary: &Binary<'a>,
+        bin: &Binary<'a>,
         slot: PointerValue<'a>,
         ns: &Namespace,
     ) -> ArrayValue<'a>;
 
     /// Clear a particlar storage slot (slot-based storage chains should implement)
-    fn storage_delete_single_slot(&self, binary: &Binary, slot: PointerValue);
+    fn storage_delete_single_slot(&self, bin: &Binary, slot: PointerValue);
 
     /// Recursively load a type from storage for slot based storage
     fn storage_load_slot<'a>(


### PR DESCRIPTION
Fixes #1799 by renaming `binary` to `bin`.

This turned out to be a smaller change than going the other way (1205 replacements vs. 1496).