### PR TITLE
fix: resolve compiler panic with large exponent constant rationals

### DIFF
--- a/src/sema/eval.rs
+++ b/src/sema/eval.rs
@@ -309,22 +309,31 @@ pub fn eval_const_rational(
             var_no,
             ..
         } => {
-            let expr = ns.contracts[*contract_no].variables[*var_no]
+            if let Some(init) = ns.contracts[*contract_no].variables[*var_no]
                 .initializer
                 .as_ref()
-                .unwrap()
-                .clone();
-
-            eval_const_rational(&expr, ns)
+            {
+                eval_const_rational(&init.clone(), ns)
+            } else {
+                Err(Diagnostic::error(
+                    expr.loc(),
+                    "constant variable has no value".to_string(),
+                ))
+            }
         }
         Expression::ConstantVariable {
             contract_no: None,
             var_no,
             ..
         } => {
-            let expr = ns.constants[*var_no].initializer.as_ref().unwrap().clone();
-
-            eval_const_rational(&expr, ns)
+            if let Some(init) = ns.constants[*var_no].initializer.as_ref() {
+                eval_const_rational(&init.clone(), ns)
+            } else {
+                Err(Diagnostic::error(
+                    expr.loc(),
+                    "constant variable has no value".to_string(),
+                ))
+            }
         }
         _ => Err(Diagnostic::error(
             expr.loc(),

--- a/tests/contract_testcases/polkadot/large_exponent_const_rational.sol
+++ b/tests/contract_testcases/polkadot/large_exponent_const_rational.sol
@@ -1,0 +1,7 @@
+contract C {
+    uint public constant Y = 0e1000;
+    constructor(int[Y - .1] memory w) {}
+}
+
+// ---- Expect: diagnostics ----
+// error: 2:30-36: exponent '1000' too large


### PR DESCRIPTION
Fixes #1881 

**Description**
The compiler was occasionally panicking with `Option::unwrap() on a None value` in [eval_const_rational](cci:1://file:///d:/Desktop/open-source/solang/solang/src/sema/eval.rs:248:0-342:1) when a constant with a large scientific-notation exponent (e.g. `0e1000`) was used in a rational type context (such as array bounds).

When the parser builds the AST, [number_literal()](cci:1://file:///d:/Desktop/open-source/solang/solang/src/sema/expression/literals.rs:319:0-376:1) correctly rejects an exponent as too large, leaving the constant variable's `initializer` as `None`. However, later evaluations simply used `.unwrap()` on the initializer. This PR replaces those calls with proper `if let Some` error handling, returning a `Diagnostic` instead.

**Changes**
* Added missing initializer checks in [sema/eval.rs](cci:7://file:///d:/Desktop/open-source/solang/solang/src/sema/eval.rs:0:0-0:0) for `ConstantVariable` evaluation branches.
* Added a polkadot contract test case [large_exponent_const_rational.sol](cci:7://file:///d:/Desktop/open-source/solang/solang/tests/contract_testcases/polkadot/large_exponent_const_rational.sol:0:0-0:0) to ensure the compilation errors gracefully rather than crashing.
