### PR TITLE
feat(soroban): support arrays of structs as function parameters

### DIFF
--- a/examples/soroban/atomic_multiswap/atomic_multiswap.sol
+++ b/examples/soroban/atomic_multiswap/atomic_multiswap.sol
@@ -1,0 +1,61 @@
+/// SPDX-License-Identifier: Apache-2.0
+// Mapping of https://github.com/stellar/soroban-examples/tree/main/atomic_multiswap
+
+contract atomic_multiswap {
+    struct SwapSpec {
+        address account;
+        uint64 amount;
+        uint64 min_recv;
+    }
+
+    // Swaps token A for token B between multiple parties in a single transaction.
+    //
+    // For every entry in `a`, find the first not-yet-matched entry in `b` whose amounts are
+    // mutually acceptable, and settle that pair through the `atomic_swap` contract via a
+    // cross-contract call. A swap that fails is skipped and the `b` entry stays available.
+    //
+    // (Solidity memory arrays cannot be shrunk like the upstream `Vec::remove`, so a `matched`
+    // mask is used to mark `b` entries that have already been consumed.)
+    function multi_swap(
+        address swap_contract,
+        address token_a,
+        address token_b,
+        SwapSpec[] memory a,
+        SwapSpec[] memory b
+    ) public {
+        bool[] memory matched = new bool[](b.length);
+
+        for (uint64 i = 0; i < a.length; i++) {
+            SwapSpec memory acc_a = a[i];
+
+            for (uint64 j = 0; j < b.length; j++) {
+                if (matched[j]) {
+                    continue;
+                }
+
+                SwapSpec memory acc_b = b[j];
+
+                if (acc_a.amount >= acc_b.min_recv && acc_b.amount >= acc_a.min_recv) {
+                    bytes payload = abi.encode(
+                        "swap",
+                        acc_a.account,
+                        acc_b.account,
+                        token_a,
+                        token_b,
+                        acc_a.amount,
+                        acc_a.min_recv,
+                        acc_b.amount,
+                        acc_b.min_recv
+                    );
+
+                    (bool success, bytes returndata) = swap_contract.call(payload);
+
+                    if (success) {
+                        matched[j] = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1892,7 +1892,14 @@ pub(crate) fn populate_arguments<T: FunctionAttributes>(
 
 fn soroban_runtime_arg_ty(ty: &Type) -> Type {
     match ty {
-        Type::Array(elem_ty, dims) if dims.last() == Some(&ast::ArrayLength::Dynamic) => {
+        // Scalar-element arrays arrive as buffers of encoded handles that decode lazily on
+        // load. Struct elements are decoded eagerly in the dispatch wrapper (their fields
+        // are accessed through StructMember chains that never see the handle type), so
+        // those parameters keep their plain memory type.
+        Type::Array(elem_ty, dims)
+            if dims.last() == Some(&ast::ArrayLength::Dynamic)
+                && !matches!(elem_ty.as_ref(), Type::Struct(_)) =>
+        {
             Type::Array(
                 Box::new(Type::SorobanHandle(Box::new(elem_ty.as_ref().clone()))),
                 dims.clone(),

--- a/src/codegen/targets/soroban/encoding.rs
+++ b/src/codegen/targets/soroban/encoding.rs
@@ -246,6 +246,8 @@ pub fn soroban_decode_arg(
         Type::Array(elem_ty, _) => {
             if let Type::StorageRef(_, _) = arg.ty() {
                 arg.clone()
+            } else if let Type::Struct(StructType::UserDefined(n)) = elem_ty.as_ref() {
+                decode_struct_vector(arg, elem_ty.as_ref(), *n, ns, wrapper_cfg, vartab)
             } else {
                 decode_vector(arg, &elem_ty, ns, wrapper_cfg, vartab)
             }
@@ -2650,4 +2652,217 @@ fn decode_vector(
     );
 
     decoded_buffer
+}
+
+/// Decode a host `Vec` of struct maps into a memory array of structs.
+///
+/// `decode_vector` leaves the elements as encoded `Val` handles, which is fine for scalar
+/// elements because loads of `SorobanHandle` values decode lazily. Struct elements are
+/// reached through `StructMember` chains that never observe the handle type, so they are
+/// decoded eagerly instead: unpack the handle buffer, then decode every element's map into
+/// the result array field by field (per-field stores follow the LLVM struct layout, which
+/// is not packed).
+fn decode_struct_vector(
+    vec_object: Expression,
+    elem_ty: &Type,
+    struct_no: usize,
+    ns: &Namespace,
+    cfg: &mut ControlFlowGraph,
+    vartab: &mut Vartable,
+) -> Expression {
+    let loc = Loc::Codegen;
+    let handle_ty = Type::SorobanHandle(Box::new(elem_ty.clone()));
+    let handles_ty = Type::Array(Box::new(handle_ty.clone()), vec![ArrayLength::Dynamic]);
+
+    // Unpack the host vec into a buffer of encoded element handles.
+    let handles = decode_vector(vec_object, elem_ty, ns, cfg, vartab);
+
+    let len_var = vartab.temp_name("struct_vec_len", &Type::Uint(32));
+    cfg.add(
+        vartab,
+        Instr::Set {
+            loc,
+            res: len_var,
+            expr: Expression::Builtin {
+                loc,
+                tys: vec![Type::Uint(32)],
+                kind: Builtin::ArrayLength,
+                args: vec![handles.clone()],
+            },
+        },
+    );
+    let len = Expression::Variable {
+        loc,
+        ty: Type::Uint(32),
+        var_no: len_var,
+    };
+
+    let result_ty = Type::Array(Box::new(elem_ty.clone()), vec![ArrayLength::Dynamic]);
+    let result_var = vartab.temp_name("struct_vec_decoded", &result_ty);
+    cfg.add(
+        vartab,
+        Instr::Set {
+            loc,
+            res: result_var,
+            expr: Expression::AllocDynamicBytes {
+                loc,
+                ty: result_ty.clone(),
+                size: Box::new(len.clone()),
+                initializer: None,
+            },
+        },
+    );
+    let result = Expression::Variable {
+        loc,
+        ty: result_ty.clone(),
+        var_no: result_var,
+    };
+
+    let i_var = vartab.temp_name("i", &Type::Uint(32));
+    cfg.add(
+        vartab,
+        Instr::Set {
+            loc,
+            res: i_var,
+            expr: Expression::NumberLiteral {
+                loc,
+                ty: Type::Uint(32),
+                value: BigInt::from(0_u64),
+            },
+        },
+    );
+    let i = Expression::Variable {
+        loc,
+        ty: Type::Uint(32),
+        var_no: i_var,
+    };
+
+    let cond_block = cfg.new_basic_block("struct_vec_decode_cond".to_string());
+    let body_block = cfg.new_basic_block("struct_vec_decode_body".to_string());
+    let done_block = cfg.new_basic_block("struct_vec_decode_done".to_string());
+
+    // Track the loop counter so a phi node is emitted at the loop header (see encode_vector).
+    vartab.new_dirty_tracker();
+
+    cfg.add(vartab, Instr::Branch { block: cond_block });
+    cfg.set_basic_block(cond_block);
+    cfg.add(
+        vartab,
+        Instr::BranchCond {
+            cond: Expression::Less {
+                loc,
+                signed: false,
+                left: Box::new(i.clone()),
+                right: Box::new(len.clone()),
+            },
+            true_block: body_block,
+            false_block: done_block,
+        },
+    );
+
+    cfg.set_basic_block(body_block);
+    // Read the encoded map handle for element `i`.
+    let handle_var = vartab.temp_name("elem_handle", &handle_ty);
+    cfg.add(
+        vartab,
+        Instr::Set {
+            loc,
+            res: handle_var,
+            expr: Expression::Load {
+                loc,
+                ty: handle_ty.clone(),
+                expr: Box::new(Expression::Subscript {
+                    loc,
+                    ty: Type::Ref(Box::new(handle_ty.clone())),
+                    array_ty: handles_ty.clone(),
+                    expr: Box::new(handles.clone()),
+                    index: Box::new(i.clone()),
+                }),
+            },
+        },
+    );
+    let handle = Expression::Variable {
+        loc,
+        ty: Type::Uint(64),
+        var_no: handle_var,
+    };
+
+    // Decode each field out of the element's map straight into the result slot.
+    let elem_slot = Expression::Subscript {
+        loc,
+        ty: Type::Ref(Box::new(elem_ty.clone())),
+        array_ty: result_ty.clone(),
+        expr: Box::new(result.clone()),
+        index: Box::new(i.clone()),
+    };
+    let fields = ns.structs[struct_no].fields.clone();
+    for (field_no, field) in fields.iter().enumerate() {
+        let name = field
+            .id
+            .as_ref()
+            .map(|id| id.name.clone())
+            .unwrap_or_else(|| field_no.to_string());
+        let key = struct_field_key(&name, loc, cfg, vartab, ns);
+
+        let val_var = vartab.temp_name("map_val", &Type::Uint(64));
+        cfg.add(
+            vartab,
+            Instr::Call {
+                res: vec![val_var],
+                return_tys: vec![Type::Uint(64)],
+                call: InternalCallTy::HostFunction {
+                    name: HostFunctions::MapGet.name().to_string(),
+                },
+                args: vec![handle.clone(), key],
+            },
+        );
+        let val = Expression::Variable {
+            loc,
+            ty: Type::Uint(64),
+            var_no: val_var,
+        };
+
+        let decoded = soroban_decode_arg(val, cfg, vartab, ns, Some(field.ty.clone()));
+        cfg.add(
+            vartab,
+            Instr::Store {
+                dest: Expression::StructMember {
+                    loc,
+                    ty: Type::Ref(Box::new(field.ty.clone())),
+                    expr: Box::new(elem_slot.clone()),
+                    member: field_no,
+                },
+                data: decoded,
+            },
+        );
+    }
+
+    cfg.add(
+        vartab,
+        Instr::Set {
+            loc,
+            res: i_var,
+            expr: Expression::Add {
+                loc,
+                ty: Type::Uint(32),
+                overflowing: false,
+                left: Box::new(i.clone()),
+                right: Box::new(Expression::NumberLiteral {
+                    loc,
+                    ty: Type::Uint(32),
+                    value: BigInt::from(1_u64),
+                }),
+            },
+        },
+    );
+    cfg.add(vartab, Instr::Branch { block: cond_block });
+
+    cfg.set_basic_block(done_block);
+
+    let phis = vartab.pop_dirty_tracker();
+    cfg.set_phis(cond_block, phis.clone());
+    cfg.set_phis(body_block, phis.clone());
+    cfg.set_phis(done_block, phis);
+
+    result
 }

--- a/src/codegen/targets/soroban/mod.rs
+++ b/src/codegen/targets/soroban/mod.rs
@@ -1061,7 +1061,7 @@ fn unsupported_parameter_type(ty: &Type, ns: &Namespace) -> Option<String> {
         Type::Struct(_) => {
             soroban_struct_field_unsupported(ty, ns).map(|_| format!("{} memory", ty.to_string(ns)))
         }
-        Type::Array(elem, _) if has_unsupported_soroban_array_element(elem.as_ref()) => {
+        Type::Array(elem, _) if has_unsupported_soroban_array_element(elem.as_ref(), ns) => {
             Some(format!("{} memory", ty.to_string(ns)))
         }
         _ => None,
@@ -1108,11 +1108,11 @@ fn unsupported_return_type(ty: &Type, ns: &Namespace) -> Option<String> {
         }
         // Arrays of scalar elements round-trip (`encode_vector` encodes each element into a
         // `Val` buffer before building the host Vec). Reject arrays whose element type is
-        // unsupported (structs, `bytes`/`bytesN`), and `string` elements, which have no
-        // verified return encoding yet.
+        // unsupported (`bytes`/`bytesN`), plus `string` and struct elements, which have no
+        // verified return encoding yet (struct elements are supported as parameters).
         Type::Array(elem, _)
-            if has_unsupported_soroban_array_element(elem.as_ref())
-                || matches!(elem.as_ref(), Type::String) =>
+            if has_unsupported_soroban_array_element(elem.as_ref(), ns)
+                || matches!(elem.as_ref(), Type::String | Type::Struct(_)) =>
         {
             Some(format!("{} memory", ty.to_string(ns)))
         }
@@ -1120,10 +1120,22 @@ fn unsupported_return_type(ty: &Type, ns: &Namespace) -> Option<String> {
     }
 }
 
-fn has_unsupported_soroban_array_element(ty: &Type) -> bool {
+fn has_unsupported_soroban_array_element(ty: &Type, ns: &Namespace) -> bool {
     match ty {
-        Type::DynamicBytes | Type::Bytes(_) | Type::Struct(_) => true,
-        Type::Array(elem, _) => has_unsupported_soroban_array_element(elem.as_ref()),
+        Type::DynamicBytes | Type::Bytes(_) => true,
+        // Flat structs (no struct-typed fields) ride the existing struct map codec per
+        // element: `decode_vector` yields `SorobanHandle` elements which decode through
+        // `decode_struct_map` on load. Structs containing structs stay rejected until
+        // nested-struct lowering is fixed.
+        Type::Struct(struct_ty) => {
+            soroban_struct_field_unsupported(ty, ns).is_some()
+                || struct_ty
+                    .definition(ns)
+                    .fields
+                    .iter()
+                    .any(|field| matches!(field.ty, Type::Struct(_)))
+        }
+        Type::Array(elem, _) => has_unsupported_soroban_array_element(elem.as_ref(), ns),
         _ => false,
     }
 }

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -28,6 +28,7 @@ mod storage;
 mod storage_array;
 mod strings;
 mod struct_abi_member_count;
+mod struct_array_args;
 mod struct_abi_single_field;
 mod struct_member_count;
 mod struct_single_field;

--- a/tests/soroban_testcases/struct_array_args.rs
+++ b/tests/soroban_testcases/struct_array_args.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{build_solidity, SorobanEnv};
+use soroban_sdk::{contracttype, testutils::Address as _, Address, IntoVal, Val};
+
+#[contracttype]
+#[derive(Clone)]
+struct Item {
+    account: Address,
+    amount: u64,
+    min_recv: u64,
+}
+
+fn item(env: &soroban_sdk::Env, amount: u64, min_recv: u64) -> Item {
+    Item {
+        account: Address::generate(env),
+        amount,
+        min_recv,
+    }
+}
+
+#[test]
+fn struct_array_member_reads() {
+    let runtime = build_solidity(
+        r#"
+        contract t {
+            struct Item {
+                address account;
+                uint64 amount;
+                uint64 min_recv;
+            }
+
+            function sum_amounts(Item[] memory items) public pure returns (uint64) {
+                uint64 total = 0;
+                for (uint64 i = 0; i < items.length; i++) {
+                    total = total + items[i].amount;
+                }
+                return total;
+            }
+
+            function nth_account(Item[] memory items, uint64 n) public pure returns (address) {
+                return items[n].account;
+            }
+        }
+        "#,
+        |_| {},
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+    let env = &runtime.env;
+
+    let first = item(env, 10, 1);
+    let second = item(env, 20, 2);
+    let third = item(env, 30, 3);
+    let items = soroban_sdk::vec![env, first.clone(), second.clone(), third.clone()];
+
+    // sum_amounts([10, 20, 30]) => 60
+    let ret = runtime.invoke_contract(addr, "sum_amounts", vec![items.clone().into_val(env)]);
+    let expected: Val = 60_u64.into_val(env);
+    assert!(expected.shallow_eq(&ret));
+
+    // nth_account(items, 1) => second.account
+    let ret = runtime.invoke_contract(
+        addr,
+        "nth_account",
+        vec![items.into_val(env), 1_u64.into_val(env)],
+    );
+    let expected: Val = second.account.into_val(env);
+    assert!(expected.shallow_eq(&ret));
+}
+
+const SWAP_STUB_SRC: &str = r#"
+contract swap_stub {
+    uint64 public swaps;
+
+    function swap(
+        address a,
+        address b,
+        address token_a,
+        address token_b,
+        uint64 amount_a,
+        uint64 min_a_for_b,
+        uint64 amount_b,
+        uint64 min_b_for_a
+    ) public {
+        require(amount_a >= min_b_for_a && amount_b >= min_a_for_b, "amounts do not match");
+        swaps = swaps + 1;
+    }
+}
+"#;
+
+// Kept in sync with examples/soroban/atomic_multiswap/atomic_multiswap.sol.
+const MULTISWAP_SRC: &str = r#"
+contract atomic_multiswap {
+    struct SwapSpec {
+        address account;
+        uint64 amount;
+        uint64 min_recv;
+    }
+
+    function multi_swap(
+        address swap_contract,
+        address token_a,
+        address token_b,
+        SwapSpec[] memory a,
+        SwapSpec[] memory b
+    ) public {
+        bool[] memory matched = new bool[](b.length);
+
+        for (uint64 i = 0; i < a.length; i++) {
+            SwapSpec memory acc_a = a[i];
+
+            for (uint64 j = 0; j < b.length; j++) {
+                if (matched[j]) {
+                    continue;
+                }
+
+                SwapSpec memory acc_b = b[j];
+
+                if (acc_a.amount >= acc_b.min_recv && acc_b.amount >= acc_a.min_recv) {
+                    bytes payload = abi.encode(
+                        "swap",
+                        acc_a.account,
+                        acc_b.account,
+                        token_a,
+                        token_b,
+                        acc_a.amount,
+                        acc_a.min_recv,
+                        acc_b.amount,
+                        acc_b.min_recv
+                    );
+
+                    (bool success, bytes returndata) = swap_contract.call(payload);
+
+                    if (success) {
+                        matched[j] = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+"#;
+
+#[test]
+fn multi_swap_matches_pairs() {
+    let mut runtime = SorobanEnv::new();
+
+    let swap_stub = runtime.deploy_contract(SWAP_STUB_SRC);
+    let multiswap = runtime.deploy_contract(MULTISWAP_SRC);
+
+    runtime.env.mock_all_auths();
+
+    let env = runtime.env.clone();
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+
+    // a[0] matches b[0] (100 >= 85 and 95 >= 90); a[1] then matches b[1] (50 >= 40 and
+    // 46 >= 45); a[2] matches nothing (its min_recv of 1000 is unsatisfiable).
+    let a = soroban_sdk::vec![
+        &env,
+        item(&env, 100, 90),
+        item(&env, 50, 45),
+        item(&env, 5, 1000),
+    ];
+    let b = soroban_sdk::vec![
+        &env,
+        item(&env, 95, 85),
+        item(&env, 46, 40),
+        item(&env, 10, 1),
+    ];
+
+    runtime.invoke_contract(
+        &multiswap,
+        "multi_swap",
+        vec![
+            swap_stub.clone().into_val(&env),
+            token_a.into_val(&env),
+            token_b.into_val(&env),
+            a.into_val(&env),
+            b.into_val(&env),
+        ],
+    );
+
+    let swaps = runtime.invoke_contract(&swap_stub, "swaps", vec![]);
+    let expected: Val = 2_u64.into_val(&env);
+    assert!(expected.shallow_eq(&swaps));
+}


### PR DESCRIPTION
## Summary

Top of the stack: #1982 → #1983 → #1984 → this. Unblocks the idiomatic [`atomic_multiswap`](https://github.com/stellar/soroban-examples/tree/main/atomic_multiswap) example (`SwapSpec[]` parameters), previously rejected with *type 'struct ...[] memory' is not supported as a Soroban external function parameter* (refs #1901).

## How

`decode_vector` leaves array elements as encoded `Val` handles; scalar element loads decode lazily, but struct fields are reached through `StructMember` chains that never observe the handle type. Struct elements are now **decoded eagerly in the dispatch wrapper**: unpack the handle buffer, then decode each element's map into a memory array **field by field** (per-field stores follow the LLVM struct layout, which is not packed — a byte-wise memcpy against sema's packed size would be wrong for padded structs). Struct-element array parameters keep their plain memory type instead of the `SorobanHandle` element representation, so everything downstream is ordinary memory code.

**Scope**: the gate admits arrays of *flat* structs (all fields scalar). Structs containing structs stay rejected (nested-struct lowering has a known codegen panic), and struct-element **returns** stay gated pending a verified encoding.

## Example + tests

- `examples/soroban/atomic_multiswap/atomic_multiswap.sol` — mapping of the upstream example. Adaptations: `uint64` amounts, a `bool[] matched` mask instead of `Vec::remove`, the swap settled via `abi.encode` + `.call`, and no per-party `requireAuth` (auth is exercised at the `atomic_swap` level in the upstream design).
- `tests/soroban_testcases/struct_array_args.rs`:
  - `struct_array_member_reads` — sum over struct fields and address extraction through `Item[]` params (SDK side passes `soroban_sdk::Vec<#[contracttype] struct>`).
  - `multi_swap_matches_pairs` — the full multiswap flow against a stub swap contract: 3×3 parties, exactly 2 matches, exercising the match, skip-matched, and no-match paths.

## Testing

Full soroban suite green (229 passed), polkadot `bytes_storage`/`bytes_storage_subscript` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)