### PR TITLE
fix(sema): handle missing Type variants in is_fixed_reference_type

### DIFF
--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -1424,7 +1424,11 @@ impl Type {
             Type::Unresolved => false,
             Type::FunctionSelector => false,
             Type::UserType(no) => ns.user_types[*no].ty.is_fixed_reference_type(ns),
-            _ => unreachable!("{:?}", self),
+            Type::Value
+            | Type::Void
+            | Type::Unreachable
+            | Type::BufferPointer
+            | Type::SorobanHandle(_) => false,
         }
     }
 


### PR DESCRIPTION
Fixes #1882

`is_fixed_reference_type` panics with `unreachable!` when it encounters `Type::Value`, which happens when `msg.value` is placed inside an array literal and subscripted (e.g. `[msg.value][0] <= 0`).

The array subscript path in `subscript.rs` calls `array_ty.deref_memory().is_fixed_reference_type(ns)` to decide whether to keep the array pointer or load the value. For an array whose element type is `Type::Value`, this call hits the catch-all `unreachable!` arm because `Type::Value` was not listed in the match.

`Type::Value` is a primitive integer type (`is_primitive` and `is_integer` both return `true` for it in the same file), so the correct return value is `false` -- it is not a fixed-size reference type.

This patch replaces the `unreachable!` catch-all with explicit arms for the five `Type` variants that were missing from the match: `Value`, `Void`, `Unreachable`, `BufferPointer`, and `SorobanHandle`. All return `false` since none of them are reference types. This also makes the match exhaustive, preventing similar panics if the `Type` enum gains new variants in the future.

Reproduce:
```solidity
contract C {
    function f() public payable returns (bool) {
        return [msg.value][0] <= 0;
    }
}
```

```
solang compile --target polkadot mre.sol
```

Before: `thread 'main' panicked at src/sema/types.rs:1427:18`
After: compiles without error.