### PR TITLE
codegen: route storage bytes/string length through TargetCodegen

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -15,8 +15,7 @@ use crate::codegen::constructor::call_constructor;
 use crate::codegen::interface::TargetCodegen;
 use crate::codegen::targets::polkadot::return_code as polkadot;
 use crate::codegen::targets::soroban::{
-    soroban_bytes_length, soroban_strings_length, soroban_struct_load, soroban_struct_member_load,
-    soroban_struct_member_store,
+    soroban_struct_load, soroban_struct_member_load, soroban_struct_member_store,
 };
 use crate::codegen::unused_variable::should_remove_assignment;
 use crate::codegen::{Builtin, Expression};
@@ -812,8 +811,9 @@ pub fn expression(
                     .unwrap();
                     expression(&ast_expr, cfg, contract_no, func, ns, vartab, opt, target)
                 }
-                Type::DynamicBytes => soroban_bytes_length(loc, array, cfg, vartab, ns),
-                Type::String => soroban_strings_length(loc, array, cfg, vartab, ns),
+                Type::DynamicBytes | Type::String => {
+                    target.lower_storage_array_length(loc, ty, array, elem_ty, cfg, vartab, ns)
+                }
                 Type::Array(_, dim) => match dim.last().unwrap() {
                     ArrayLength::Dynamic => {
                         target.lower_storage_array_length(loc, ty, array, elem_ty, cfg, vartab, ns)

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -811,13 +811,12 @@ pub fn expression(
                     .unwrap();
                     expression(&ast_expr, cfg, contract_no, func, ns, vartab, opt, target)
                 }
-                Type::DynamicBytes | Type::String => {
-                    target.lower_storage_array_length(loc, ty, array, elem_ty, cfg, vartab, ns)
-                }
-                Type::Array(_, dim) => match dim.last().unwrap() {
-                    ArrayLength::Dynamic => {
-                        target.lower_storage_array_length(loc, ty, array, elem_ty, cfg, vartab, ns)
-                    }
+                Type::DynamicBytes | Type::String => target
+                    .lower_storage_array_length(loc, ty, &array_ty, array, elem_ty, cfg, vartab, ns),
+                Type::Array(_, ref dim) => match dim.last().unwrap() {
+                    ArrayLength::Dynamic => target.lower_storage_array_length(
+                        loc, ty, &array_ty, array, elem_ty, cfg, vartab, ns,
+                    ),
                     ArrayLength::Fixed(length) => {
                         let ast_expr = bigint_to_expression(
                             loc,

--- a/src/codegen/interface.rs
+++ b/src/codegen/interface.rs
@@ -48,6 +48,7 @@ pub(crate) trait TargetCodegen {
         &self,
         loc: &Loc,
         ty: &Type,
+        array_ty: &Type,
         array: Expression,
         elem_ty: &Type,
         cfg: &mut ControlFlowGraph,

--- a/src/codegen/targets/polkadot/mod.rs
+++ b/src/codegen/targets/polkadot/mod.rs
@@ -183,14 +183,24 @@ impl TargetCodegen for PolkadotTarget {
     fn lower_storage_array_length(
         &self,
         loc: &Loc,
-        _ty: &Type,
+        ty: &Type,
         array: Expression,
-        _elem_ty: &Type,
+        elem_ty: &Type,
         cfg: &mut ControlFlowGraph,
         vartab: &mut Vartable,
         ns: &Namespace,
     ) -> Expression {
-        load_storage(loc, &ns.storage_type(), array, cfg, vartab, None, ns, self)
+        match array.ty().deref_into() {
+            // `bytes`/`string` length is lowered in emit.
+            Type::DynamicBytes | Type::String => Expression::StorageArrayLength {
+                loc: *loc,
+                ty: ty.clone(),
+                array: Box::new(array),
+                elem_ty: elem_ty.clone(),
+            },
+            // Dynamic arrays keep their length in the storage slot.
+            _ => load_storage(loc, &ns.storage_type(), array, cfg, vartab, None, ns, self),
+        }
     }
 }
 

--- a/src/codegen/targets/polkadot/mod.rs
+++ b/src/codegen/targets/polkadot/mod.rs
@@ -184,13 +184,14 @@ impl TargetCodegen for PolkadotTarget {
         &self,
         loc: &Loc,
         ty: &Type,
+        array_ty: &Type,
         array: Expression,
         elem_ty: &Type,
         cfg: &mut ControlFlowGraph,
         vartab: &mut Vartable,
         ns: &Namespace,
     ) -> Expression {
-        match array.ty().deref_into() {
+        match array_ty.deref_any() {
             // `bytes`/`string` length is lowered in emit.
             Type::DynamicBytes | Type::String => Expression::StorageArrayLength {
                 loc: *loc,
@@ -384,6 +385,7 @@ impl TargetCodegen for EvmTarget {
         &self,
         loc: &Loc,
         ty: &Type,
+        array_ty: &Type,
         array: Expression,
         elem_ty: &Type,
         cfg: &mut ControlFlowGraph,
@@ -391,7 +393,7 @@ impl TargetCodegen for EvmTarget {
         ns: &Namespace,
     ) -> Expression {
         self.0
-            .lower_storage_array_length(loc, ty, array, elem_ty, cfg, vartab, ns)
+            .lower_storage_array_length(loc, ty, array_ty, array, elem_ty, cfg, vartab, ns)
     }
 }
 

--- a/src/codegen/targets/solana/mod.rs
+++ b/src/codegen/targets/solana/mod.rs
@@ -57,6 +57,7 @@ impl TargetCodegen for SolanaTarget {
         &self,
         loc: &Loc,
         ty: &Type,
+        _array_ty: &Type,
         array: Expression,
         elem_ty: &Type,
         _cfg: &mut ControlFlowGraph,

--- a/src/codegen/targets/soroban/mod.rs
+++ b/src/codegen/targets/soroban/mod.rs
@@ -55,6 +55,7 @@ impl TargetCodegen for SorobanTarget {
         &self,
         loc: &pt::Loc,
         ty: &Type,
+        array_ty: &Type,
         array: Expression,
         elem_ty: &Type,
         cfg: &mut ControlFlowGraph,
@@ -62,7 +63,9 @@ impl TargetCodegen for SorobanTarget {
         ns: &Namespace,
     ) -> Expression {
         // Storage `bytes`/`string` live in host objects, so their length is a host call.
-        match array.ty().deref_into() {
+        // Dispatch on the declared array type: the lowered expression's own type is the
+        // storage slot, not the array.
+        match array_ty.deref_any() {
             Type::DynamicBytes => soroban_bytes_length(loc, array, cfg, vartab, ns),
             Type::String => soroban_strings_length(loc, array, cfg, vartab, ns),
             _ => Expression::StorageArrayLength {

--- a/src/codegen/targets/soroban/mod.rs
+++ b/src/codegen/targets/soroban/mod.rs
@@ -57,15 +57,20 @@ impl TargetCodegen for SorobanTarget {
         ty: &Type,
         array: Expression,
         elem_ty: &Type,
-        _cfg: &mut ControlFlowGraph,
-        _vartab: &mut Vartable,
-        _ns: &Namespace,
+        cfg: &mut ControlFlowGraph,
+        vartab: &mut Vartable,
+        ns: &Namespace,
     ) -> Expression {
-        Expression::StorageArrayLength {
-            loc: *loc,
-            ty: ty.clone(),
-            array: Box::new(array),
-            elem_ty: elem_ty.clone(),
+        // Storage `bytes`/`string` live in host objects, so their length is a host call.
+        match array.ty().deref_into() {
+            Type::DynamicBytes => soroban_bytes_length(loc, array, cfg, vartab, ns),
+            Type::String => soroban_strings_length(loc, array, cfg, vartab, ns),
+            _ => Expression::StorageArrayLength {
+                loc: *loc,
+                ty: ty.clone(),
+                array: Box::new(array),
+                elem_ty: elem_ty.clone(),
+            },
         }
     }
 


### PR DESCRIPTION
## Summary

Stacked on #1983 (final PR of the stack: #1982 → #1983 → this).

Since #1927, shared codegen lowered storage `bytes`/`string` `.length` through Soroban host functions **unconditionally, for every target**. On Polkadot the emitted CFG then contained host-function calls that don't exist in its module, and `polkadot_tests::strings::bytes_storage` panicked in emit (`module.get_function(...)` returned `None` for the Soroban bytes-length host function).

## Fix

Dispatch the `DynamicBytes`/`String` storage-length lowering through `TargetCodegen::lower_storage_array_length`, so shared codegen no longer inspects `ns.target`:

- **Soroban** impl does the host-call lowering (`soroban_bytes_length`/`soroban_strings_length`).
- **Polkadot** impl restores its pre-#1927 behaviour: `StorageArrayLength` for `bytes`/`string` (lowered in emit), slot load for dynamic arrays.
- **Solana**'s passthrough impl is unaffected; EVM delegates to Polkadot's.

## Testing

Covered by the existing `polkadot_tests::strings::bytes_storage`/`bytes_storage_subscript` (panicked before, pass after) — note these run in the `tests/polkadot.rs` suite, which CI does not currently execute. The soroban `bytes_pass`/`strings` suites cover the Soroban side and stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)