### PR TITLE
fix: resolve panic when UserType appears as struct member

### DIFF
--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -1633,6 +1633,7 @@ impl Type {
                 .max()
                 .unwrap_or(1), // All fields had infinite size, so we just pretend the alignment is one
             Type::InternalFunction { .. } => ns.target.ptr_size().into(),
+            Type::UserType(no) => ns.user_types[*no].ty.align_of(ns),
             _ => 1,
         }
     }
@@ -1835,6 +1836,7 @@ impl Type {
                 Type::Mapping(..) => BigInt::from(4),
                 Type::Ref(ty) | Type::StorageRef(_, ty) => ty.storage_align(ns),
                 Type::Unresolved => BigInt::one(),
+                Type::UserType(no) => ns.user_types[*no].ty.storage_align(ns),
                 _ => unimplemented!(),
             };
 

--- a/tests/solana_tests/structs.rs
+++ b/tests/solana_tests/structs.rs
@@ -78,3 +78,40 @@ fn struct_as_reference() {
         ])
     );
 }
+
+#[test]
+fn user_defined_type_in_struct() {
+    let mut vm = build_solidity(
+        r#"
+        type C is address;
+        struct S { C c; }
+        contract T {
+            S s;
+            function set_c(C c) public {
+                s.c = c;
+            }
+            function get_c() public view returns (C) {
+                return s.c;
+            }
+        }
+        "#,
+    );
+
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let address = [0x42; 32];
+    vm.function("set_c")
+        .arguments(&[BorshToken::Address(address)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let res = vm
+        .function("get_c")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
+    assert_eq!(res, BorshToken::Address(address));
+}


### PR DESCRIPTION
### Description

This PR resolves an internal compiler panic that occurred when a user-defined value type (such as `type C is address;`) was used as a member of a struct (fixes #1920). 

### Root Cause
During semantic analysis for target Solana, layout and alignment calculations are performed on struct fields. However, `Type::storage_align` and `Type::align_of` in `src/sema/types.rs` did not handle the `Type::UserType` variant, triggering the fallback wildcard panic (`unimplemented!()`).

### Fix
- Handled `Type::UserType(no)` in `Type::storage_align` by recursing into its underlying resolved type:
  ```rust
  Type::UserType(no) => ns.user_types[*no].ty.storage_align(ns),
