### PR TITLE
fix(soroban): handle DynamicBytes in ABI spec, codec, and LLVM type system

### DIFF
--- a/src/codegen/encoding/soroban_encoding.rs
+++ b/src/codegen/encoding/soroban_encoding.rs
@@ -142,7 +142,7 @@ pub fn soroban_decode_arg(
         },
         Type::Uint(64) => decode_u64(wrapper_cfg, vartab, arg),
 
-        Type::Address(_) | Type::String => arg.clone(),
+        Type::Address(_) | Type::String | Type::DynamicBytes => arg.clone(),
 
         Type::Enum(enum_no) => {
             let decoded = soroban_decode_arg(arg, wrapper_cfg, vartab, ns, Some(Type::Uint(32)));
@@ -720,6 +720,11 @@ pub fn soroban_encode_arg(
             loc: Loc::Codegen,
             res: obj,
             expr: encode_vector(item.clone(), cfg, vartab),
+        },
+        Type::DynamicBytes => Instr::Set {
+            loc: Loc::Codegen,
+            res: obj,
+            expr: item.clone(),
         },
 
         _ => todo!("Type not yet supported in soroban encoder: {:?}", item.ty()),

--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -888,11 +888,8 @@ impl<'a> Binary<'a> {
 
     fn var_ty_uses_pointer_storage(&self, ty: &Type) -> bool {
         match ty.deref_memory() {
-            Type::Struct(_)
-            | Type::Array(..)
-            | Type::DynamicBytes
-            | Type::ExternalFunction { .. } => true,
-            Type::String => self.ns.target != Target::Soroban,
+            Type::Struct(_) | Type::Array(..) | Type::ExternalFunction { .. } => true,
+            Type::String | Type::DynamicBytes => self.ns.target != Target::Soroban,
             _ => false,
         }
     }

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -338,7 +338,9 @@ impl SorobanTarget {
                                 ast::Type::Uint(256) => ScSpecTypeDef::U256,
                                 ast::Type::Bool => ScSpecTypeDef::Bool,
                                 ast::Type::Address(_) => ScSpecTypeDef::Address,
-                                ast::Type::Bytes(_) => ScSpecTypeDef::Bytes,
+                                ast::Type::Bytes(_) | ast::Type::DynamicBytes => {
+                                    ScSpecTypeDef::Bytes
+                                }
                                 ast::Type::String => ScSpecTypeDef::String,
                                 ast::Type::Array(ty, _) => {
                                     let element = Self::vec_spec_type(ty.as_ref());
@@ -377,7 +379,7 @@ impl SorobanTarget {
                             ast::Type::Int(_) => ScSpecTypeDef::I32,
                             ast::Type::Bool => ScSpecTypeDef::Bool,
                             ast::Type::Address(_) => ScSpecTypeDef::Address,
-                            ast::Type::Bytes(_) => ScSpecTypeDef::Bytes,
+                            ast::Type::Bytes(_) | ast::Type::DynamicBytes => ScSpecTypeDef::Bytes,
                             ast::Type::String => ScSpecTypeDef::String,
                             ast::Type::Void => ScSpecTypeDef::Void,
                             ast::Type::Struct(_) => ScSpecTypeDef::Void, // TODO: Map struct types.

--- a/tests/soroban_testcases/dynamic_bytes.rs
+++ b/tests/soroban_testcases/dynamic_bytes.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::build_solidity;
+use soroban_sdk::{Bytes, FromVal, IntoVal};
+
+#[test]
+fn set_and_get_bytes() {
+    let src = build_solidity(
+        r#"contract BytesWriteStub {
+            bytes public data;
+
+            function set_data(bytes memory d) public {
+                data = d;
+            }
+        }"#,
+        |_| {},
+    );
+
+    let addr = src.contracts.last().unwrap();
+
+    // empty bytes round-trip
+    let empty = Bytes::from_slice(&src.env, b"");
+    src.invoke_contract(addr, "set_data", vec![empty.clone().into_val(&src.env)]);
+    let res = src.invoke_contract(addr, "data", vec![]);
+    assert_eq!(Bytes::from_val(&src.env, &res), empty);
+
+    // non-empty bytes round-trip
+    let payload = Bytes::from_slice(&src.env, b"hello");
+    src.invoke_contract(addr, "set_data", vec![payload.clone().into_val(&src.env)]);
+    let res = src.invoke_contract(addr, "data", vec![]);
+    assert_eq!(Bytes::from_val(&src.env, &res), payload);
+}

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 mod alloc;
 mod array_args;
+mod dynamic_bytes;
 mod atomic_swap;
 mod auth;
 mod constructor;


### PR DESCRIPTION
**Description**

Any solidity contract on soroban using `bytes` as a function parameter or return type would panic at compile time. This was caused by three independent gaps in the `DynamicBytes` emit path.

The following contract now compiles to a valid WASM binary:

```solidity
// SPDX-License-Identifier: Apache-2.0
contract BytesWriteStub {
    bytes public data;

    function set_data(bytes memory d) public {
        data = d;
    }
}
```

**Key Changes**

- `codegen/encoding/soroban_encoding.rs` : added `DynamicBytes` arm to `soroban_decode_arg` and `soroban_encode_arg`, same as `String` and `Address`.

- `emit/soroban/mod.rs`: added `DynamicBytes` arm to `emit_function_spec_entry` for both inputs and outputs.

- `emit/binary.rs`: extended the Soroban guard in `var_ty_uses_pointer_storage()` to cover `DynamicBytes`, on soroban `bytes` is `i64` handle, not a ptr, so its LLVM alloca must be `i64` not `ptr`

**Tests**

- Added one test in `soroban_testcases/dynamic_bytes.rs`:  covering `set_data` call with empty bytes then with `b"hello"`, reads back via the auto generated `data()` getter, and asserts equality. Verifying all three fixed gaps.
