### PR TITLE
fix(soroban): skip empty CFGs in emit_functions_with_spec

### DIFF
--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -279,6 +279,9 @@ impl SorobanTarget {
             .add_function("storage_initializer", init_type, None);
 
         for (func_decl, cfg) in defines {
+            if cfg.is_placeholder() {
+                continue;
+            }
             emit_cfg(&mut SorobanTarget, bin, contract, cfg, func_decl);
         }
     }

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -13,6 +13,7 @@ mod integer_width_warnings;
 mod liquidity_pool;
 mod mappings;
 mod math;
+mod modifiers;
 mod print;
 mod storage;
 mod storage_array;

--- a/tests/soroban_testcases/modifiers.rs
+++ b/tests/soroban_testcases/modifiers.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::build_solidity;
+
+#[test]
+fn unused_modifier_compiles_without_panic() {
+    let src = build_solidity(
+        r#"contract C {
+          modifier m0() { _; }
+          function run() external pure {}
+      }"#,
+        |_| {},
+    );
+
+    let addr = src.contracts.last().unwrap();
+    src.invoke_contract(addr, "run", vec![]);
+}


### PR DESCRIPTION
## Description
an unused modifier produces a CFG with no basic blocks. the Soroban
emit path passed it to `emit_cfg` which called `create_block` and indexed
into the empty block list, panicking. the generic `emit_functions` path
already guards against this with `cfg.is_placeholder()`. apply the same
guard in `emit_functions_with_spec`.

## Fix
one guard added in `src/emit/soroban/mod.rs` to skip any CFG where `cfg.is_placeholder()` returns true before passing it to `emit_cfg`.

## Tests
one test in `tests/soroban_testcases/modifiers.rs` that compiles the exact MRE from the issue and invokes `run()` to show the contract is not only panic-free but executable.

Fixes #1906