### PR TITLE
feat: add pause example (Refs #1901)

### DIFF
--- a/docs/examples/soroban/pause/pause.sol
+++ b/docs/examples/soroban/pause/pause.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+contract Pause {
+    bool private _isPaused;
+
+    function paused() public view returns (bool) {
+        return _isPaused;
+    }
+
+    function set(bool p) public {
+        _isPaused = p;
+    }
+}

--- a/docs/examples/soroban/pause/pause.sol
+++ b/docs/examples/soroban/pause/pause.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 contract Pause {
-    bool private _isPaused;
+    bool private instance _isPaused;
 
     function paused() public view returns (bool) {
         return _isPaused;


### PR DESCRIPTION
This PR adds the Solidity equivalent of the pause contract to the Soroban examples directory. This directly addresses missing/incomplete example (pause) in the upstream example coverage tracking issue.