### PR TITLE
Fix missing FAIL diagnostic reporting in codegen tests

### DIFF
--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -168,6 +168,10 @@ fn testcase(path: PathBuf) {
     } else if current_fail < fails.len() {
         println!("STDERR: \n===8<===8<===\n{stderr}===8<===8<===\n");
 
-        panic!("NOT FOUND FAIL: {:?}", fails[current_check]);
+        panic!(
+            "NOT FOUND FAIL: {:?}, {}",
+            fails[current_fail],
+            path.display()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fix the codegen test harness to report the unmatched `// FAIL:` directive using `current_fail` instead of `current_check`.

The previous code indexed into `fails` with `current_check`, which can point at the wrong entry or panic with an unrelated index when a `FAIL` expectation is not found. This change reports the actual missing `FAIL` expectation and includes the testcase path, matching the existing `CHECK` failure output style.

## Testing

- `cargo fmt --check`
- `git diff --check`

-`cargo test --test codegen` 