### PR TITLE
Fix soroban i128/u128 encoding high-bit truncation and signed small-f…

### DIFF
--- a/src/codegen/targets/soroban/encoding.rs
+++ b/src/codegen/targets/soroban/encoding.rs
@@ -774,7 +774,7 @@ fn encode_i128(
         left: high.clone().into(),
         right: Expression::NumberLiteral {
             loc: pt::Loc::Codegen,
-            ty: Type::Uint(64),
+            ty: high.ty(),
             value: BigInt::from(0_u64),
         }
         .into(),
@@ -1140,7 +1140,7 @@ fn decode_i128(cfg: &mut ControlFlowGraph, vartab: &mut Vartable, arg: Expressio
         left: arg.clone().into(),
         right: Expression::NumberLiteral {
             loc: pt::Loc::Codegen,
-            ty: Type::Int(64),
+            ty: Type::Uint(64),
             value: BigInt::from(8_u64),
         }
         .into(),

--- a/src/codegen/targets/soroban/encoding.rs
+++ b/src/codegen/targets/soroban/encoding.rs
@@ -763,26 +763,15 @@ fn encode_i128(
     };
 
     vartab.new_dirty_tracker();
+
+    let check_lo = cfg.new_basic_block("check_lo".to_string());
     let fits_in_56_bits = cfg.new_basic_block("fits_in_56_bits".to_string());
     let should_be_in_host = cfg.new_basic_block("should_be_in_host".to_string());
     let return_block = cfg.new_basic_block("finish".to_string());
 
-    let high_8_bits = Expression::ShiftRight {
+    let high_is_zero = Expression::Equal {
         loc: pt::Loc::Codegen,
-        ty: Type::Uint(64),
-        left: lo.clone().into(),
-        right: Expression::NumberLiteral {
-            loc: pt::Loc::Codegen,
-            ty: Type::Uint(64),
-            value: BigInt::from(56_u64),
-        }
-        .into(),
-        signed: false,
-    };
-
-    let cond = Expression::Equal {
-        loc: pt::Loc::Codegen,
-        left: high_8_bits.clone().into(),
+        left: high.clone().into(),
         right: Expression::NumberLiteral {
             loc: pt::Loc::Codegen,
             ty: Type::Uint(64),
@@ -794,7 +783,51 @@ fn encode_i128(
     cfg.add(
         vartab,
         Instr::BranchCond {
-            cond,
+            cond: high_is_zero,
+            true_block: check_lo,
+            false_block: should_be_in_host,
+        },
+    );
+
+    cfg.set_basic_block(check_lo);
+
+    // check if the low limb fits within the small representation limit
+    // signed positive must stay under 55 bits to avoid sign-extension confusion.
+    // unsigned can use up to 56 bits
+    let shift_amount = match int128_ty {
+        Type::Uint(128) => 56_u64,
+        Type::Int(128) => 55_u64,
+        _ => unreachable!(),
+    };
+
+    let lo_shifted = Expression::ShiftRight {
+        loc: pt::Loc::Codegen,
+        ty: Type::Uint(64),
+        left: lo.clone().into(),
+        right: Expression::NumberLiteral {
+            loc: pt::Loc::Codegen,
+            ty: Type::Uint(64),
+            value: BigInt::from(shift_amount),
+        }
+        .into(),
+        signed: false,
+    };
+
+    let lo_is_small = Expression::Equal {
+        loc: pt::Loc::Codegen,
+        left: lo_shifted.into(),
+        right: Expression::NumberLiteral {
+            loc: pt::Loc::Codegen,
+            ty: Type::Uint(64),
+            value: BigInt::from(0_u64),
+        }
+        .into(),
+    };
+
+    cfg.add(
+        vartab,
+        Instr::BranchCond {
+            cond: lo_is_small,
             true_block: fits_in_56_bits,
             false_block: should_be_in_host,
         },
@@ -1095,9 +1128,15 @@ fn decode_i128(cfg: &mut ControlFlowGraph, vartab: &mut Vartable, arg: Expressio
 
     cfg.set_basic_block(val_in_obj);
 
+    let is_signed = matches!(ty, Type::Int(128));
+
     let value = Expression::ShiftRight {
         loc: pt::Loc::Codegen,
-        ty: Type::Int(64),
+        ty: if is_signed {
+            Type::Int(64)
+        } else {
+            Type::Uint(64)
+        },
         left: arg.clone().into(),
         right: Expression::NumberLiteral {
             loc: pt::Loc::Codegen,
@@ -1105,13 +1144,21 @@ fn decode_i128(cfg: &mut ControlFlowGraph, vartab: &mut Vartable, arg: Expressio
             value: BigInt::from(8_u64),
         }
         .into(),
-        signed: false,
+        signed: is_signed,
     };
 
-    let extend = Expression::ZeroExt {
-        loc: Loc::Codegen,
-        ty: ty.clone(),
-        expr: Box::new(value.clone()),
+    let extend = match ty {
+        Type::Int(128) => Expression::SignExt {
+            loc: Loc::Codegen,
+            ty: ty.clone(),
+            expr: Box::new(value.clone()),
+        },
+        Type::Uint(128) => Expression::ZeroExt {
+            loc: Loc::Codegen,
+            ty: ty.clone(),
+            expr: Box::new(value.clone()),
+        },
+        _ => unreachable!(),
     };
 
     let set_instr = Instr::Set {

--- a/tests/soroban_testcases/i128_u128.rs
+++ b/tests/soroban_testcases/i128_u128.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 use crate::build_solidity;
 use soroban_sdk::{FromVal, IntoVal, Val};
 

--- a/tests/soroban_testcases/i128_u128.rs
+++ b/tests/soroban_testcases/i128_u128.rs
@@ -1,0 +1,78 @@
+use crate::build_solidity;
+use soroban_sdk::{FromVal, IntoVal, Val};
+
+#[test]
+fn uint128_high_limb_not_dropped_on_encode() {
+    let runtime = build_solidity(
+        r#"contract test {
+            function id(uint128 a) public returns (uint128) { return a; }
+        }"#,
+        |_| {},
+    );
+    let addr = runtime.contracts.last().unwrap();
+    let value: u128 = (1u128 << 64) + 5; // high limb set, low limb < 2**56
+    let arg: Val = value.into_val(&runtime.env);
+    let res: Val = runtime.invoke_contract(addr, "id", vec![arg]);
+    let got: u128 = FromVal::from_val(&runtime.env, &res);
+    assert_eq!(got, value, "uint128 high 64 bits were dropped on encode");
+}
+
+#[test]
+fn i128_u128_encode_decode_coverage() {
+    let runtime = build_solidity(
+        r#"contract test {
+            function id_u(uint128 a) public returns (uint128) { return a; }
+            function id_i(int128 a) public returns (int128) { return a; }
+        }"#,
+        |_| {},
+    );
+    let addr = runtime.contracts.last().unwrap();
+
+    // uint128 test values: zero, small (56-bit), boundary, high bits, edge cases
+    let u_vals = [
+        0u128,
+        1,
+        (1 << 56) - 1,
+        1 << 56,
+        (1 << 64) - 1,
+        1 << 64,
+        (1 << 64) + 5,
+        u64::MAX as u128,
+        u128::MAX,
+    ];
+
+    for &v in &u_vals {
+        let res = runtime.invoke_contract(addr, "id_u", vec![v.into_val(&runtime.env)]);
+        assert_eq!(
+            u128::from_val(&runtime.env, &res),
+            v,
+            "uint128 failed for {}",
+            v
+        );
+    }
+
+    // int128 test values: zero, small pos/neg (56-bit), boundary, high bits, edge cases
+    let i_vals = [
+        0i128,
+        1,
+        (1 << 55) - 1,
+        1 << 55,
+        (1 << 63) - 1,
+        -(1 << 55),
+        -(1 << 55) - 1,
+        -1,
+        i64::MIN as i128,
+        i128::MIN,
+        i128::MAX,
+    ];
+
+    for &v in &i_vals {
+        let res = runtime.invoke_contract(addr, "id_i", vec![v.into_val(&runtime.env)]);
+        assert_eq!(
+            i128::from_val(&runtime.env, &res),
+            v,
+            "int128 failed for {}",
+            v
+        );
+    }
+}

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -9,6 +9,7 @@ mod constructor;
 mod cross_contract_calls;
 mod events;
 mod hello_world;
+mod i128_u128;
 mod i256_u256;
 mod integer_width_rounding;
 mod integer_width_warnings;


### PR DESCRIPTION
Fixes #1938

* **Fixes `i128`/`u128` encoding truncation:** Gated the small-form encoding on the full 128-bit value (`value >> 8 == 0`) rather than just the low 64-bit limb, preventing high-bit truncation.

* **Fixes signed small-form decoding:** Replaced the default zero-extension with sign-extension (`SignExt`) when decoding signed `i128` small-form values to prevent negative numbers from decoding as positive.

* **Tests:** Added the reproduction test and expanded coverage for both small-form/host-object boundaries and negative numbers.