### PR TITLE
refactor(soroban): lower extendTtl and extendInstanceTtl in codegen

### DIFF
--- a/src/codegen/targets/soroban/mod.rs
+++ b/src/codegen/targets/soroban/mod.rs
@@ -828,7 +828,8 @@ impl TargetCodegen for SorobanTarget {
                 Some(call_res_var)
             }
             ast::Builtin::ExtendTtl => {
-                let mut arguments: Vec<Expression> = args
+                assert_eq!(args.len(), 3, "extendTtl expects 3 arguments");
+                let arguments: Vec<Expression> = args
                     .iter()
                     .map(|v| expression(v, cfg, contract_no, func, ns, vartab, opt, self))
                     .collect();
@@ -852,17 +853,71 @@ impl TargetCodegen for SorobanTarget {
                     ),
                 };
 
-                arguments.push(Expression::NumberLiteral {
+                let slot = Expression::NumberLiteral {
                     loc: *loc,
-                    ty: Type::Uint(32),
+                    ty: Type::Uint(64),
+                    value: BigInt::from(var_no),
+                };
+                let storage_type = Expression::NumberLiteral {
+                    loc: *loc,
+                    ty: Type::Uint(64),
                     value: BigInt::from(storage_type_usize),
-                });
+                };
+                let threshold =
+                    encoding::encode_object(*loc, arguments[1].clone(), 32, encoding::tags::U32);
+                let extend_to =
+                    encoding::encode_object(*loc, arguments[2].clone(), 32, encoding::tags::U32);
 
-                Some(Expression::Builtin {
+                // The host functions return Void, so the result is not decoded.
+                let res = vartab.temp_name("extend_ttl", &Type::Int(64));
+                cfg.add(
+                    vartab,
+                    Instr::Call {
+                        res: vec![res],
+                        return_tys: vec![Type::Int(64)],
+                        call: InternalCallTy::HostFunction {
+                            name: HostFunctions::ExtendContractDataTtl.name().to_string(),
+                        },
+                        args: vec![slot, storage_type, threshold, extend_to],
+                    },
+                );
+                Some(Expression::Variable {
                     loc: *loc,
-                    tys: vec![Type::Int(64)],
-                    kind: (&builtin).into(),
-                    args: arguments,
+                    ty: Type::Int(64),
+                    var_no: res,
+                })
+            }
+            ast::Builtin::ExtendInstanceTtl => {
+                assert_eq!(args.len(), 2, "extendInstanceTtl expects 2 arguments");
+                let arguments: Vec<Expression> = args
+                    .iter()
+                    .map(|v| expression(v, cfg, contract_no, func, ns, vartab, opt, self))
+                    .collect();
+
+                let threshold =
+                    encoding::encode_object(*loc, arguments[0].clone(), 32, encoding::tags::U32);
+                let extend_to =
+                    encoding::encode_object(*loc, arguments[1].clone(), 32, encoding::tags::U32);
+
+                // The host functions return Void, so the result is not decoded.
+                let res = vartab.temp_name("extend_instance_ttl", &Type::Int(64));
+                cfg.add(
+                    vartab,
+                    Instr::Call {
+                        res: vec![res],
+                        return_tys: vec![Type::Int(64)],
+                        call: InternalCallTy::HostFunction {
+                            name: HostFunctions::ExtendCurrentContractInstanceAndCodeTtl
+                                .name()
+                                .to_string(),
+                        },
+                        args: vec![threshold, extend_to],
+                    },
+                );
+                Some(Expression::Variable {
+                    loc: *loc,
+                    ty: Type::Int(64),
+                    var_no: res,
                 })
             }
             _ => None,

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -2,7 +2,6 @@
 
 use crate::codegen::cfg::HashTy;
 use crate::codegen::error::CodegenError;
-use crate::codegen::Builtin;
 use crate::codegen::Expression;
 use crate::emit::binary::Binary;
 use crate::emit::soroban::{HostFunctions, SorobanTarget};
@@ -21,8 +20,6 @@ use inkwell::values::{
 
 use solang_parser::helpers::CodeLocation;
 use solang_parser::pt::{Loc, StorageType};
-
-use num_traits::ToPrimitive;
 
 use std::collections::HashMap;
 
@@ -817,169 +814,12 @@ impl<'a> TargetRuntime<'a> for SorobanTarget {
     /// builtin expressions
     fn builtin<'b>(
         &self,
-        bin: &Binary<'b>,
+        _bin: &Binary<'b>,
         expr: &Expression,
-        vartab: &HashMap<usize, Variable<'b>>,
-        function: FunctionValue<'b>,
+        _vartab: &HashMap<usize, Variable<'b>>,
+        _function: FunctionValue<'b>,
     ) -> BasicValueEnum<'b> {
-        emit_context!(bin);
-
-        match expr {
-            Expression::Builtin {
-                kind: Builtin::ExtendTtl,
-                args,
-                ..
-            } => {
-                // TODO: a good chance to move ExtendTtl implementation to codegen
-                // and use CFG instead of llvm-ir
-                // Get arguments
-                // (func $extend_contract_data_ttl (param $k_val i64) (param $t_storage_type i64) (param $threshold_u32_val i64) (param $extend_to_u32_val i64) (result i64))
-                assert_eq!(args.len(), 4, "extendTtl expects 4 arguments");
-                // SAFETY: We already checked that the length of args is 4 so it is safe to unwrap here
-                let slot_no = match args.first().unwrap() {
-                    Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!(
-                        "Expected slot_no to be of type Expression::NumberLiteral. Actual: {:?}",
-                        args.get(1).unwrap()
-                    ),
-                }
-                .to_u64()
-                .unwrap();
-                let threshold = match args.get(1).unwrap() {
-                    Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!(
-                        "Expected threshold to be of type Expression::NumberLiteral. Actual: {:?}",
-                        args.get(1).unwrap()
-                    ),
-                }
-                .to_u64()
-                .unwrap();
-                let extend_to = match args.get(2).unwrap() {
-                    Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!(
-                        "Expected extend_to to be of type Expression::NumberLiteral. Actual: {:?}",
-                        args.get(2).unwrap()
-                    ),
-                }
-                .to_u64()
-                .unwrap();
-                let storage_type = match args.get(3).unwrap() {
-                    Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!(
-                    "Expected storage_type to be of type Expression::NumberLiteral. Actual: {:?}",
-                    args.get(3).unwrap()
-                ),
-                }
-                .to_u64()
-                .unwrap();
-
-                // Encode the values (threshold and extend_to)
-                // See: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-01.md#tag-values
-                let threshold_u32_val = (threshold << 32) + 4;
-                let extend_to_u32_val = (extend_to << 32) + 4;
-
-                // Call the function
-                let function_name = HostFunctions::ExtendContractDataTtl.name();
-                let function_value =
-                    runtime_helper(bin, function_name, "emitting Soroban extendTtl builtin");
-
-                let value = bin
-                    .builder
-                    .build_call(
-                        function_value,
-                        &[
-                            bin.context.i64_type().const_int(slot_no, false).into(),
-                            bin.context.i64_type().const_int(storage_type, false).into(),
-                            bin.context
-                                .i64_type()
-                                .const_int(threshold_u32_val, false)
-                                .into(),
-                            bin.context
-                                .i64_type()
-                                .const_int(extend_to_u32_val, false)
-                                .into(),
-                        ],
-                        function_name,
-                    )
-                    .unwrap()
-                    .try_as_basic_value()
-                    .left()
-                    .unwrap_or_else(|| {
-                        expect_return_value(None, "emitting Soroban extendTtl builtin")
-                    })
-                    .into_int_value();
-
-                value.into()
-            }
-            Expression::Builtin {
-                kind: Builtin::ExtendInstanceTtl,
-                args,
-                ..
-            } => {
-                // Get arguments
-                // (func $extend_contract_data_ttl (param $k_val i64) (param $t_storage_type i64) (param $threshold_u32_val i64) (param $extend_to_u32_val i64) (result i64))
-                assert_eq!(args.len(), 2, "extendTtl expects 2 arguments");
-                // SAFETY: We already checked that the length of args is 2 so it is safe to unwrap here
-                let threshold = match args.first().unwrap() {
-                    Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!(
-                        "Expected threshold to be of type Expression::NumberLiteral. Actual: {:?}",
-                        args.get(1).unwrap()
-                    ),
-                }
-                .to_u64()
-                .unwrap();
-                let extend_to = match args.get(1).unwrap() {
-                    Expression::NumberLiteral { value, .. } => value,
-                    _ => panic!(
-                        "Expected extend_to to be of type Expression::NumberLiteral. Actual: {:?}",
-                        args.get(2).unwrap()
-                    ),
-                }
-                .to_u64()
-                .unwrap();
-
-                // Encode the values (threshold and extend_to)
-                // See: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-01.md#tag-values
-                let threshold_u32_val = (threshold << 32) + 4;
-                let extend_to_u32_val = (extend_to << 32) + 4;
-
-                // Call the function
-                let function_name = HostFunctions::ExtendCurrentContractInstanceAndCodeTtl.name();
-                let function_value = runtime_helper(
-                    bin,
-                    function_name,
-                    "emitting Soroban extendInstanceTtl builtin",
-                );
-
-                let value = bin
-                    .builder
-                    .build_call(
-                        function_value,
-                        &[
-                            bin.context
-                                .i64_type()
-                                .const_int(threshold_u32_val, false)
-                                .into(),
-                            bin.context
-                                .i64_type()
-                                .const_int(extend_to_u32_val, false)
-                                .into(),
-                        ],
-                        function_name,
-                    )
-                    .unwrap()
-                    .try_as_basic_value()
-                    .left()
-                    .unwrap_or_else(|| {
-                        expect_return_value(None, "emitting Soroban extendInstanceTtl builtin")
-                    })
-                    .into_int_value();
-
-                value.into()
-            }
-            _ => unsupported_soroban(expr.loc(), "this Soroban builtin"),
-        }
+        unsupported_soroban(expr.loc(), "this Soroban builtin")
     }
 
     /// Return the return data from an external call (either revert error or return values)


### PR DESCRIPTION
Fixes #1971

extendTtl was half migrated. Its codegen arm resolved the storage type and then
re-emitted the builtin, so the host call was still hand written LLVM IR in emit.
extendInstanceTtl had no codegen arm at all.

Both now emit the host call from lower_builtin, and the two emit arms are
deleted. The threshold and extend_to arguments go through the existing
encode_object helper instead of a compile time shift, so they no longer have to
be number literals.

Existing ttl tests cover both paths.
