### PR TITLE
fix(codegen): prevent index out of bounds in dead_storage reaching_definitions

### DIFF
--- a/src/codegen/dead_storage.rs
+++ b/src/codegen/dead_storage.rs
@@ -336,6 +336,11 @@ fn apply_transfers(
 
     debug_assert_eq!(transfers.len(), cfg.blocks[block_no].instr.len());
 
+    if transfers.is_empty() {
+        block_vars.insert(block_no, vec![vars.clone()]);
+        return;
+    }
+
     // this is done in two passes. The first pass just deals with variables.
     // The second pass deals with storage stores
 

--- a/src/sema/yul/for_loop.rs
+++ b/src/sema/yul/for_loop.rs
@@ -42,6 +42,7 @@ pub(crate) fn resolve_for_loop(
 
     loop_scope.enter_scope();
 
+    let body_reachable = next_reachable;
     let resolved_exec_block = resolve_yul_block(
         &yul_for.execution_block.loc,
         &yul_for.execution_block.statements,
@@ -52,7 +53,8 @@ pub(crate) fn resolve_for_loop(
         symtable,
         ns,
     );
-    next_reachable &= resolved_exec_block.1;
+    let post_reachable = body_reachable
+        && (resolved_exec_block.1 || block_ends_with_reachable_continue(&resolved_exec_block.0));
 
     loop_scope.leave_scope();
 
@@ -60,7 +62,7 @@ pub(crate) fn resolve_for_loop(
         &yul_for.post_block.loc,
         &yul_for.post_block.statements,
         context,
-        next_reachable,
+        post_reachable,
         loop_scope,
         function_table,
         symtable,
@@ -81,6 +83,28 @@ pub(crate) fn resolve_for_loop(
         },
         resolved_init_block.1,
     ))
+}
+
+fn block_ends_with_reachable_continue(block: &YulBlock) -> bool {
+    block
+        .statements
+        .iter()
+        .rev()
+        .find(|statement| statement.is_reachable())
+        .map(statement_ends_with_reachable_continue)
+        .unwrap_or(false)
+}
+
+fn statement_ends_with_reachable_continue(statement: &YulStatement) -> bool {
+    if !statement.is_reachable() {
+        return false;
+    }
+
+    match statement {
+        YulStatement::Continue(..) => true,
+        YulStatement::Block(block) => block_ends_with_reachable_continue(block),
+        _ => false,
+    }
 }
 
 /// Resolve for initialization block.

--- a/tests/polkadot_tests/yul.rs
+++ b/tests/polkadot_tests/yul.rs
@@ -315,3 +315,18 @@ fn storage_slot_on_return_data() {
     runtime.function("get", key.to_vec());
     assert_eq!(runtime.output(), runtime.caller())
 }
+
+#[test]
+fn continue_only_for_body() {
+    build_solidity(
+        r#"
+contract C {
+    function f() public pure {
+        assembly {
+            for { let i := 0 } lt(i, 1) { i := add(i, 1) } { continue }
+        }
+    }
+}
+        "#,
+    );
+}


### PR DESCRIPTION
## What panics and where

`solang compile --target polkadot` panics with:

```
thread 'main' panicked at src/codegen/dead_storage.rs:376:16:
index out of bounds: the len is 0 but the index is 0
```

The panic is in `apply_transfers()` at the line:

```rust
*vars = res[0].clone();
```

`res` is built by iterating over `transfers` in the first pass (lines 343–371). When a basic block has zero instructions — which happens with a Yul `for` loop whose body contains only `continue` — `transfers` is empty, `res` is never pushed to, and indexing `res[0]` panics.

## Root cause: two cooperating bugs

**Bug 1 — `dead_storage.rs`:** `apply_transfers()` does not guard against an empty `transfers`/`res` before indexing `res[0]`. The fix is a four-line early-return that records the current reaching-definition set for the block and returns without touching `*vars`, which is the correct semantic: an empty block has no transfers, so the outgoing state equals the incoming state.

**Bug 2 — `sema/yul/for_loop.rs`:** `resolve_for_loop()` computed post-block reachability purely from whether the body block fell through (`resolved_exec_block.1`). A body that ends with a reachable `continue` always reaches the post block but never falls through, so post-block reachability was incorrectly set to `false`. Codegen then skipped the post block's instructions entirely, producing an empty basic block with zero instructions — the direct trigger for Bug 1. The fix adds a helper (`block_ends_with_reachable_continue`) that walks the body's last reachable statement and ORs its result into the post-block reachability flag.

## Changes

- `src/codegen/dead_storage.rs` — guard `apply_transfers()` against empty transfers/res.
- `src/sema/yul/for_loop.rs` — fix post-block reachability when body ends with a reachable `continue`; add `block_ends_with_reachable_continue` and `statement_ends_with_reachable_continue` helpers.
- `tests/polkadot_tests/yul.rs` — regression test `continue_only_for_body` that reproduces the MRE from the issue.

## Minimum reproducer

```solidity
contract C {
    function f() public pure {
        assembly {
            for { let i := 0 } lt(i, 1) { i := add(i, 1) } { continue }
        }
    }
}
```

```
solang compile --target polkadot mre.sol
```

Before this fix: compiler panics. After this fix: compiles cleanly.

Fixes #1876