### PR TITLE
fix(sema): reject internal function references in abi.encode* arguments

### DIFF
--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1413,6 +1413,14 @@ pub(super) fn resolve_namespace_call(
             return Err(());
         }
 
+        if matches!(ty, Type::InternalFunction { .. }) {
+            diagnostics.push(Diagnostic::error(
+                arg.loc(),
+                "internal function references cannot be abi encoded".to_string(),
+            ));
+            return Err(());
+        }
+
         expr = expr.cast(&arg.loc(), ty.deref_any(), true, ns, diagnostics)?;
 
         // A string or hex literal should be encoded as a string


### PR DESCRIPTION
This PR fixes a compiler panic when an internal function reference is passed as an argument to `abi.encode*`.

- Fixes #1862

The root cause is that sema's `abi.encode*` argument resolution loop at `sema/builtin.rs:1403` only guards against mapping and recursive types. It has no guard for `Type::InternalFunction`. So when a bare internal function reference like `f` is passed as an argument, sema accepts it without error and stores it in the AST with `Type::InternalFunction` and put into the args of `ast::Expression::Builtin`.

`codegen/expression.rs:1048` matches `ast::Builtin::AbiEncodePacked` and calls `abi_encode_packed()` at `codegen/expression.rs:1853`.

`abi_encode_packed` maps `expression()` over each arg and passes the result to `abi_encode()` at `codegen/expression.rs:1858`.

`abi_encode` calls `calculate_size_args()` at `codegen/encoding/mod.rs:48`, which calls `get_expr_size()` at `codegen/encoding/mod.rs:176`.

`get_expr_size` matches on the expression's type. `Type::InternalFunction` hits the unreachable arm at `codegen/encoding/mod.rs:1448–1453`:

```rust
Type::InternalFunction { .. } | Type::Void | ... => unreachable!("This type cannot be encoded"),
```

Fix

Add a `Type::InternalFunction` guard in the arg resolution loop at `sema/builtin.rs:1407`, that is,  immediately after the existing mapping/recursive check:

```rust
if matches!(ty, Type::InternalFunction { .. }) {
    diagnostics.push(Diagnostic::error(
        arg.loc(),
        "internal function references cannot be abi encoded".to_string(),
    ));
    return Err(());
}
```

This makes sema reject internal function references before they reach codegen. The fix covers `abi.encode*` variants such as `abi.encode`, `abi.encodePacked`, `abi.encodeWithSelector`, and `abi.encodeWithSignature`,  since they all share the same loop at `sema/builtin.rs:1403`.

Previously panicking inputs:

- `abi.encodePacked(f);`
- `abi.encode(f);`

where `f` is a function in the same contract

Reproduces on `polkadot`, `solana`, and `evm` targets.
