### PR TITLE
feat(soroban): implement sha256 host function builtin

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -92,6 +92,7 @@ impl From<inkwell::OptimizationLevel> for OptimizationLevel {
 }
 
 pub enum HostFunctions {
+    ComputeHashSha256,
     PutContractData,
     GetContractData,
     HasContractData,
@@ -156,6 +157,7 @@ pub enum HostFunctions {
 impl HostFunctions {
     pub fn name(&self) -> &str {
         match self {
+            HostFunctions::ComputeHashSha256 => "c._",
             HostFunctions::PutContractData => "l._",
             HostFunctions::GetContractData => "l.1",
             HostFunctions::HasContractData => "l.0",

--- a/src/codegen/targets/soroban/mod.rs
+++ b/src/codegen/targets/soroban/mod.rs
@@ -302,6 +302,34 @@ impl TargetCodegen for SorobanTarget {
                 );
                 Some(address_var)
             }
+            ast::Builtin::Sha256 => {
+                let input = expression(&args[0], cfg, contract_no, func, ns, vartab, opt, self);
+                let bytes_obj = soroban_encode_arg(input, cfg, vartab, ns);
+                let hash_obj = vartab.temp_anonymous(&Type::Uint(64));
+                cfg.add(
+                    vartab,
+                    Instr::Call {
+                        res: vec![hash_obj],
+                        call: InternalCallTy::HostFunction {
+                            name: HostFunctions::ComputeHashSha256.name().to_string(),
+                        },
+                        args: vec![bytes_obj],
+                        return_tys: vec![Type::Uint(64)],
+                    },
+                );
+                let hash_expr = Expression::Variable {
+                    loc: pt::Loc::Codegen,
+                    ty: Type::Uint(64),
+                    var_no: hash_obj,
+                };
+                Some(soroban_decode_arg(
+                    hash_expr,
+                    cfg,
+                    vartab,
+                    ns,
+                    Some(Type::Bytes(32)),
+                ))
+            }
             ast::Builtin::BlockNumber => {
                 let block_var_no = vartab.temp_name("block_number", &Type::Uint(64));
                 let block_var = Expression::Variable {

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -188,6 +188,7 @@ impl HostFunctions {
                 .context
                 .i64_type()
                 .fn_type(&[ty.into(), ty.into()], false),
+            HostFunctions::ComputeHashSha256 => bin.context.i64_type().fn_type(&[ty.into()], false),
         }
     }
 }
@@ -554,6 +555,7 @@ impl SorobanTarget {
             HostFunctions::VecLen,
             HostFunctions::VecPopBack,
             HostFunctions::ContractEvent,
+            HostFunctions::ComputeHashSha256,
         ];
 
         for func in &host_functions {

--- a/tests/soroban_testcases/hash.rs
+++ b/tests/soroban_testcases/hash.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+use crate::build_solidity;
+use soroban_sdk::{Bytes, BytesN, IntoVal, TryFromVal};
+
+#[test]
+fn sha256_basic() {
+    let runtime = build_solidity(
+        r#"contract HashTest {
+            function hash(bytes memory input) public pure returns (bytes32) {
+                return sha256(input);
+            }
+        }"#,
+        |_| {},
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+
+    let input = Bytes::from_slice(&runtime.env, b"abc");
+    let result = runtime.invoke_contract(addr, "hash", vec![input.into_val(&runtime.env)]);
+
+    let result_bytes = BytesN::<32>::try_from_val(&runtime.env, &result).unwrap();
+
+    // let expected = BytesN::<32>::from_array(
+    //     &runtime.env,
+    //     &hex_literal::hex!("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"),
+    // );
+
+    let expected = BytesN::<32>::from_array(
+        &runtime.env,
+        &[
+            0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae,
+            0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61,
+            0xf2, 0x00, 0x15, 0xad,
+        ],
+    );
+
+    assert_eq!(result_bytes, expected);
+}

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -10,6 +10,7 @@ mod bytes_pass;
 mod constructor;
 mod cross_contract_calls;
 mod events;
+mod hash;
 mod hello_world;
 mod i128_u128;
 mod i256_u256;


### PR DESCRIPTION
## Support sha256 on Soroban

Closes #1973

Implements sha256(bytes) for the Soroban target. Previously this panicked at compile time via SorobanTarget::hash() -> unsupported_soroban(...).

### Changes
- Add HostFunctions::ComputeHashSha256 (host symbol c._, Soroban's compute_hash_sha256) in src/codegen/mod.rs

- Add its signature ((i64) -> i64) and external declaration in src/emit/soroban/mod.rs

- Lower Builtin::Sha256 in SorobanTarget::lower_builtin (src/codegen/targets/soroban/mod.rs): encode input via soroban_encode_arg, call the host function, decode result via soroban_decode_arg as Bytes(32)

- Add a test in tests/soroban_testcases/hash.rs verifying the result against the known sha256("abc") vector

### Note
This is a fresh implementation against current main rather than a rebase of #1919, since that PR predates the codegen/targets tree reorg. Same end state described in the issue.