### PR TITLE
Make persistent/temporary/instance keywords target-aware (fixes #1847)

### DIFF
--- a/solang-parser/src/lexer.rs
+++ b/solang-parser/src/lexer.rs
@@ -361,6 +361,11 @@ pub struct Lexer<'input> {
     last_tokens: [Option<Token<'input>>; 2],
     /// The mutable reference to the error vector.
     pub errors: &'input mut Vec<LexicalError>,
+    /// When true, `persistent`, `temporary`, and `instance` are lexed as
+    /// keywords. When false (the default), they are treated as plain
+    /// identifiers so that non-Soroban targets remain compatible with
+    /// standard Solidity.
+    soroban: bool,
 }
 
 /// An error thrown by [Lexer].
@@ -593,7 +598,14 @@ impl<'input> Lexer<'input> {
             parse_semver: false,
             last_tokens: [None, None],
             errors,
+            soroban: false,
         }
+    }
+
+    /// Enable Soroban keyword mode. When enabled, `persistent`, `temporary`,
+    /// and `instance` are lexed as keywords rather than identifiers.
+    pub fn set_soroban_keywords(&mut self, enable: bool) {
+        self.soroban = enable;
     }
 
     fn parse_number(&mut self, mut start: usize, ch: char) -> Result<'input> {
@@ -860,7 +872,15 @@ impl<'input> Lexer<'input> {
                     }
 
                     return if let Some(w) = KEYWORDS.get(id) {
-                        Some((start, *w, end))
+                        // Soroban storage-type keywords should only be
+                        // recognised when we are targeting Soroban.
+                        if !self.soroban
+                            && matches!(w, Token::Persistent | Token::Temporary | Token::Instance)
+                        {
+                            Some((start, Token::Identifier(id), end))
+                        } else {
+                            Some((start, *w, end))
+                        }
                     } else {
                         Some((start, Token::Identifier(id), end))
                     };

--- a/solang-parser/src/lib.rs
+++ b/solang-parser/src/lib.rs
@@ -37,10 +37,32 @@ pub fn parse(
     src: &str,
     file_no: usize,
 ) -> Result<(pt::SourceUnit, Vec<pt::Comment>), Vec<Diagnostic>> {
+    parse_internal(src, file_no, false)
+}
+
+/// Parses a Solidity file with Soroban storage-type keywords enabled.
+///
+/// When using this function, the keywords `persistent`, `temporary`, and
+/// `instance` are recognised as Soroban storage-type annotations. Use the
+/// regular [`parse`] function for all other compilation targets so that
+/// these words can be used as ordinary identifiers.
+pub fn parse_soroban(
+    src: &str,
+    file_no: usize,
+) -> Result<(pt::SourceUnit, Vec<pt::Comment>), Vec<Diagnostic>> {
+    parse_internal(src, file_no, true)
+}
+
+fn parse_internal(
+    src: &str,
+    file_no: usize,
+    soroban: bool,
+) -> Result<(pt::SourceUnit, Vec<pt::Comment>), Vec<Diagnostic>> {
     // parse phase
     let mut comments = Vec::new();
     let mut lexer_errors = Vec::new();
     let mut lex = lexer::Lexer::new(src, file_no, &mut comments, &mut lexer_errors);
+    lex.set_soroban_keywords(soroban);
 
     let mut parser_errors = Vec::new();
     let res = solidity::SourceUnitParser::new().parse(src, file_no, &mut parser_errors, &mut lex);

--- a/solang-parser/src/tests.rs
+++ b/solang-parser/src/tests.rs
@@ -1349,3 +1349,53 @@ fn loc_union() {
     second.union(&other_first);
     assert_eq!(second, Loc::File(1, 4, 24));
 }
+
+#[test]
+fn soroban_keywords_are_identifiers_in_default_parse() {
+    // Issue #1847: `persistent`, `temporary`, and `instance` should be
+    // usable as regular identifiers when not targeting Soroban.
+    let src = r#"
+        contract C {
+            uint256 persistent = 1;
+            uint256 temporary = 2;
+            uint256 instance = 3;
+
+            function persistent() public pure returns (uint256) {
+                return 1;
+            }
+
+            function temporary() public pure returns (uint256) {
+                return 2;
+            }
+
+            function instance() public pure returns (uint256) {
+                return 3;
+            }
+        }
+    "#;
+
+    let result = crate::parse(src, 0);
+    assert!(
+        result.is_ok(),
+        "default parse() should accept persistent/temporary/instance as identifiers, got: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn soroban_keywords_are_keywords_in_soroban_parse() {
+    // Issue #1847: `persistent`, `temporary`, and `instance` should be
+    // recognised as Soroban storage-type keywords when using parse_soroban().
+    let src = r#"
+        contract C {
+            uint256 persistent x = 1;
+        }
+    "#;
+
+    let result = crate::parse_soroban(src, 0);
+    assert!(
+        result.is_ok(),
+        "parse_soroban() should accept persistent as a keyword, got: {:?}",
+        result.err()
+    );
+}

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -12,7 +12,7 @@ use crate::file_resolver::{FileResolver, ResolvedFile};
 use num_bigint::BigInt;
 use solang_parser::{
     doccomment::{parse_doccomments, DocComment},
-    parse,
+    parse, parse_soroban,
     pt::{self, CodeLocation},
 };
 use std::{ffi::OsString, str};
@@ -105,7 +105,13 @@ fn sema_file(file: &ResolvedFile, resolver: &mut FileResolver, ns: &mut ast::Nam
         file.import_no,
     ));
 
-    let (pt, comments) = match parse(&source_code, file_no) {
+    let parse_fn = if ns.target == crate::Target::Soroban {
+        parse_soroban
+    } else {
+        parse
+    };
+
+    let (pt, comments) = match parse_fn(&source_code, file_no) {
         Ok(s) => s,
         Err(mut errors) => {
             ns.diagnostics.append(&mut errors);


### PR DESCRIPTION
Fixes #1847

PR #1664 added `persistent`, `temporary`, and `instance` as global keywords, which breaks
any Solidity code using these as identifiers on non-Soroban targets (e.g. `uint256 persistent = 0;`).

This fix makes the lexer target-aware, as suggested by @seanyoung. The three words are only
treated as keywords when targeting Soroban, and fall back to plain identifiers for all other targets.

**Changes:**
- `solang-parser/src/lexer.rs` — added `soroban: bool` flag; keyword lookup skips the three tokens when flag is off
- `solang-parser/src/lib.rs` — added `parse_soroban()` alongside existing `parse()`; shared logic in `parse_internal()`
- `src/sema/mod.rs` — dispatches to `parse_soroban()` when `ns.target == Soroban`, `parse()` otherwise
- `solang-parser/src/tests.rs` — two regression tests: identifiers pass in default, keywords pass in soroban

**Testing:**
- All 18 parser unit tests pass
- All 4 doc-tests pass
- `cargo fmt --check` clean
