### PR TITLE
linked support for keccak256

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -93,6 +93,7 @@ impl From<inkwell::OptimizationLevel> for OptimizationLevel {
 
 pub enum HostFunctions {
     ComputeHashSha256,
+    ComputeHashKeccak256,
     PutContractData,
     GetContractData,
     HasContractData,
@@ -158,6 +159,7 @@ impl HostFunctions {
     pub fn name(&self) -> &str {
         match self {
             HostFunctions::ComputeHashSha256 => "c._",
+            HostFunctions::ComputeHashKeccak256 => "c.1",
             HostFunctions::PutContractData => "l._",
             HostFunctions::GetContractData => "l.1",
             HostFunctions::HasContractData => "l.0",

--- a/src/codegen/targets/soroban/mod.rs
+++ b/src/codegen/targets/soroban/mod.rs
@@ -331,6 +331,35 @@ impl TargetCodegen for SorobanTarget {
                     Some(Type::Bytes(32)),
                 ))
             }
+            ast::Builtin::Keccak256 => {
+                assert_eq!(args.len(), 1, "Keccak256 takes exactly one argument");
+                let input = expression(&args[0], cfg, contract_no, func, ns, vartab, opt, self);
+                let bytes_obj = soroban_encode_arg(input, cfg, vartab, ns);
+                let hash_obj = vartab.temp_name("keccak256_hash", &Type::Uint(64));
+                cfg.add(
+                    vartab,
+                    Instr::Call {
+                        res: vec![hash_obj],
+                        call: InternalCallTy::HostFunction {
+                            name: HostFunctions::ComputeHashKeccak256.name().to_string(),
+                        },
+                        args: vec![bytes_obj],
+                        return_tys: vec![Type::Uint(64)],
+                    },
+                );
+                let hash_expr = Expression::Variable {
+                    loc: pt::Loc::Codegen,
+                    ty: Type::Uint(64),
+                    var_no: hash_obj,
+                };
+                Some(soroban_decode_arg(
+                    hash_expr,
+                    cfg,
+                    vartab,
+                    ns,
+                    Some(Type::Bytes(32)),
+                ))
+            }
             ast::Builtin::Timestamp => {
                 assert_eq!(args.len(), 0, "timestamp expects no arguments");
                 let timestamp_var_no = vartab.temp_name("timestamp", &Type::Uint(64));

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -189,6 +189,9 @@ impl HostFunctions {
                 .i64_type()
                 .fn_type(&[ty.into(), ty.into()], false),
             HostFunctions::ComputeHashSha256 => bin.context.i64_type().fn_type(&[ty.into()], false),
+            HostFunctions::ComputeHashKeccak256 => {
+                bin.context.i64_type().fn_type(&[ty.into()], false)
+            }
         }
     }
 }
@@ -556,6 +559,7 @@ impl SorobanTarget {
             HostFunctions::VecPopBack,
             HostFunctions::ContractEvent,
             HostFunctions::ComputeHashSha256,
+            HostFunctions::ComputeHashKeccak256,
         ];
 
         for func in &host_functions {

--- a/tests/soroban_testcases/keccak256.rs
+++ b/tests/soroban_testcases/keccak256.rs
@@ -1,0 +1,31 @@
+use crate::build_solidity;
+use soroban_sdk::{Bytes, BytesN, IntoVal, TryFromVal};
+
+#[test]
+fn keccak256_basic() {
+    let runtime = build_solidity(
+        r#"contract Keccak256HashTest {
+            function hash(bytes memory input) public pure returns (bytes32) {
+                return keccak256(input);
+            }
+        }"#,
+        |_| {},
+    );
+
+    let addr = runtime.contracts.last().unwrap();
+
+    let input = Bytes::from_slice(&runtime.env, b"hello_world");
+    let result = runtime.invoke_contract(addr, "hash", vec![input.into_val(&runtime.env)]);
+
+    let result_bytes = BytesN::<32>::try_from_val(&runtime.env, &result).unwrap();
+
+    let expected = BytesN::<32>::from_array(
+        &runtime.env,
+        &hex::decode("5b07e077a81ffc6b47435f65a8727bcc542bc6fc0f25a56210efb1a74b88a5ae")
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+
+    assert_eq!(result_bytes, expected);
+}

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -18,6 +18,7 @@ mod i128_u128;
 mod i256_u256;
 mod integer_width_rounding;
 mod integer_width_warnings;
+mod keccak256;
 mod liquidity_pool;
 mod mappings;
 mod math;


### PR DESCRIPTION
closes #1974 
- Added an builtin arm `Keccak256`, calling `ComputeHashKeccak256` and returning using `some()`
- Added required functions in `src/codegen/mod.rs`
- signature (i64) -> i64 in function_signature and added to declare_externals
- Added tests for the same, asserting "Hello_world" against it's keccak256 hash image.

PS - do let me know if you would like to have tests in the way #1979 have implemented, I used `hex:decode()` for better readability.