### PR TITLE
test(soroban): add mint_lock example coverage

### DIFF
--- a/integration/soroban/mint_lock.sol
+++ b/integration/soroban/mint_lock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Mapping of https://github.com/stellar/soroban-examples/tree/main/mint-lock
+
+contract mint_lock {
+    mapping(address => uint64) limit;
+    mapping(address => uint64) minted;
+
+    function set_limit(address minter, uint64 max_amount) public {
+        limit[minter] = max_amount;
+    }
+
+    function mint(address token, address minter, address to, uint64 amount) public {
+        require(amount > 0, "amount must be positive");
+        require(minted[minter] + amount <= limit[minter], "over mint limit");
+
+        minted[minter] = minted[minter] + amount;
+
+        bytes payload = abi.encode("mint", to, amount);
+        (bool ok, bytes returndata) = token.call(payload);
+    }
+}

--- a/integration/soroban/mint_lock.spec.js
+++ b/integration/soroban/mint_lock.spec.js
@@ -1,0 +1,63 @@
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { readFileSync } from 'fs';
+import { expect } from 'chai';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { call_contract_function, call_contract_view, toSafeJson } from './test_helpers.js';
+import { Server } from '@stellar/stellar-sdk/rpc';
+
+const __filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(__filename);
+const server = new Server('https://soroban-testnet.stellar.org');
+
+function readContractAddress(filename) {
+  return readFileSync(path.join(dirname, '.stellar', 'contract-ids', filename), 'utf8').trim();
+}
+
+function u64(value) {
+  return StellarSdk.xdr.ScVal.scvU64(new StellarSdk.xdr.Uint64(BigInt(value)));
+}
+
+function randomAddress() {
+  return new StellarSdk.Address(StellarSdk.Keypair.random().publicKey()).toScVal();
+}
+
+describe('Mint lock', () => {
+  let keypair;
+  let mintLock;
+  let token;
+
+  before(async () => {
+    keypair = StellarSdk.Keypair.fromSecret(readFileSync('alice.txt', 'utf8').trim());
+    mintLock = new StellarSdk.Contract(readContractAddress('mint_lock.txt'));
+    token = new StellarSdk.Contract(readContractAddress('ml_token.txt'));
+  });
+
+  async function balance(owner) {
+    const res = await call_contract_view('balance', server, keypair, token, owner);
+    expect(res.status, `balance failed: ${toSafeJson(res)}`).to.equal('SUCCESS');
+    return res.returnValue;
+  }
+
+  it('mints up to the configured limit and blocks the rest', async () => {
+    // Fresh minter/user each run so persisted `minted`/balances stay deterministic.
+    const minter = randomAddress();
+    const user = randomAddress();
+    const tokenAddr = token.address().toScVal();
+
+    let res = await call_contract_function('set_limit', server, keypair, mintLock, minter, u64(100));
+    expect(res.status, `set_limit failed: ${toSafeJson(res)}`).to.equal('SUCCESS');
+
+    // First mint of 60 is within the 100 limit.
+    res = await call_contract_function('mint', server, keypair, mintLock, tokenAddr, minter, user, u64(60));
+    expect(res.status, `first mint failed: ${toSafeJson(res)}`).to.equal('SUCCESS');
+    expect(await balance(user)).to.equal(60n);
+
+    // Second mint of 60 would total 120 > 100: rejected.
+    res = await call_contract_function('mint', server, keypair, mintLock, tokenAddr, minter, user, u64(60));
+    expect(res.status, `over-limit mint unexpectedly succeeded: ${toSafeJson(res)}`).to.not.equal('SUCCESS');
+
+    // Only the first mint went through.
+    expect(await balance(user)).to.equal(60n);
+  });
+});

--- a/integration/soroban/ml_token.sol
+++ b/integration/soroban/ml_token.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Minimal token used by the mint_lock example
+// (https://github.com/stellar/soroban-examples/tree/main/mint-lock).
+
+contract ml_token {
+    mapping(address => uint64) public balances;
+
+    function mint(address to, uint64 amount) public {
+        balances[to] = balances[to] + amount;
+    }
+
+    function balance(address addr) public view returns (uint64) {
+        return balances[addr];
+    }
+}

--- a/tests/soroban_testcases/mint_lock.rs
+++ b/tests/soroban_testcases/mint_lock.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::SorobanEnv;
+use soroban_sdk::{testutils::Address as _, Address, IntoVal, Val};
+
+const TOKEN_SRC: &str = r#"
+contract token {
+    address public admin;
+    uint32 public decimals;
+    string public name;
+    string public symbol;
+
+    constructor(address _admin, string memory _name, string memory _symbol, uint32 _decimals) {
+        admin = _admin;
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+    }
+
+    mapping(address => int128) public balances;
+
+    function mint(address to, int128 amount) public {
+        require(amount >= 0, "Amount must be non-negative");
+        admin.requireAuth();
+        balances[to] = balances[to] + amount;
+    }
+
+    function balance(address addr) public view returns (int128) {
+        return balances[addr];
+    }
+}
+"#;
+
+// Mapping of https://github.com/stellar/soroban-examples/tree/main/mint-lock
+//
+// An admin authorizes minters with a per-minter cap. Each minter can mint tokens (through a
+// cross-contract call into the token) up to its configured limit; minting past the limit reverts.
+const MINT_LOCK_SRC: &str = r#"
+contract mint_lock {
+    address admin;
+    mapping(address => int128) limit;
+    mapping(address => int128) minted;
+
+    function set_admin(address new_admin) public {
+        admin = new_admin;
+    }
+
+    function set_limit(address minter, int128 max_amount) public {
+        admin.requireAuth();
+        limit[minter] = max_amount;
+    }
+
+    function mint(address token, address minter, address to, int128 amount) public {
+        minter.requireAuth();
+        require(amount > 0, "amount must be positive");
+        require(minted[minter] + amount <= limit[minter], "over mint limit");
+
+        minted[minter] = minted[minter] + amount;
+
+        bytes payload = abi.encode("mint", to, amount);
+        (bool ok, bytes returndata) = token.call(payload);
+    }
+}
+"#;
+
+fn deploy_token(runtime: &mut SorobanEnv, admin: &Address) -> Address {
+    let decimals: Val = 18_u32.into_val(&runtime.env);
+    let name = soroban_sdk::String::from_str(&runtime.env, "Token");
+    let symbol = soroban_sdk::String::from_str(&runtime.env, "TKN");
+
+    runtime.deploy_contract_with_args(TOKEN_SRC, (admin.clone(), name, symbol, decimals))
+}
+
+fn assert_balance(runtime: &SorobanEnv, token: &Address, owner: &Address, expected: i128) {
+    let balance =
+        runtime.invoke_contract(token, "balance", vec![owner.clone().into_val(&runtime.env)]);
+    let expected: Val = expected.into_val(&runtime.env);
+    assert!(expected.shallow_eq(&balance));
+}
+
+#[test]
+fn mint_lock_allows_minting_up_to_limit() {
+    let mut runtime = SorobanEnv::new();
+
+    // The token's admin is the mint_lock contract itself, so mint_lock's cross-contract mint is
+    // authorized automatically (a contract authorizes its own sub-invocations).
+    let mint_lock = runtime.deploy_contract(MINT_LOCK_SRC);
+    let token = deploy_token(&mut runtime, &mint_lock);
+
+    runtime.env.mock_all_auths();
+
+    let admin = Address::generate(&runtime.env);
+    let minter = Address::generate(&runtime.env);
+    let user = Address::generate(&runtime.env);
+
+    runtime.invoke_contract(&mint_lock, "set_admin", vec![admin.clone().into_val(&runtime.env)]);
+    runtime.invoke_contract(
+        &mint_lock,
+        "set_limit",
+        vec![
+            minter.clone().into_val(&runtime.env),
+            100_i128.into_val(&runtime.env),
+        ],
+    );
+
+    // Two mints that together stay within the 100 limit.
+    runtime.invoke_contract(
+        &mint_lock,
+        "mint",
+        vec![
+            token.clone().into_val(&runtime.env),
+            minter.clone().into_val(&runtime.env),
+            user.clone().into_val(&runtime.env),
+            60_i128.into_val(&runtime.env),
+        ],
+    );
+    runtime.invoke_contract(
+        &mint_lock,
+        "mint",
+        vec![
+            token.clone().into_val(&runtime.env),
+            minter.clone().into_val(&runtime.env),
+            user.clone().into_val(&runtime.env),
+            40_i128.into_val(&runtime.env),
+        ],
+    );
+
+    assert_balance(&runtime, &token, &user, 100);
+}
+
+#[test]
+fn mint_lock_rejects_minting_over_limit() {
+    let mut runtime = SorobanEnv::new();
+
+    // The token's admin is the mint_lock contract itself, so mint_lock's cross-contract mint is
+    // authorized automatically (a contract authorizes its own sub-invocations).
+    let mint_lock = runtime.deploy_contract(MINT_LOCK_SRC);
+    let token = deploy_token(&mut runtime, &mint_lock);
+
+    runtime.env.mock_all_auths();
+
+    let admin = Address::generate(&runtime.env);
+    let minter = Address::generate(&runtime.env);
+    let user = Address::generate(&runtime.env);
+
+    runtime.invoke_contract(&mint_lock, "set_admin", vec![admin.clone().into_val(&runtime.env)]);
+    runtime.invoke_contract(
+        &mint_lock,
+        "set_limit",
+        vec![
+            minter.clone().into_val(&runtime.env),
+            100_i128.into_val(&runtime.env),
+        ],
+    );
+
+    runtime.invoke_contract(
+        &mint_lock,
+        "mint",
+        vec![
+            token.clone().into_val(&runtime.env),
+            minter.clone().into_val(&runtime.env),
+            user.clone().into_val(&runtime.env),
+            60_i128.into_val(&runtime.env),
+        ],
+    );
+
+    // 60 + 60 = 120 > 100 limit: rejected.
+    let logs = runtime.invoke_contract_expect_error(
+        &mint_lock,
+        "mint",
+        vec![
+            token.clone().into_val(&runtime.env),
+            minter.clone().into_val(&runtime.env),
+            user.clone().into_val(&runtime.env),
+            60_i128.into_val(&runtime.env),
+        ],
+    );
+
+    assert!(logs
+        .iter()
+        .any(|entry| entry.contains("require condition failed")));
+
+    // Only the first mint went through.
+    assert_balance(&runtime, &token, &user, 60);
+}

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -20,6 +20,7 @@ mod integer_width_warnings;
 mod liquidity_pool;
 mod mappings;
 mod math;
+mod mint_lock;
 mod print;
 mod sha256;
 mod storage;


### PR DESCRIPTION
## Summary

Maps the upstream [`stellar/soroban-examples` mint-lock](https://github.com/stellar/soroban-examples/tree/main/mint-lock) example (refs #1901): an admin grants per-minter mint limits; minters mint through a cross-contract call into the token and are reverted past their cap.

Independent of the #1982/#1983/#1984 stack — everything here works on current `main`.

## What's included

- **Mock-VM tests** (`tests/soroban_testcases/mint_lock.rs`): mint up to the limit succeeds; minting over it reverts.
- **Integration test** (`integration/soroban/mint_lock.sol`, `ml_token.sol`, `mint_lock.spec.js`).

## Fidelity to the upstream example (adaptations disclosed)

The **mock-VM contract stays close to upstream**: `int128` amounts, `admin.requireAuth()` on `set_limit`, `minter.requireAuth()` on `mint`, cross-contract token mint. Tweaks:
- upstream's **per-epoch** minted-amount window is simplified to a cumulative cap;
- admin is set via `set_admin` rather than at init;
- the token call is a low-level `abi.encode` + `.call` rather than a typed client.

The **integration variant is adapted further**, following the existing `integration/soroban` conventions: **auth-free** (no auth mocking is available against the test network), `uint64` amounts, no admin role, one contract per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)