### PR TITLE
fix: use correct panic code in buffer bounds checks

### DIFF
--- a/src/codegen/encoding/buffer_validator.rs
+++ b/src/codegen/encoding/buffer_validator.rs
@@ -142,8 +142,8 @@ impl BufferValidator<'_> {
 
         cfg.set_basic_block(invalid);
 
-        // TODO: This needs a proper error message
-        let error = SolidityError::Panic(PanicCode::Generic);
+        // Use ArrayIndexOob panic code for proper Solidity-compliant error reporting
+        let error = SolidityError::Panic(PanicCode::ArrayIndexOob);
         assert_failure(&Loc::Codegen, error, ns, cfg, vartab);
 
         cfg.set_basic_block(valid);
@@ -222,8 +222,8 @@ impl BufferValidator<'_> {
         );
 
         cfg.set_basic_block(out_of_bounds_block);
-        // TODO: Add an error message here
-        let error = SolidityError::Panic(PanicCode::Generic);
+        // Use ArrayIndexOob panic code for proper Solidity-compliant error reporting
+        let error = SolidityError::Panic(PanicCode::ArrayIndexOob);
         assert_failure(&Loc::Codegen, error, ns, cfg, vartab);
         cfg.set_basic_block(inbounds_block);
     }


### PR DESCRIPTION
BufferValidator was emitting Panic(0x00) (Generic) for out-of-bounds reads, but 0x32 (ArrayIndexOob) is what Solidity actually specifies for this case. Debuggers and block explorers use these codes to explain reverts, so the wrong code makes failures harder to trace.

Also cleaned up the two TODO comments that were flagging this.