### PR TITLE
fix(sema): validate ternary conditions in return statements

### DIFF
--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -2042,6 +2042,8 @@ fn return_with_values(
             )?;
             used_variable(ns, &cond, symtable);
 
+            let cond = cond.cast(&cond.loc(), &Type::Bool, true, ns, diagnostics)?;
+
             let left = return_with_values(left, &left.loc(), context, symtable, ns, diagnostics)?;
             used_variable(ns, &left, symtable);
 


### PR DESCRIPTION
This PR fixes two compiler panics caused by invalid ternary conditions used in return statements:

- Fixes #1865
- Fixes #1873

The root cause is that Solang has two sema paths for ternary expressions:

- The normal expression resolver handles generic ternaries at `/sema/expression/resolve_expression.rs:180`. It resolves the condition and validates it with `cond.cast(...)?` at `/sema/expression/resolve_expression.rs:187`.

- The return specific resolver handles ternaries inside return values at `/sema/statements.rs:2034`. It resolves the condition at line:2035, but did not apply the equivalent `.cast(...)` boolean check before storing the condition in `Expression::ConditionalOperator`.

Because of that missing check, invalid conditions such as `type(bool)` or a void returning function call slip through sema and reach codegen.

Fix

Add the missing boolean check `.cast(...)` after the condition is resolved at `/sema/statements.rs:2042` and marked used at `/sema/statements.rs:2043`

```rust
used_variable(ns, &cond, symtable); // for reference

let cond = cond.cast(&cond.loc(), &Type::Bool, true, ns, diagnostics)?;
```

This makes sema reject invalid conditions like following before codegen:

- `return type(bool) ? 1 : 2;`
- `return g() ? 1 : 2;` where `g()` returns no value

This mirrors the existing generic ternary behavior at `/sema/expression/resolve_expression.rs:187`.
