### PR TITLE
Release 0.3.5 Luxor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ will be documented here.
 
 ## Unreleased
 
+## v0.3.5 Luxor
+
+### Added
+- **Soroban** Support for `string`, `bytes` and `bytesN` types. [Islam-Imad](https://github.com/Islam-Imad)
+- **Soroban** Support for structs. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- **Soroban** Support for (u)int256. [Pratyksh Gupta](https://github.com/Pratyksh-Gupta)
+- **Soroban** Support for dynamic memory arrays. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- **Soroban** Vectors are represented in storage as `VecObject`s. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- **Soroban** Integer width rounding for unsupported integer widths. [Pratyksh Gupta](https://github.com/Pratyksh-Gupta)
+- **Soroban** Events are emitted via the `contract_event` host function. [0xull](https://github.com/0xull)
+- **Soroban** Added a `pause` example. [Amit Singhmar](https://github.com/Amit5601)
+
+### Changed
+- **codegen** Large internal refactor: introduced a `TargetCodegen` trait and moved
+  the Solana, Polkadot and Soroban backends under `src/codegen/targets/`, threading the
+  target through the lowering call graph and routing target-specific hooks (abi
+  encode/decode, storage arrays, events, builtins, load/store) through the trait. Added
+  an `EvmTarget` scaffold. [Islam-Imad](https://github.com/Islam-Imad)
+- **Soroban** Updated the Soroban protocol version to match testnet. [Ahmad Sameh](https://github.com/ahmadsamehh)
+- Bumped the inkwell crate to 0.5.0. [seanyoung](https://github.com/seanyoung)
+- Migrated the toolchain to Rust 1.90 (via 1.88). [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- Expanded the Soroban integration tests and examples, and reorganized the docs to
+  clarify Soroban support status. [salaheldinsoliman](https://github.com/salaheldinsoliman), [Mohamed Basuony](https://github.com/mohamedbasuony)
+- Binaries are uploaded on every push to the main branch. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- Moved Lucas and Xermicus to Emeritus Maintainers. [seanyoung](https://github.com/seanyoung)
+
+### Fixed
+- Committed `Cargo.lock` (pinning `ed25519-dalek` to 2.2.0) so CI and release builds are
+  reproducible and no longer break on semver-compatible upstream dependency drift; the
+  lock is un-ignored in both `.gitignore` and `.dockerignore`. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- The VS Code extension test runner no longer collects stray `*.test.js` files from
+  `node_modules`. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- **Soroban** Improved error reporting. [mohamedbasuony](https://github.com/mohamedbasuony)
+- **Soroban** Use the instance storage modifier to match upstream. [Amit Singhmar](https://github.com/Amit5601)
+- **Soroban** Propagate `strict_soroban_types` and re-enable the Soroban testcases. [Pratyksh Gupta](https://github.com/Pratyksh-Gupta)
+- Silenced the `mismatched_lifetime_syntaxes` lint. [Samuel Moelius](https://github.com/smoelius)
+- Fixed clippy warnings for Rust 1.86 and 1.88, and fixed the docs test. [seanyoung](https://github.com/seanyoung)
+- Fixed typos in the documentation. [Pratyksh Gupta](https://github.com/Pratyksh-Gupta), [John Wick](https://github.com/johnwick)
+
 ## v0.3.4 London
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "solang"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anchor-syn",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 repository = "https://github.com/hyperledger-solang/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -75,8 +75,8 @@ Once you have node and npm installed, you can build the extension like so:
     npm install -g vsce
     vsce package
 
-You should now have an extension file called ``solang-0.3.4.vsix`` which can be
-installed using ``code --install-extension solang-0.3.4.vsix``.
+You should now have an extension file called ``solang-0.3.5.vsix`` which can be
+installed using ``code --install-extension solang-0.3.5.vsix``.
 
 Alternatively, the extension is run from vscode itself.
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,11 +28,11 @@ Option 2: Download binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger-solang/solang/releases/download/v0.3.4/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger-solang/solang/releases/download/v0.3.4/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger-solang/solang/releases/download/v0.3.4/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger-solang/solang/releases/download/v0.3.4/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger-solang/solang/releases/download/v0.3.4/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger-solang/solang/releases/download/v0.3.5/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger-solang/solang/releases/download/v0.3.5/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger-solang/solang/releases/download/v0.3.5/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger-solang/solang/releases/download/v0.3.5/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger-solang/solang/releases/download/v0.3.5/solang-mac-arm>`_
 
 Download the file and save it somewhere in your ``$PATH``, for example the bin directory in your home directory. If the
 path you use is not already in ``$PATH``, then you need to add it yourself.
@@ -56,7 +56,7 @@ Option 3: Use ghcr.io/hyperledger/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger-solang/solang/pkgs/container/solang>`_.
-There is a release `v0.3.4` tag and a `latest` tag:
+There is a release `v0.3.5` tag and a `latest` tag:
 
 .. code-block:: bash
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "solang" extension will be documented in this file.
 
+## [0.3.5]
+
+- Fixed the extension test runner collecting stray `*.test.js` files from `node_modules`. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- Updated dependencies.
+
 ## [0.3.4]
 
 - Language server code completion is fully implemented. [chioni16](https://github.com/chioni16)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -9,7 +9,7 @@
 		"Govardhan G D <chioni1620@gmail.com>",
 		"Sean Young <sean@mess.org>"
 	],
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"repository": "github.com/hyperledger/solang",
 	"engines": {
 		"vscode": "^1.43.0"


### PR DESCRIPTION
Cuts the **v0.3.5 "Luxor"** release.

## Contents
- Bump `solang` to 0.3.5 (`Cargo.toml`), the VS Code extension to 0.3.5, and the version references in `docs/installing.rst` / `docs/extension.rst`.
- New `## v0.3.5 Luxor` section in `CHANGELOG.md` and `vscode/CHANGELOG.md`.
- Refreshed `Cargo.lock`.

`solang-parser` intentionally **stays at 0.3.5**: its only change since v0.3.4 is an inert clippy allow, 0.3.5 is already published, and `solang` consumes the published `solang-forge-fmt 0.2.0` (which depends on registry `solang-parser 0.3.5`) — so no parser republish is needed and the lock keeps its validated structure.

## Depends on / includes the CI reproducibility fixes (#1929)
The release build only succeeds with the dependency fix, so this branch is built on top of it. The first two commits are the same ones in #1929:
- `ci: commit Cargo.lock to pin ed25519-dalek and unbreak main` — a newly-released `ed25519-dalek 3.0.0` broke `soroban-env-host` compilation; committing `Cargo.lock` (un-ignored in `.gitignore` and `.dockerignore`) pins it to 2.2.0 and makes CI/release builds reproducible.
- `fix(vscode): exclude node_modules from test-suite glob` — the extension test runner was collecting stray `*.test.js` files from `node_modules` and aborting.

If #1929 is merged first, only the `Release 0.3.5 Luxor` commit remains in this diff.

## Highlights since v0.3.4
- **Soroban**: `string`/`bytes`/`bytesN`, structs, (u)int256, dynamic memory arrays, vectors-as-`VecObject`s in storage, integer width rounding, `contract_event`-based events, and a `pause` example.
- **codegen**: large internal refactor introducing a `TargetCodegen` trait and relocating the Solana/Polkadot/Soroban backends under `src/codegen/targets/` (plus an `EvmTarget` scaffold).
- Toolchain moved to Rust 1.90; inkwell bumped to 0.5.0.

See `CHANGELOG.md` for the full, attributed list.