### PR TITLE
ci: submit SBOM to PG Atlas

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,19 @@
+name: Submit SBOM to PG Atlas
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  sbom:
+    name: Submit SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for GitHub Dependency Graph API
+      id-token: write # for OIDC authentication to PG Atlas
+    steps:
+      - uses: SCF-Public-Goods-Maintenance/pg-atlas-sbom-action@bca8911b12604b102c41dab217b20c0a005fb126 # v1.0.0


### PR DESCRIPTION
## Summary

Adds the [SCF PG Atlas SBOM action](https://github.com/SCF-Public-Goods-Maintenance/pg-atlas-sbom-action): on every push to `main` and on published releases, the repo's SPDX 2.3 dependency graph (via the [GitHub Dependency Graph API](https://docs.github.com/en/rest/dependency-graph/sboms)) is submitted to the PG Atlas ingestion endpoint, contributing Solang's dependency data to the Stellar ecosystem dependency graph.

- **No secrets required** — authentication is a short-lived GitHub OIDC token (`id-token: write`).
- **Action pinned to a full commit hash** (v1.0.0), per the action's own usage guidance.
- `workflow_dispatch` included so the first submission can be triggered manually without waiting for a push.
- Prerequisite verified: the repo's dependency graph is enabled and serves SPDX 2.3 with 759 packages (thanks to the committed `Cargo.lock`).

Requested by the SCF Public Goods Maintenance program as part of the Q3 review round ([PG Atlas ingestion docs](https://scf-public-goods-maintenance.github.io/pg-atlas/)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)