### PR TITLE
fix(sema): reject subscripting zero-length bytes literal

### DIFF
--- a/src/sema/expression/subscript.rs
+++ b/src/sema/expression/subscript.rs
@@ -80,6 +80,17 @@ pub(super) fn array_subscript(
     index = index.cast(&index.loc(), index_ty.deref_any(), true, ns, diagnostics)?;
 
     let deref_ty = array_ty.deref_any();
+
+    // Subscripting a zero-length bytes type is always out of bounds.
+    // Reject early to avoid a u8 underflow in codegen (array_length - 1).
+    if let Type::Bytes(0) = deref_ty {
+        diagnostics.push(Diagnostic::error(
+            *loc,
+            "array subscript is out of bounds".to_string(),
+        ));
+        return Err(());
+    }
+
     match deref_ty {
         Type::Bytes(_) | Type::Array(..) | Type::DynamicBytes | Type::Slice(_) => {
             if array_ty.is_contract_storage() {


### PR DESCRIPTION
Fixes #1874

Subscripting an empty bytes literal (`""[0]`) panics in codegen with
`attempt to subtract with overflow`. The `array_subscript` codegen path
in `codegen/expression.rs` computes `array_length - 1` where
`array_length` is 0 (from `Type::Bytes(0)`), causing a `u8` underflow.

Without overflow checks (release builds), the subtraction silently wraps
to 254, producing an incorrect shift expression instead of panicking.

This patch adds an early check in `sema/expression/subscript.rs` that
rejects subscripting `Type::Bytes(0)` with a diagnostic error before it
reaches codegen. Any index into a zero-length bytes value is guaranteed
out of bounds, so this is a compile-time error matching solc's behavior.

Reproduce:
```solidity
contract C {
    function f() public pure returns (bytes1) {
        return ""[0];
    }
}
```

Before: `thread 'main' panicked at src/codegen/expression.rs:4077:60: attempt to subtract with overflow`
After: `error: array subscript is out of bounds`
