### PR TITLE
feat(soroban): implement `emit_event` via `contract_event` host function

### DIFF
--- a/docs/targets/soroban_examples_coverage.rst
+++ b/docs/targets/soroban_examples_coverage.rst
@@ -52,6 +52,9 @@ Documented Counterparts
    * - `token <https://github.com/stellar/soroban-examples/tree/main/token>`_
      - `docs/examples/soroban/token.sol <https://github.com/hyperledger-solang/solang/blob/main/docs/examples/soroban/token.sol>`_
      - Token-style contract with balances, allowances, and Soroban auth.
+   * - `events <https://github.com/stellar/soroban-examples/tree/main/events>`_
+     - `tests/soroban_testcases/events.rs <https://github.com/hyperledger-solang/solang/blob/main/tests/soroban_testcases/events.rs>`_
+     - Solidity ``event`` declarations and ``emit`` statements, with indexed fields mapping to Soroban topics and non-indexed fields mapping to event data.
    * - `ttl <https://github.com/stellar/soroban-examples/tree/main/ttl>`_
      - `docs/examples/soroban/ttl_storage.sol <https://github.com/hyperledger-solang/solang/blob/main/docs/examples/soroban/ttl_storage.sol>`_
      - Extending TTL on stored contract data.
@@ -172,7 +175,6 @@ The following upstream examples do not currently have a documented Solidity coun
 - `deployer <https://github.com/stellar/soroban-examples/tree/main/deployer>`_
 - `errors <https://github.com/stellar/soroban-examples/tree/main/errors>`_
 - `eth_abi <https://github.com/stellar/soroban-examples/tree/main/eth_abi>`_
-- `events <https://github.com/stellar/soroban-examples/tree/main/events>`_
 - `fuzzing <https://github.com/stellar/soroban-examples/tree/main/fuzzing>`_
 - `merkle_distribution <https://github.com/stellar/soroban-examples/tree/main/merkle_distribution>`_
 - `mint-lock <https://github.com/stellar/soroban-examples/tree/main/mint-lock>`_

--- a/docs/targets/soroban_language_compatibility.rst
+++ b/docs/targets/soroban_language_compatibility.rst
@@ -124,6 +124,33 @@ For the storage and representation side of those features, see :doc:`soroban_rus
 
 Current documented support is summarized on :doc:`soroban_support_matrix`.
 
+Events
+++++++
+
+Solidity ``event`` declarations and ``emit`` statements are supported on Soroban. The Soroban host records contract events through the ``contract_event`` host function, which takes a vector of topics and a data value.
+
+Solang maps Solidity event fields to Soroban event components as follows:
+
+- ``indexed`` fields become entries in the Soroban topics vector
+- non-indexed fields become the event data value
+
+For example:
+
+.. code-block:: solidity
+
+    contract EventEmitter {
+        event Transfer(address indexed from, address indexed to, uint64 value);
+
+        function transfer(address from, address to, uint64 amount) public {
+            from.requireAuth();
+            emit Transfer(from, to, amount);
+        }
+    }
+
+In the example above, ``from`` and ``to`` are indexed and appear as topics in the recorded Soroban event. ``value`` is non-indexed and becomes the event data. Note that Soroban imposes a limit of four topics per event, and topics cannot contain ``Vec``, ``Map``, or ``Bytes`` values longer than 32 bytes.
+
+See `tests/soroban_testcases/events.rs <https://github.com/hyperledger-solang/solang/blob/main/tests/soroban_testcases/events.rs>`_ for tested examples.
+
 Integer Widths
 ++++++++++++++
 

--- a/docs/targets/soroban_support_matrix.rst
+++ b/docs/targets/soroban_support_matrix.rst
@@ -37,8 +37,8 @@ Language Features
      - Supported
      - Primitive types, ``uint256`` and ``int256``, documented struct shapes, mappings and nested mappings, and memory/storage arrays. Examples: `token.sol <https://github.com/hyperledger-solang/solang/blob/main/docs/examples/soroban/token.sol>`_, `timelock.sol <https://github.com/hyperledger-solang/solang/blob/main/docs/examples/soroban/timelock/timelock.sol>`_, `liquidity_pool.sol <https://github.com/hyperledger-solang/solang/blob/main/docs/examples/soroban/liquidity_pool/liquidity_pool.sol>`_, `atomic_swap <https://github.com/hyperledger-solang/solang/tree/main/docs/examples/soroban/atomic_swap>`_, and `liquidity_pool <https://github.com/hyperledger-solang/solang/tree/main/docs/examples/soroban/liquidity_pool>`_.
    * - Events and logs
-     - Partially supported
-     - ``print()`` and runtime error logging are available. Solidity events are not. Example: `error.sol <https://github.com/hyperledger-solang/solang/blob/main/docs/examples/soroban/error.sol>`_.
+     - Supported
+     - Solidity ``event`` declarations and ``emit`` statements are supported. Indexed fields map to Soroban event topics and non-indexed fields map to event data. ``print()`` and runtime error logging are also available. Example: `error.sol <https://github.com/hyperledger-solang/solang/blob/main/docs/examples/soroban/error.sol>`_.
    * - Complex user-defined and composite types
      - Partial support
      - Coverage is still limited. More complex user-defined types and deeper composite values, such as nested structs, might not compile in some cases.

--- a/src/codegen/events/mod.rs
+++ b/src/codegen/events/mod.rs
@@ -2,10 +2,12 @@
 
 mod polkadot;
 mod solana;
+mod soroban;
 
 use crate::codegen::cfg::ControlFlowGraph;
 use crate::codegen::events::polkadot::PolkadotEventEmitter;
 use crate::codegen::events::solana::SolanaEventEmitter;
+use crate::codegen::events::soroban::SorobanEventEmitter;
 use crate::codegen::vartable::Vartable;
 use crate::codegen::Options;
 use crate::sema::ast;
@@ -51,6 +53,6 @@ pub(super) fn new_event_emitter<'a>(
             event_no,
         }),
 
-        Target::Soroban => todo!(),
+        Target::Soroban => Box::new(SorobanEventEmitter { args, ns, event_no }),
     }
 }

--- a/src/codegen/events/soroban.rs
+++ b/src/codegen/events/soroban.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::codegen::cfg::{ControlFlowGraph, Instr};
+use crate::codegen::encoding::soroban_encoding::soroban_encode_arg;
+use crate::codegen::events::EventEmitter;
+use crate::codegen::expression::expression;
+use crate::codegen::vartable::Vartable;
+use crate::codegen::{Expression, Options};
+use crate::sema::ast::{self, Function, Namespace, Type};
+use num_bigint::BigInt;
+use solang_parser::pt;
+
+/// Implements [EventEmitter] for the Soroban target.
+///
+/// Each indexed Solidity event field becomes a topic Val in the Soroban
+/// `contract_event` call. The first non-indexed field becomes the data Val.
+/// If there are no non-indexed fields, a zero Val is passed as data.
+pub(super) struct SorobanEventEmitter<'a> {
+    pub(super) args: &'a [ast::Expression],
+    pub(super) ns: &'a Namespace,
+    pub(super) event_no: usize,
+}
+
+impl EventEmitter for SorobanEventEmitter<'_> {
+    fn selector(&self, _: usize) -> Vec<u8> {
+        // Soroban events are identified by topics, not a selector discriminator.
+        vec![]
+    }
+
+    fn emit(
+        &self,
+        contract_no: usize,
+        func: &Function,
+        cfg: &mut ControlFlowGraph,
+        vartab: &mut Vartable,
+        opt: &Options,
+    ) {
+        let event = &self.ns.events[self.event_no];
+        let mut topics: Vec<Expression> = Vec::new();
+        let mut data_args: Vec<Expression> = Vec::new();
+
+        for (ast_exp, field) in self.args.iter().zip(event.fields.iter()) {
+            let value = expression(ast_exp, cfg, contract_no, Some(func), self.ns, vartab, opt);
+            let encoded = soroban_encode_arg(value, cfg, vartab, self.ns);
+            if field.indexed {
+                topics.push(encoded);
+            } else {
+                data_args.push(encoded);
+            }
+        }
+
+        // Soroban's contract_event takes a single Val for data. Use the first
+        // non-indexed arg if one exists; otherwise pass a zero Val.
+        let data = data_args
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| Expression::NumberLiteral {
+                loc: pt::Loc::Codegen,
+                ty: Type::Uint(64),
+                value: BigInt::from(0u64),
+            });
+
+        cfg.add(
+            vartab,
+            Instr::EmitEvent {
+                event_no: self.event_no,
+                data,
+                topics,
+            },
+        );
+    }
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -144,6 +144,7 @@ pub enum HostFunctions {
     BytesNewFromLinearMemory,
     BytesLen,
     BytesCopyToLinearMemory,
+    ContractEvent,
 }
 
 impl HostFunctions {
@@ -192,6 +193,7 @@ impl HostFunctions {
             HostFunctions::BytesNewFromLinearMemory => "b.3",
             HostFunctions::BytesLen => "b.8",
             HostFunctions::BytesCopyToLinearMemory => "b.1",
+            HostFunctions::ContractEvent => "x.1",
             HostFunctions::VecLen => "v.3",
             HostFunctions::VecPopBack => "v.7",
             HostFunctions::VecGet => "v.1",

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -156,6 +156,10 @@ impl HostFunctions {
                 .context
                 .i64_type()
                 .fn_type(&[ty.into(), ty.into(), ty.into(), ty.into()], false),
+            HostFunctions::ContractEvent => bin
+                .context
+                .i64_type()
+                .fn_type(&[ty.into(), ty.into()], false),
         }
     }
 }
@@ -468,6 +472,7 @@ impl SorobanTarget {
             HostFunctions::BytesCopyToLinearMemory,
             HostFunctions::VecLen,
             HostFunctions::VecPopBack,
+            HostFunctions::ContractEvent,
         ];
 
         for func in &host_functions {

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -1017,11 +1017,35 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
     fn emit_event<'b>(
         &self,
         bin: &Binary<'b>,
-        function: FunctionValue<'b>,
+        _function: FunctionValue<'b>,
         data: BasicValueEnum<'b>,
         topics: &[BasicValueEnum<'b>],
     ) {
-        unimplemented!()
+        emit_context!(bin);
+
+        // Build a Soroban VecObject from the topics slice.
+        // VectorNew() -> VecObject
+        let mut topics_vec = call!(HostFunctions::VectorNew.name(), &[])
+            .try_as_basic_value()
+            .left()
+            .unwrap();
+
+        // VecPushBack(vec: VecObject, val: Val) -> VecObject
+        for topic in topics.iter() {
+            topics_vec = call!(
+                HostFunctions::VecPushBack.name(),
+                &[topics_vec.into(), (*topic).into()]
+            )
+            .try_as_basic_value()
+            .left()
+            .unwrap();
+        }
+
+        // contract_event(topics: VecObject, data: Val) -> Void
+        call!(
+            HostFunctions::ContractEvent.name(),
+            &[topics_vec.into(), data.into()]
+        );
     }
 
     /// Return ABI encoded data

--- a/tests/soroban_testcases/events.rs
+++ b/tests/soroban_testcases/events.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+use crate::build_solidity;
+use soroban_sdk::testutils::Events as _;
+use soroban_sdk::{IntoVal, Val};
+
+#[test]
+fn emit_event_no_topics() {
+    let src = build_solidity(
+        r#"contract EventEmitter {
+            event Transfer(uint64 value);
+            function doTransfer(uint64 value) public {
+                emit Transfer(value);
+            }
+        }"#,
+        |_| {},
+    );
+
+    let addr = src.contracts.last().unwrap();
+    src.invoke_contract(addr, "doTransfer", vec![42_u64.into_val(&src.env)]);
+
+    let events = src.env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    assert_eq!(topics.len(), 0);
+    let expected_data: Val = 42_u64.into_val(&src.env);
+    assert!(expected_data.shallow_eq(&data));
+}
+
+#[test]
+fn emit_event_with_topic() {
+    let src = build_solidity(
+        r#"contract EventEmitter {
+            event Transfer(uint64 indexed from, uint64 value);
+            function doTransfer(uint64 from, uint64 value) public {
+                emit Transfer(from, value);
+            }
+        }"#,
+        |_| {},
+    );
+
+    let addr = src.contracts.last().unwrap();
+    src.invoke_contract(
+        addr,
+        "doTransfer",
+        vec![1_u64.into_val(&src.env), 42_u64.into_val(&src.env)],
+    );
+
+    let events = src.env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    assert_eq!(topics.len(), 1);
+    let expected_topic: Val = 1_u64.into_val(&src.env);
+    assert!(expected_topic.shallow_eq(&topics.get(0).unwrap()));
+    let expected_data: Val = 42_u64.into_val(&src.env);
+    assert!(expected_data.shallow_eq(&data));
+}

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -5,6 +5,7 @@ mod atomic_swap;
 mod auth;
 mod constructor;
 mod cross_contract_calls;
+mod events;
 mod i256_u256;
 mod integer_width_rounding;
 mod integer_width_warnings;


### PR DESCRIPTION
### Description
any solidity contract using `emit` would panic at compile time on the soroban target. the codegen dispatch in `src/codegen/events/mod.rs` had a `todo!()` for soroban, and `emit_event` in `src/emit/soroban/target.rs` was stubbed with `unimplemented!()`, so the path from solidity event emission down to the host was never wired up.

### Key Changes

- added `SorobanEventEmitter` in `src/codegen/events/soroban.rs`; indexed fields map to topics, first non-indexed field becomes the data val, falls back to zero val when there is no data
- wired `SorobanEventEmitter` into `new_event_emitter()` target dispatch
- added `ContractEvent` (`x.1`) to `HostFunctions` enum with type signature and wasm import registered in `declare_externals`
- implemented `emit_event` in `SorobanTarget` using `VectorNew` + `VecPushBack` to build the topics vec then calling `contract_event(topics, data)`

### Tests
two tests in `tests/soroban_testcases/events.rs` covering zero-topic and indexed-topic emission, both verified against the embedded soroban host.