### PR TITLE
fix(sema): reject target gated builtin methods on wrong target

### DIFF
--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1445,7 +1445,11 @@ pub(super) fn resolve_method_call(
     let deref_ty = expr_ty.deref_memory();
     let funcs: Vec<_> = BUILTIN_METHODS
         .iter()
-        .filter(|func| func.name == id.name && func.method.contains(deref_ty))
+        .filter(|func| {
+            func.name == id.name
+                && func.method.contains(deref_ty)
+                && (func.target.is_empty() || func.target.contains(&ns.target))
+        })
         .collect();
 
     // try to resolve the arguments, give up if there are any errors
@@ -1523,6 +1527,19 @@ pub(super) fn resolve_method_call(
     }
 
     if funcs.is_empty() {
+        if BUILTIN_METHODS
+            .iter()
+            .any(|func| func.name == id.name && func.method.contains(deref_ty))
+        {
+            diagnostics.push(Diagnostic::error(
+                id.loc,
+                format!(
+                    "method '{}' is not available on target {}",
+                    id.name, ns.target
+                ),
+            ));
+            return Err(());
+        }
         Ok(None)
     } else {
         diagnostics.extend(call_diagnostics);


### PR DESCRIPTION
This PR fixes compiler panics caused by calling target gated builtin methods on a target they are not valid for

- Fixes #1872

Each builtin in `BUILTIN_METHODS` carries a `target` field, empty means available on all targets, non empty means restricted to the listed targets only. The `is_builtin_call` at `src/sema/builtin.rs:898` already enforces this with `p.target.is_empty() || p.target.contains(&ns.target)`. The method resolver at `src/sema/builtin.rs:1446` filters only by name and receiver type and never checks `func.target`. So any target gated builtin method passes sema on every target and reaches codegen, where the target specific host function lookup fails and the compiler panics.

`extendTtl` is gated to Soroban but sema accepted it on Solana, Polkadot, and EVM, causing `.unwrap()` to panic at `codegen/expression.rs:2892`.

Fix

Add the target check to the filter at `src/sema/builtin.rs:1446`:

```rust
let funcs: Vec<_> = BUILTIN_METHODS
    .iter()
    .filter(|func| {
        func.name == id.name
            && func.method.contains(deref_ty)
            && (func.target.is_empty() || func.target.contains(&ns.target))
    })
    .collect();
```

And improve the `funcs.is_empty()` branch at `src/sema/builtin.rs:1525` to emit a specific diagnostic when the method exists but is gated to a different target:

```rust
if funcs.is_empty() {
    if BUILTIN_METHODS
        .iter()
        .any(|func| func.name == id.name && func.method.contains(deref_ty))
    {
        diagnostics.push(Diagnostic::error(
            id.loc,
            format!(
                "method '{}' is not available on target {}",
                id.name, ns.target
            ),
        ));
        return Err(());
    }
    Ok(None)
} else {
    diagnostics.extend(call_diagnostics);
    Err(())
}
```

Now any target gated builtin method called on the wrong target is rejected in sema with a clear diagnostic instead of panicking in codegen. Methods with no target restriction are unaffected.

Happy to make changes if the approach needs adjustment.