### PR TITLE
fix(soroban): support scalar-array returns and unsigned enum tag

### DIFF
--- a/src/codegen/targets/soroban/encoding.rs
+++ b/src/codegen/targets/soroban/encoding.rs
@@ -461,7 +461,9 @@ pub fn soroban_encode_arg(
                     right: Box::new(Expression::NumberLiteral {
                         loc: item.loc(),
                         ty: Type::Uint(64),
-                        value: tags::I32.into(),
+                        // Enum discriminants are unsigned and decoded as `Uint(32)`, so they must
+                        // be encoded with the U32 `Val` tag (not the signed I32 tag).
+                        value: tags::U32.into(),
                     }),
                     overflowing: false,
                 },
@@ -643,7 +645,7 @@ pub fn soroban_encode_arg(
         Type::Array(_, _) => Instr::Set {
             loc: Loc::Codegen,
             res: obj,
-            expr: encode_vector(item.clone(), cfg, vartab),
+            expr: encode_vector(item.clone(), cfg, vartab, ns),
         },
 
         _ => panic!(
@@ -1956,21 +1958,174 @@ fn encode_vector(
     item: Expression,
     cfg: &mut ControlFlowGraph,
     vartab: &mut Vartable,
+    ns: &Namespace,
 ) -> Expression {
-    let len = Expression::Builtin {
-        loc: item.loc(),
-        tys: vec![Type::Uint(32)],
-        kind: Builtin::ArrayLength,
-        args: vec![item.clone()],
+    let loc = item.loc();
+    let item_ty = item.ty();
+
+    // Length of the source array (held in a variable so it survives the encode loop below).
+    let len_var = vartab.temp_name("vec_len", &Type::Uint(32));
+    cfg.add(
+        vartab,
+        Instr::Set {
+            loc,
+            res: len_var,
+            expr: Expression::Builtin {
+                loc,
+                tys: vec![Type::Uint(32)],
+                kind: Builtin::ArrayLength,
+                args: vec![item.clone()],
+            },
+        },
+    );
+    let len = Expression::Variable {
+        loc,
+        ty: Type::Uint(32),
+        var_no: len_var,
+    };
+
+    let elem_ty = match item_ty.deref_any() {
+        Type::Array(elem, _) => elem.as_ref().clone(),
+        _ => Type::Uint(64),
+    };
+
+    // `vec_new_from_linear_memory` reads a contiguous buffer of encoded `Val`s. If the array
+    // elements are already encoded (`SorobanHandle`, e.g. a decoded argument passed straight
+    // through), the array's own buffer is directly usable. Otherwise the array holds raw scalars
+    // (e.g. a freshly built `uint64[]`), so encode each element into a `Val` buffer first.
+    let vals = if matches!(elem_ty, Type::SorobanHandle(_)) {
+        item.clone()
+    } else {
+        let vals_ty = Type::Array(Box::new(Type::Uint(64)), vec![ArrayLength::Dynamic]);
+        let vals_var = vartab.temp_name("encoded_vec", &vals_ty);
+        cfg.add(
+            vartab,
+            Instr::Set {
+                loc,
+                res: vals_var,
+                expr: Expression::AllocDynamicBytes {
+                    loc,
+                    ty: vals_ty.clone(),
+                    size: Box::new(len.clone()),
+                    initializer: None,
+                },
+            },
+        );
+        let vals = Expression::Variable {
+            loc,
+            ty: vals_ty.clone(),
+            var_no: vals_var,
+        };
+
+        let i_var = vartab.temp_name("i", &Type::Uint(32));
+        cfg.add(
+            vartab,
+            Instr::Set {
+                loc,
+                res: i_var,
+                expr: Expression::NumberLiteral {
+                    loc,
+                    ty: Type::Uint(32),
+                    value: BigInt::from(0_u64),
+                },
+            },
+        );
+        let i = Expression::Variable {
+            loc,
+            ty: Type::Uint(32),
+            var_no: i_var,
+        };
+
+        let cond_block = cfg.new_basic_block("vec_encode_cond".to_string());
+        let body_block = cfg.new_basic_block("vec_encode_body".to_string());
+        let done_block = cfg.new_basic_block("vec_encode_done".to_string());
+
+        // Track the loop counter so a phi node is emitted at the loop header. Without this the
+        // counter would be folded to its initial value (0) at every use, giving an infinite loop.
+        // `i_var` was created before this call, so it falls under the tracker; the temporaries
+        // created inside `soroban_encode_arg` are created afterwards and stay out of this set.
+        vartab.new_dirty_tracker();
+
+        cfg.add(vartab, Instr::Branch { block: cond_block });
+        cfg.set_basic_block(cond_block);
+        cfg.add(
+            vartab,
+            Instr::BranchCond {
+                cond: Expression::Less {
+                    loc,
+                    signed: false,
+                    left: Box::new(i.clone()),
+                    right: Box::new(len.clone()),
+                },
+                true_block: body_block,
+                false_block: done_block,
+            },
+        );
+
+        cfg.set_basic_block(body_block);
+        // Load the value at index `i` (Subscript yields the element address, so read through it).
+        let elem = Expression::Load {
+            loc,
+            ty: elem_ty.clone(),
+            expr: Box::new(Expression::Subscript {
+                loc,
+                ty: Type::Ref(Box::new(elem_ty.clone())),
+                array_ty: item_ty.clone(),
+                expr: Box::new(item.clone()),
+                index: Box::new(i.clone()),
+            }),
+        };
+        let encoded = soroban_encode_arg(elem, cfg, vartab, ns);
+        cfg.add(
+            vartab,
+            Instr::Store {
+                dest: Expression::Subscript {
+                    loc,
+                    ty: Type::Ref(Box::new(Type::Uint(64))),
+                    array_ty: vals_ty.clone(),
+                    expr: Box::new(vals.clone()),
+                    index: Box::new(i.clone()),
+                },
+                data: encoded,
+            },
+        );
+        cfg.add(
+            vartab,
+            Instr::Set {
+                loc,
+                res: i_var,
+                expr: Expression::Add {
+                    loc,
+                    ty: Type::Uint(32),
+                    overflowing: false,
+                    left: Box::new(i.clone()),
+                    right: Box::new(Expression::NumberLiteral {
+                        loc,
+                        ty: Type::Uint(32),
+                        value: BigInt::from(1_u64),
+                    }),
+                },
+            },
+        );
+        cfg.add(vartab, Instr::Branch { block: cond_block });
+
+        cfg.set_basic_block(done_block);
+
+        let phis = vartab.pop_dirty_tracker();
+        cfg.set_phis(cond_block, phis.clone());
+        cfg.set_phis(body_block, phis.clone());
+        cfg.set_phis(done_block, phis);
+
+        vals
     };
 
     let data_ptr = Expression::VectorData {
-        pointer: Box::new(item.clone()),
+        pointer: Box::new(vals),
     };
 
     // VectorNewFromLinearMemory expects (ptr_u32val, len_u32val).
-    let encoded_ptr = encode_object(item.loc(), data_ptr, 32, tags::U32);
-    let encoded_len = encode_object(item.loc(), len, 32, tags::U32);
+    let encoded_ptr = encode_object(loc, data_ptr, 32, tags::U32);
+    let encoded_len = encode_object(loc, len, 32, tags::U32);
 
     let obj = vartab.temp_name("vec_obj", &Type::Uint(64));
     cfg.add(
@@ -1983,7 +2138,7 @@ fn encode_vector(
     );
 
     Expression::Variable {
-        loc: item.loc(),
+        loc,
         ty: Type::Uint(64),
         var_no: obj,
     }

--- a/src/codegen/targets/soroban/mod.rs
+++ b/src/codegen/targets/soroban/mod.rs
@@ -1098,7 +1098,16 @@ fn unsupported_return_type(ty: &Type, ns: &Namespace) -> Option<String> {
         Type::Struct(_) => {
             soroban_struct_field_unsupported(ty, ns).map(|_| format!("{} memory", ty.to_string(ns)))
         }
-        Type::Array(_, _) => Some(format!("{} memory", ty.to_string(ns))),
+        // Arrays of scalar elements round-trip (`encode_vector` encodes each element into a
+        // `Val` buffer before building the host Vec). Reject arrays whose element type is
+        // unsupported (structs, `bytes`/`bytesN`), and `string` elements, which have no
+        // verified return encoding yet.
+        Type::Array(elem, _)
+            if has_unsupported_soroban_array_element(elem.as_ref())
+                || matches!(elem.as_ref(), Type::String) =>
+        {
+            Some(format!("{} memory", ty.to_string(ns)))
+        }
         _ => None,
     }
 }

--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -1078,7 +1078,7 @@ impl<'a> Binary<'a> {
         let allocator = if self.ns.target == Target::Soroban {
             self.builder.build_call(
                 self.module.get_function("soroban_alloc_init").unwrap(),
-                &[size.into(), init.into()],
+                &[size.into(), elem_size.into(), init.into()],
                 "soroban_alloc",
             )
         } else {

--- a/src/emit/expression.rs
+++ b/src/emit/expression.rs
@@ -1581,7 +1581,7 @@ pub(super) fn expression<'a, T: TargetRuntime<'a> + ?Sized>(
                 bin.builder
                     .build_call(
                         bin.module.get_function("soroban_alloc_init").unwrap(),
-                        &[size.into(), init.into()],
+                        &[size.into(), elem_size.into(), init.into()],
                         "soroban_alloc",
                     )
                     .unwrap_or_else(|err| {

--- a/stdlib/soroban.c
+++ b/stdlib/soroban.c
@@ -3,10 +3,10 @@
 // Exports:
 //   soroban_alloc(size)                -> void*
 //   soroban_alloc_align(size, align)   -> void*
-//   soroban_alloc_init(size, init_ptr) -> struct vector*
-//       Returns a pointer to a `struct vector` (see stdlib.h),
-//       with `len` and `size` set to `size` and `data` initialized
-//       from `init_ptr` if provided.
+//   soroban_alloc_init(members, elem_size, init_ptr) -> struct vector*
+//       Returns a pointer to a `struct vector` (see stdlib.h), with `len`
+//       and `size` set to `members` (element count) and a `members*elem_size`
+//       byte payload initialized from `init_ptr` if provided.
 //   soroban_malloc(size)               -> void*
 //   soroban_realloc(ptr, new_size)     -> void*   (COPY using header)
 //   soroban_realloc_with_old(ptr, old_size, new_size) -> void* (explicit copy)
@@ -118,21 +118,24 @@ static void *alloc_impl(uint32_t bytes, uint32_t align)
 
 // -------------------- exported API --------------------
 // Forward declare so soroban_alloc can delegate to it
-struct vector *soroban_alloc_init(uint32_t members, const void *init_ptr);
+struct vector *soroban_alloc_init(uint32_t members, uint32_t elem_size, const void *init_ptr);
 
 __attribute__((export_name("soroban_alloc"))) struct vector *soroban_alloc(uint32_t members)
 {
-    // Delegate to soroban_alloc_init with empty initializer
-    return soroban_alloc_init(members, (const void *)0);
+    // Delegate to soroban_alloc_init with byte-sized members and no initializer
+    return soroban_alloc_init(members, 1, (const void *)0);
 }
 
 __attribute__((export_name("soroban_alloc_init"))) struct vector *soroban_alloc_init(uint32_t members,
+                                                                                     uint32_t elem_size,
                                                                                      const void *init_ptr)
 {
-    // Emulate stdlib.c:vector_new() but allocate via alloc_impl.
-    // Note: here `members` is the number of bytes in the vector payload
-    // (element size assumed to be 1 for Soroban at present).
-    uint32_t size_array = members;
+    // Emulate stdlib.c:vector_new(). `members` is the element count and
+    // `elem_size` the size of each element in bytes, so the payload is
+    // `members * elem_size` bytes while `len`/`size` stay in element units.
+    if (elem_size == 0)
+        elem_size = 1;
+    uint32_t size_array = members * elem_size;
 
     struct vector *v = (struct vector *)alloc_impl((uint32_t)sizeof(struct vector) + size_array, 8);
     if (v == (struct vector *)0)

--- a/tests/soroban_testcases/array_return.rs
+++ b/tests/soroban_testcases/array_return.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::build_solidity;
+use soroban_sdk::{FromVal, IntoVal};
+
+#[test]
+fn returns_freshly_built_array() {
+    let runtime = build_solidity(
+        r#"
+        contract array_return {
+            function nums() public pure returns (uint64[] memory) {
+                uint64[] memory a = new uint64[](3);
+                a[0] = 10;
+                a[1] = 20;
+                a[2] = 30;
+                return a;
+            }
+        }
+        "#,
+        |_| {},
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+    let env = &runtime.env;
+
+    // nums() => [10, 20, 30]
+    let ret: soroban_sdk::Vec<u64> =
+        soroban_sdk::Vec::from_val(env, &runtime.invoke_contract(addr, "nums", vec![]));
+    let expected: soroban_sdk::Vec<u64> = soroban_sdk::vec![env, 10_u64, 20_u64, 30_u64];
+    assert_eq!(ret, expected);
+}
+
+#[test]
+fn round_trips_array_arg_and_return() {
+    let runtime = build_solidity(
+        r#"
+        contract array_return {
+            function doubled(uint64[] memory input) public pure returns (uint64[] memory) {
+                uint64[] memory out = new uint64[](input.length);
+                for (uint64 i = 0; i < input.length; i++) {
+                    out[i] = input[i] * 2;
+                }
+                return out;
+            }
+        }
+        "#,
+        |_| {},
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+    let env = &runtime.env;
+
+    // doubled([1, 2, 3]) => [2, 4, 6]
+    let input: soroban_sdk::Vec<u64> = soroban_sdk::vec![env, 1_u64, 2_u64, 3_u64];
+    let ret: soroban_sdk::Vec<u64> = soroban_sdk::Vec::from_val(
+        env,
+        &runtime.invoke_contract(addr, "doubled", vec![input.into_val(env)]),
+    );
+    let expected: soroban_sdk::Vec<u64> = soroban_sdk::vec![env, 2_u64, 4_u64, 6_u64];
+    assert_eq!(ret, expected);
+}

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -2,6 +2,7 @@
 mod abi_encode;
 mod alloc;
 mod array_args;
+mod array_return;
 mod atomic_swap;
 mod auth;
 mod block_number;
@@ -20,6 +21,7 @@ mod integer_width_warnings;
 mod liquidity_pool;
 mod mappings;
 mod math;
+mod other_custom_types;
 mod print;
 mod sha256;
 mod storage;

--- a/tests/soroban_testcases/other_custom_types.rs
+++ b/tests/soroban_testcases/other_custom_types.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Mapping of https://github.com/stellar/soroban-examples/tree/main/other_custom_types
+
+use crate::build_solidity;
+use soroban_sdk::{contracttype, FromVal, IntoVal};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Card {
+    pub rank: u32,
+    pub suit: u32,
+}
+
+const CONTRACT: &str = r#"
+    contract other_custom_types {
+        enum Suit { Hearts, Diamonds, Clubs, Spades }
+
+        struct Card {
+            uint32 rank;
+            Suit suit;
+        }
+
+        Card stored;
+
+        function set(Card memory c) public {
+            stored = c;
+        }
+
+        function get() public view returns (Card memory) {
+            return stored;
+        }
+
+        function pick(Suit s) public pure returns (Suit) {
+            return s;
+        }
+    }
+"#;
+
+#[test]
+fn enum_round_trips_through_abi() {
+    let runtime = build_solidity(CONTRACT, |_| {});
+    let addr = runtime.contracts.last().unwrap();
+    let env = &runtime.env;
+
+    // Suit.Clubs == 2
+    let ret: u32 = FromVal::from_val(
+        env,
+        &runtime.invoke_contract(addr, "pick", vec![2_u32.into_val(env)]),
+    );
+    assert_eq!(ret, 2);
+}
+
+#[test]
+fn struct_with_enum_field_round_trips() {
+    let runtime = build_solidity(CONTRACT, |_| {});
+    let addr = runtime.contracts.last().unwrap();
+    let env = &runtime.env;
+
+    // rank 7, Suit.Spades (== 3)
+    let card = Card { rank: 7, suit: 3 };
+    runtime.invoke_contract(addr, "set", vec![card.clone().into_val(env)]);
+
+    let got = Card::from_val(env, &runtime.invoke_contract(addr, "get", vec![]));
+    assert_eq!(got, Card { rank: 7, suit: 3 });
+}

--- a/tests/soroban_testcases/unsupported_parameters.rs
+++ b/tests/soroban_testcases/unsupported_parameters.rs
@@ -57,9 +57,9 @@ fn array_and_multiple_return_abi_types_are_rejected() {
         return Item({ value: 1 });
     }
 
-    function array_return() public returns (uint64[] memory) {
-        uint64[] memory values = new uint64[](1);
-        values[0] = 1;
+    function array_return() public returns (bytes[] memory) {
+        bytes[] memory values = new bytes[](1);
+        values[0] = hex"01";
         return values;
     }
 
@@ -79,7 +79,7 @@ fn array_and_multiple_return_abi_types_are_rejected() {
     assert!(errors.iter().any(|diagnostic| diagnostic.message
         == "type 'bytes[] memory' is not supported as a Soroban external function parameter"));
     assert!(errors.iter().any(|diagnostic| diagnostic.message
-        == "type 'uint64[] memory' is not supported as a Soroban external function return value"));
+        == "type 'bytes[] memory' is not supported as a Soroban external function return value"));
     assert!(errors.iter().any(|diagnostic| diagnostic.message
         == "Soroban external functions can return at most one value"));
 }


### PR DESCRIPTION
## Summary

Stacked on #1982 (requires the allocator element-size fix to be correct at runtime).

Two ABI fixes:

**Scalar-array returns.** `encode_vector` blitted the array's raw memory as if it already contained encoded `Val`s — only correct for `SorobanHandle` elements (decoded arguments passed straight through). A freshly built scalar array (`uint64[]`) returned garbage. It now encodes each element through `soroban_encode_arg` into a `Val` buffer inside a counted loop, registering the loop counter for phi insertion (`new_dirty_tracker`/`set_phis`) so it is not constant-folded into an infinite loop. The return-type gate is lifted **only for scalar-element arrays**; `string`/`bytes`/`bytesN`/struct element types stay rejected pending verified encodings (the `unsupported_parameters` testcase now asserts on `bytes[]`).

**Enum returns.** Enum discriminants were encoded with the signed `I32` `Val` tag but decoded as `Uint(32)`, failing with `ConversionError`. Encode with `U32`.

## Tests

- `array_return`: returning a fresh `uint64[]`; array-arg → array-return round trip.
- `other_custom_types`: enum and struct-with-enum-field ABI round trips (toward the upstream `other_custom_types` example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)